### PR TITLE
add a transport_options arg to generated methods

### DIFF
--- a/python/looker_sdk/rtl/api_methods.py
+++ b/python/looker_sdk/rtl/api_methods.py
@@ -113,6 +113,7 @@ class APIMethods:
         path: str,
         structure: TStructure,
         query_params: Optional[TQueryParams] = None,
+        transport_options: Optional[transport.TransportSettings] = None,
     ) -> TReturn:
         """GET method
         """
@@ -123,6 +124,7 @@ class APIMethods:
             query_params=params,
             body=None,
             authenticator=self.auth.authenticate,
+            transport_options=transport_options,
         )
         return self._return(response, structure)
 
@@ -142,6 +144,7 @@ class APIMethods:
         structure: TStructure,
         query_params: Optional[TQueryParams] = None,
         body: TBody = None,
+        transport_options: Optional[transport.TransportSettings] = None,
     ) -> TReturn:
         """POST method
         """
@@ -153,6 +156,7 @@ class APIMethods:
             query_params=params,
             body=serialized,
             authenticator=self.auth.authenticate,
+            transport_options=transport_options,
         )
         return self._return(response, structure)
 
@@ -162,6 +166,7 @@ class APIMethods:
         structure: TStructure,
         query_params: Optional[TQueryParams] = None,
         body: TBody = None,
+        transport_options: Optional[transport.TransportSettings] = None,
     ) -> TReturn:
         """PATCH method
         """
@@ -173,6 +178,7 @@ class APIMethods:
             query_params=params,
             body=serialized,
             authenticator=self.auth.authenticate,
+            transport_options=transport_options,
         )
         return self._return(response, structure)
 
@@ -182,6 +188,7 @@ class APIMethods:
         structure: TStructure = None,
         query_params: Optional[TQueryParams] = None,
         body: TBody = None,
+        transport_options: Optional[transport.TransportSettings] = None,
     ) -> TReturn:
         """PUT method
         """
@@ -193,6 +200,7 @@ class APIMethods:
             query_params=params,
             body=serialized,
             authenticator=self.auth.authenticate,
+            transport_options=transport_options,
         )
         return self._return(response, structure)
 
@@ -201,6 +209,7 @@ class APIMethods:
         path: str,
         structure: TStructure = None,
         query_params: Optional[MutableMapping[str, str]] = None,
+        transport_options: Optional[transport.TransportSettings] = None,
     ) -> TReturn:
         """DELETE method
         """
@@ -209,5 +218,6 @@ class APIMethods:
             path,
             body=None,
             authenticator=self.auth.authenticate,
+            transport_options=transport_options,
         )
         return self._return(response, structure)

--- a/python/looker_sdk/rtl/transport.py
+++ b/python/looker_sdk/rtl/transport.py
@@ -60,7 +60,7 @@ class TransportSettings:
     base_url: str = ""
     api_version: str = "3.1"
     verify_ssl: bool = True
-    timeout: TConnectAndReadTimeout = (1800, 120)
+    timeout: TConnectAndReadTimeout = (120, 120)
     headers: Optional[MutableMapping[str, str]] = None
 
     @property

--- a/python/looker_sdk/rtl/transport.py
+++ b/python/looker_sdk/rtl/transport.py
@@ -24,7 +24,7 @@
 """
 import abc
 import enum
-from typing import Callable, Dict, MutableMapping, Optional, Union
+from typing import Callable, Dict, MutableMapping, Optional, Union, Tuple
 
 import attr
 
@@ -44,14 +44,23 @@ class HttpMethod(enum.Enum):
     HEAD = 7
 
 
+TConnectTimeout = int
+TReadTimeout = int
+TConnectAndReadTimeout = int
+TConnectAndReadTimeoutSeconds = Union[
+    Tuple[TConnectTimeout, TReadTimeout], TConnectAndReadTimeout
+]
+
+
 @attr.s(auto_attribs=True, kw_only=True)
 class TransportSettings:
     """Basic transport settings.
     """
 
-    base_url: str
+    base_url: str = ""
     api_version: str = "3.1"
     verify_ssl: bool = True
+    timeout: TConnectAndReadTimeout = (1800, 120)
     headers: Optional[MutableMapping[str, str]] = None
 
     @property
@@ -100,6 +109,7 @@ class Transport(abc.ABC):
         body: Optional[bytes] = None,
         authenticator: TAuthenticator = None,
         headers: Optional[MutableMapping[str, str]] = None,
+        transport_options: Optional[TransportSettings] = None,
     ) -> Response:
         """Send API request.
         """

--- a/python/looker_sdk/rtl/transport.py
+++ b/python/looker_sdk/rtl/transport.py
@@ -47,9 +47,7 @@ class HttpMethod(enum.Enum):
 TConnectTimeout = int
 TReadTimeout = int
 TConnectAndReadTimeout = int
-TConnectAndReadTimeoutSeconds = Union[
-    Tuple[TConnectTimeout, TReadTimeout], TConnectAndReadTimeout
-]
+TTimeoutSeconds = Union[Tuple[TConnectTimeout, TReadTimeout], TConnectAndReadTimeout]
 
 
 @attr.s(auto_attribs=True, kw_only=True)
@@ -60,7 +58,7 @@ class TransportSettings:
     base_url: str = ""
     api_version: str = "3.1"
     verify_ssl: bool = True
-    timeout: TConnectAndReadTimeoutSeconds = (120, 120)
+    timeout: TTimeoutSeconds = (120, 120)
     headers: Optional[MutableMapping[str, str]] = None
 
     @property

--- a/python/tests/rtl/test_requests_transport.py
+++ b/python/tests/rtl/test_requests_transport.py
@@ -46,7 +46,7 @@ class Session:
         self.ret_val = ret_val
         self.error = error
 
-    def request(self, method, url, params, data, headers):
+    def request(self, method, url, params, data, headers, timeout):
         """Fake request.Session.request
         """
         if self.error:

--- a/src/python.gen.spec.ts
+++ b/src/python.gen.spec.ts
@@ -102,17 +102,17 @@ describe('python generator', () => {
     it('add_group_group', () => {
       const method = apiModel.methods['add_group_group']
       const args = gen.httpArgs('', method).trim()
-      expect(args).toEqual('models.Group, body=body')
+      expect(args).toEqual('models.Group, body=body, transport_options=transport_options')
     })
     it('create_query', () => {
       const method = apiModel.methods['create_query']
       const args = gen.httpArgs('', method).trim()
-      expect(args).toEqual('models.Query, query_params={"fields": fields}, body=body')
+      expect(args).toEqual('models.Query, query_params={"fields": fields}, body=body, transport_options=transport_options')
     })
     it('create_dashboard', () => {
       const method = apiModel.methods['create_dashboard']
       const args = gen.httpArgs('', method).trim()
-      expect(args).toEqual('models.Dashboard, body=body')
+      expect(args).toEqual('models.Dashboard, body=body, transport_options=transport_options')
     })
   })
 
@@ -122,7 +122,8 @@ describe('python generator', () => {
       const expected =
         `# GET /datagroups -> Sequence[models.Datagroup]
 def all_datagroups(
-    self
+    self,
+    transport_options: Optional[transport.TransportSettings] = None,
 ) -> Sequence[models.Datagroup]:
 `
       const actual = gen.methodSignature('', method)
@@ -134,7 +135,7 @@ def all_datagroups(
     it('assert response is model add_group_group', () => {
       const method = apiModel.methods['add_group_group']
       const expected =
-        `response = self.post(f"/groups/{group_id}/groups", models.Group, body=body)
+        `response = self.post(f"/groups/{group_id}/groups", models.Group, body=body, transport_options=transport_options)
 assert isinstance(response, models.Group)
 return response`
       const actual = gen.httpCall(indent, method)
@@ -143,7 +144,7 @@ return response`
     it('assert response is None delete_group_from_group', () => {
       const method = apiModel.methods['delete_group_from_group']
       const expected =
-        `response = self.delete(f"/groups/{group_id}/groups/{deleting_group_id}")
+        `response = self.delete(f"/groups/{group_id}/groups/{deleting_group_id}", None, transport_options=transport_options)
 assert response is None
 return response`
       const actual = gen.httpCall(indent, method)
@@ -152,7 +153,7 @@ return response`
     it('assert response is list active_themes', () => {
       const method = apiModel.methods['active_themes']
       const expected =
-        `response = self.get(f"/themes/active", Sequence[models.Theme], query_params={"name": name, "ts": ts, "fields": fields})
+        `response = self.get(f"/themes/active", Sequence[models.Theme], query_params={"name": name, "ts": ts, "fields": fields}, transport_options=transport_options)
 assert isinstance(response, list)
 return response`
       const actual = gen.httpCall(indent, method)
@@ -161,7 +162,7 @@ return response`
     it('assert response is dict query_task_results', () => {
       const method = apiModel.methods['query_task_results']
       const expected =
-        `response = self.get(f"/query_tasks/{query_task_id}/results", MutableMapping[str, str])
+        `response = self.get(f"/query_tasks/{query_task_id}/results", MutableMapping[str, str], transport_options=transport_options)
 assert isinstance(response, dict)
 return response`
       const actual = gen.httpCall(indent, method)

--- a/src/python.gen.ts
+++ b/src/python.gen.ts
@@ -120,6 +120,7 @@ from typing import MutableMapping, Optional, Sequence
 
 from ${this.packagePath}.sdk import models
 from ${this.packagePath}.rtl import api_methods
+from ${this.packagePath}.rtl import transport
 
 
 class ${this.packageName}(api_methods.APIMethods):
@@ -203,6 +204,7 @@ ${this.hooks.join('\n')}
     let params: string[] = []
     const args = method.allParams
     if (args && args.length > 0) method.allParams.forEach(p => params.push(this.declareParameter(bump, p)))
+    params.push(`${bump}transport_options: Optional[transport.TransportSettings] = None,`)
     return this.commentHeader(indent, `${method.httpMethod} ${method.endpoint} -> ${type.name}`)
       + `${indent}def ${method.name}(\n${bump}self${params.length > 0 ? ',\n' : ''}${params.join(this.paramDelimiter)}\n${indent}) -> ${type.name}:\n`
   }
@@ -263,6 +265,7 @@ ${this.hooks.join('\n')}
   httpArgs(indent: string, method: IMethod) {
     let result = this.argFill('', this.argGroup(indent, method.cookieArgs))
     result = this.argFill(result, this.argGroup(indent, method.headerArgs))
+    result = this.argFill(result, `transport_options=transport_options`)
     if (method.bodyArg) {
       result = this.argFill(result, `body=${method.bodyArg}`)
     }


### PR DESCRIPTION
This will allow users to pass a `transport.TransportSettings` object to override defaults or provide new transport settings  for a given call.

For now I set the default connection timeout to an arbitrary 1800 seconds. Will change this to a more reasonable one later on. The read timeout is 180 seconds to mimic the TS implementation.