### PR TITLE
Python: binary reponse handling

### DIFF
--- a/python/Pipfile
+++ b/python/Pipfile
@@ -19,6 +19,7 @@ pyyaml = "*"
 pytest-pudb = "*"
 pytest-mock = "*"
 twine = "*"
+pillow = "*"
 
 [packages]
 requests = "*"

--- a/python/Pipfile.lock
+++ b/python/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6faf299ad8c4b1105461fa5340005740a8efa41e3fd8dca766fde79eb6ff8888"
+            "sha256": "c8e84e9db29be09aef625ab209d56f7e384cf119286b44ea274abcdd5e7c3968"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,11 +18,11 @@
     "default": {
         "attrs": {
             "hashes": [
-                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
-                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
+                "sha256:ec20e7a4825331c1b5ebf261d111e16fa9612c1f7a5e1f884f12bd53a664dfd2",
+                "sha256:f913492e1663d3c36f502e5e9ba6cd13cf19d7fab50aa13239e420fef95e1396"
             ],
             "index": "pypi",
-            "version": "==19.1.0"
+            "version": "==19.2.0"
         },
         "cattrs": {
             "hashes": [
@@ -93,11 +93,11 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
-                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
+                "sha256:ec20e7a4825331c1b5ebf261d111e16fa9612c1f7a5e1f884f12bd53a664dfd2",
+                "sha256:f913492e1663d3c36f502e5e9ba6cd13cf19d7fab50aa13239e420fef95e1396"
             ],
             "index": "pypi",
-            "version": "==19.1.0"
+            "version": "==19.2.0"
         },
         "backcall": {
             "hashes": [
@@ -151,35 +151,33 @@
         },
         "coverage": {
             "hashes": [
-                "sha256:094378c3a35594335a840ea04d473c019e6d4fe10e343cd0d7fb5e87f8b7e926",
-                "sha256:10216222f3e4139910b6230d0ca0fe9d10ee98837eb83d29525722d628729d20",
-                "sha256:147478e21cba12c63b3454df5a2fb77b44df630428cffa3a36a6813e38157eab",
-                "sha256:230ce08965190c0f69196be34a07a795981b2b02b21419c2e1918a882b3eeab0",
-                "sha256:2469621d680a4c71cdbd3ea4dbed9d199bba93f21d2be1c107ded907b2db41a8",
-                "sha256:26526174d11fb2163832628d943edd452e07528b0ecc0c83c88256a59a32287c",
-                "sha256:2690bf0835f34ef3451860b02471e9560e4b3caf7413abeaa7544af72eb6d9ed",
-                "sha256:2b6f2d9a60413e75651cebe33c3f2f66d61209db44e8b9cf6d8d66fb0cb01fda",
-                "sha256:3ce91c6b92160ecefedf95a8c61fbf4fb36b0addef1a40c654acf1ad390653d0",
-                "sha256:43d16d7e9e9eaace3d9f1828b617b1be248f90d031a4b2dc1b6e1c88f1602dcf",
-                "sha256:52b6455da5f547cad72fd5cfc57a16678573fda6c695d257b5c266a44dbbd172",
-                "sha256:533f3036c8f58e6381fcca3306fe988740638c62c7fc86b7fae9c74b85ac3cdc",
-                "sha256:62d2abe5c733394058cb381d088bcab64a18da3ce9dc9a8ef2a18e122cbe47f1",
-                "sha256:72c34f99164679e44a5cbf19bf1a13be4e715c680816302b6ceca49b979fde91",
-                "sha256:81fc07feed4e40a7c0bdd266efa65e5afc83b5e0f1063007acc6759a957322a1",
-                "sha256:82093e673182c761ce54dfab17f026a06be3c011fee9b653855b9a2649f20232",
-                "sha256:87947fef728f72860407c446fd9b4a0f98e39e91ad7ae80803c02a85738e63ef",
-                "sha256:8b18c5a5a6b35b6311d2c356782ce3c7bacf6d987d9dc479178577391bf1c7dd",
-                "sha256:90e1850e993aa6b81bafaf672c8e508eaa17fbb5eb23aba93f7f4df822f3bd29",
-                "sha256:99f71e365bcb03a8debe1a75061329c9e45379f244a229442319d64c53c4e844",
-                "sha256:9b2c559104a90bf0043d6ef262ca205326d1fe6ec572dcf59e34be9289432793",
-                "sha256:ad22b073d92ea65b063e612154c72d6367dec3dd47ed33c02e3ab339eabe7bf3",
-                "sha256:bc3648da235fee2113a8cb80154d9fff4e2689d2d4a11ad35c1ecae23454b539",
-                "sha256:d0e2478bde68c5d853bcd306b5aae8fbe80417e87957a21fa6ee71edb90639f2",
-                "sha256:d3e6912d2370925222d2bfb3bd2ba02e9698b8da89cf7192ddf80cbb9f2455ee",
-                "sha256:d4fa98e3e15863568ea89eaec5e0866ca763980bdc56098dd9316865c111a28e",
-                "sha256:ee924a23457b373241ff39d21570360afd8ccb58520eb1e8e18eb00827b73e2d"
+                "sha256:17a417c691de3fc88de027832267313e5ed2b2ea3956745b562c4c389e44d05b",
+                "sha256:24307e67ebd9dc06fcbab9b7fef87412a97746c1baabb04ed8a93d5c2ccfe5ba",
+                "sha256:2a5d44a9d8426bd3699123864e63f008dc8dea9df22d5216a141a25d4670f22c",
+                "sha256:3726b8f5461e103a40e380f52b4b4ccdf2eda55d5d72f037cee43627992b4462",
+                "sha256:39dd15bbc4880a64399e180925bbc21c0c316a3065f6455d2512039f5cb59b94",
+                "sha256:3bb121f5dd156aab4fba2ebad6b0ad605bc5dc305931140dc614b101aa9d81ed",
+                "sha256:3bfdea9226eaed97736c973a7d6d0bbf9e1c1f1c7391c8e9c2bb2d0dbae49156",
+                "sha256:43be906a16239c1aa9f3742e3e6b0a5dd24781a13ce401f063262e9b4e93b69f",
+                "sha256:4a54cac1b39b2925041a41bcd1f191898fe401618627d7c3abf127c32a1c6dd1",
+                "sha256:4e58d65b90d6f26b3ccca7cf0fe573ef847347b8734af596a087a21eebb681f5",
+                "sha256:50229727d9baf0cd7f5ee6b194bf9dea708e9a20823d93f9e04d710b0a60e757",
+                "sha256:5141cdb010e9cd6939e37b8c2769d535cb535d80ef94f927c8a306f2e05a4736",
+                "sha256:748ba2b950425b9aef9d1bde2d6af7023585505016bd634e578f76ada4a30465",
+                "sha256:75e635bc6730c88b04421b25a0afc47b9b80efc1ed57630839196eb475722e50",
+                "sha256:78556f51dbfb33f18794eee29a4a8542fd2e301aa0d072653930793974dced03",
+                "sha256:7de17133509210ecc256535bab2f9a5547f3016c44f984fe12b4c10d81a4623f",
+                "sha256:83bf376555898fe2dc50d111a34b0152b504e454ed1e13cdcda6e5d50ba0ed5b",
+                "sha256:87730b5e4c3a42674fe8f0ecbb0d556c59c7e12b11a65c2178f2787252a80dfd",
+                "sha256:9bb7819c020c20c6200764879f0b10b323d6d4719aa7b0ae316c9e35730f9e2d",
+                "sha256:9c825788acb13d49ac20455433f3b862029aa497e97faba8c998555a042a6b91",
+                "sha256:b2bb4941c8838fc9ea2fca3c52e6dd865d39bbbc014bde249161bf8fcccf2152",
+                "sha256:c1b44c6c680f137910cb0f5481a2ae9899787ca7019f110a3708d9e99df941be",
+                "sha256:c52c2bc67bd3ff8db685f7c5f03e34a95bddd58a535630161f28d1c485d61e22",
+                "sha256:d6845e46338695c571759be1c770b013c477111e785b26151ec9feb6cd063543",
+                "sha256:e292b32dfc80d9f271af2d52df95455248322156e764763c4bfb2385b2e33533"
             ],
-            "version": "==5.0a7"
+            "version": "==5.0a8"
         },
         "decorator": {
             "hashes": [
@@ -295,10 +293,9 @@
         },
         "mypy-extensions": {
             "hashes": [
-                "sha256:37e0e956f41369209a3d5f34580150bcacfabaa57b33a15c0b25f4b5725e0812",
-                "sha256:b16cabe759f55e3409a7d231ebd2841378fb0c27a5d1994719e340e4f429ac3e"
+                "sha256:a161e3b917053de87dbe469987e173e49fb454eca10ef28b48b384538cc11458"
             ],
-            "version": "==0.4.1"
+            "version": "==0.4.2"
         },
         "packaging": {
             "hashes": [
@@ -329,6 +326,38 @@
             ],
             "version": "==0.7.5"
         },
+        "pillow": {
+            "hashes": [
+                "sha256:00fdeb23820f30e43bba78eb9abb00b7a937a655de7760b2e09101d63708b64e",
+                "sha256:01f948e8220c85eae1aa1a7f8edddcec193918f933fb07aaebe0bfbbcffefbf1",
+                "sha256:08abf39948d4b5017a137be58f1a52b7101700431f0777bec3d897c3949f74e6",
+                "sha256:099a61618b145ecb50c6f279666bbc398e189b8bc97544ae32b8fcb49ad6b830",
+                "sha256:2c1c61546e73de62747e65807d2cc4980c395d4c5600ecb1f47a650c6fa78c79",
+                "sha256:2ed9c4f694861642401f27dc3cb99772be67cd190e84845c749dae0a06c3bfae",
+                "sha256:338581b30b908e111be578f0297255f6b57a51358cd16fa0e6f664c9a1f88bff",
+                "sha256:38c7d48a21cd06fdeee93987147b9b1c55b73b4cfcbf83240568bfbd5adee447",
+                "sha256:43fd026f613c8e48a25eba1a92f4d2ad7f3903c95d8c33a11611a7717d2ab654",
+                "sha256:4548236844327a718ce3bb182ab32a16fa2050c61e334e959f554cac052fb0df",
+                "sha256:5090857876c58885cfa388dc649e5db30aae98a068c26f3fd0ac9d7d9a4d9572",
+                "sha256:5bbba34f97a26a93f5e8dec469ca4ddd712451418add43da946dbaed7f7a98d2",
+                "sha256:65a28969a025a0eb4594637b6103201dc4ed2a9508bdab56ac33e43e3081c404",
+                "sha256:892bb52b70bd5ea9dbbc3ac44f38e84f5a04e9d8b1bff48159d96cb795b81159",
+                "sha256:8a9becd5cbd5062f973bcd2e7bc79483af310222de112b6541f8af1f93a3cc42",
+                "sha256:972a7aaeb7c4a2795b52eef52ee991ef040b31009f36deca6207a986607b55f3",
+                "sha256:97b119c436bfa96a92ac2ca525f7025836d4d4e64b1c9f9eff8dbaf3ff1d86f3",
+                "sha256:9ba37698e242223f8053cc158f130aee046a96feacbeab65893dbe94f5530118",
+                "sha256:b1b0e1f626a0f079c0d3696db70132fb1f29aa87c66aecb6501a9b8be64ce9f7",
+                "sha256:c14c1224fd1a5be2733530d648a316974dbbb3c946913562c6005a76f21ca042",
+                "sha256:c79a8546c48ae6465189e54e3245a97ddf21161e33ff7eaa42787353417bb2b6",
+                "sha256:ceb76935ac4ebdf6d7bc845482a4450b284c6ccfb281e34da51d510658ab34d8",
+                "sha256:e22bffaad04b4d16e1c091baed7f2733fc1ebb91e0c602abf1b6834d17158b1f",
+                "sha256:ec883b8e44d877bda6f94a36313a1c6063f8b1997aa091628ae2f34c7f97c8d5",
+                "sha256:f1baa54d50ec031d1a9beb89974108f8f2c0706f49798f4777df879df0e1adb6",
+                "sha256:f53a5385932cda1e2c862d89460992911a89768c65d176ff8c50cddca4d29bed"
+            ],
+            "index": "pypi",
+            "version": "==6.2.0"
+        },
         "pkginfo": {
             "hashes": [
                 "sha256:7424f2c8511c186cd5424bbf31045b77435b37a8d604990b79d4e70d741148bb",
@@ -353,11 +382,11 @@
         },
         "prompt-toolkit": {
             "hashes": [
-                "sha256:11adf3389a996a6d45cc277580d0d53e8a5afd281d0c9ec71b28e6f121463780",
-                "sha256:2519ad1d8038fd5fc8e770362237ad0364d16a7650fb5724af6997ed5515e3c1",
-                "sha256:977c6583ae813a37dc1c2e1b715892461fcbdaa57f6fc62f33a528c4886c8f55"
+                "sha256:46642344ce457641f28fc9d1c9ca939b63dadf8df128b86f1b9860e59c73a5e4",
+                "sha256:e7f8af9e3d70f514373bf41aa51bc33af12a6db3f71461ea47fea985defb2c31",
+                "sha256:f15af68f66e664eaa559d4ac8a928111eebd5feda0c11738b5998045224829db"
             ],
-            "version": "==2.0.9"
+            "version": "==2.0.10"
         },
         "ptpython": {
             "hashes": [
@@ -426,11 +455,11 @@
         },
         "pytest-cov": {
             "hashes": [
-                "sha256:2b097cde81a302e1047331b48cadacf23577e431b61e9c6f49a1170bbe3d3da6",
-                "sha256:e00ea4fdde970725482f1f35630d12f074e121a23801aabf2ae154ec6bdd343a"
+                "sha256:9b64b54d21bd0fd77f7eb6ccb38638b8daba8d98ab5a51d67c93a133ec8c5ba4",
+                "sha256:a42cb9af7a429b6cd7c97be307cbb4cefca1d50c5b3018711558341979946851"
             ],
             "index": "pypi",
-            "version": "==2.7.1"
+            "version": "==2.8.0"
         },
         "pytest-mock": {
             "hashes": [
@@ -512,10 +541,10 @@
         },
         "traitlets": {
             "hashes": [
-                "sha256:262089114405f22f4833be96b31e143ab906d7764a22c04c71fee0bbda4787ba",
-                "sha256:6ad5b30dacd5e2424c46cc94a0aeab990d98ae17d181acea2cc4272ac3409fca"
+                "sha256:70b4c6a1d9019d7b4f6846832288f86998aa3b9207c6821f3578a6a6a467fe44",
+                "sha256:d023ee369ddd2763310e4c3eae1ff649689440d4ae59d7485eb4cfbbe3e359f7"
             ],
-            "version": "==4.3.3.dev0"
+            "version": "==4.3.3"
         },
         "twine": {
             "hashes": [

--- a/python/looker_sdk/rtl/auth_session.py
+++ b/python/looker_sdk/rtl/auth_session.py
@@ -29,9 +29,9 @@ import urllib.parse
 from looker_sdk import error
 from looker_sdk.rtl import api_settings
 from looker_sdk.rtl import auth_token
-from looker_sdk.rtl import transport
+from looker_sdk.rtl import constants
 from looker_sdk.rtl import serialize
-from looker_sdk.rtl import versions
+from looker_sdk.rtl import transport
 from looker_sdk.sdk import models
 
 
@@ -123,10 +123,10 @@ class AuthSession:
             self.settings._filename, self.settings._section
         )
         client_id = os.getenv(
-            f"{versions.environment_prefix}_CLIENT_ID"
+            f"{constants.environment_prefix}_CLIENT_ID"
         ) or config_data.get("client_id")
         client_secret = os.getenv(
-            f"{versions.environment_prefix}_CLIENT_SECRET"
+            f"{constants.environment_prefix}_CLIENT_SECRET"
         ) or config_data.get("client_secret")
 
         if not (client_id and client_secret):
@@ -217,7 +217,7 @@ class AuthSession:
     def _reset_user_token(self) -> None:
         self.user_token = auth_token.AuthToken()
 
-    def _ok(self, response: transport.Response) -> transport.TResponseValue:
+    def _ok(self, response: transport.Response) -> str:
         if not response.ok:
             raise error.SDKError(response.value)
-        return response.value
+        return response.value.decode(encoding="utf-8")

--- a/python/looker_sdk/rtl/model.py
+++ b/python/looker_sdk/rtl/model.py
@@ -65,7 +65,7 @@ class DelimSequence(collections.UserList, MutableSequence[T]):
         super().remove(elem)
 
     def index(self, x: T, *args):
-        super().index(x, *args)
+        super().index(x, *args)  # type: ignore
 
     def count(self, elem: T):
         super().count(elem)

--- a/python/looker_sdk/rtl/serialize.py
+++ b/python/looker_sdk/rtl/serialize.py
@@ -40,7 +40,6 @@ from typing import (  # type: ignore
 import cattr
 
 from looker_sdk.rtl import model
-from looker_sdk.rtl import transport
 
 
 class DeserializeError(Exception):
@@ -57,13 +56,11 @@ TModelOrSequence = Union[
 ]
 TDeserializeReturn = TModelOrSequence
 TStructure = Union[Type[Sequence[int]], Type[Sequence[str]], Type[TDeserializeReturn]]
-TDeserialize = Callable[[transport.TResponseValue, TStructure], TDeserializeReturn]
+TDeserialize = Callable[[str, TStructure], TDeserializeReturn]
 TSerialize = Callable[[TModelOrSequence], bytes]
 
 
-def deserialize(
-    data: transport.TResponseValue, structure: TStructure
-) -> TDeserializeReturn:
+def deserialize(data: str, structure: TStructure) -> TDeserializeReturn:
     """Translate API data into models.
     """
     try:

--- a/python/looker_sdk/rtl/transport.py
+++ b/python/looker_sdk/rtl/transport.py
@@ -25,7 +25,7 @@
 import abc
 import enum
 import re
-from typing import Callable, Dict, MutableMapping, Optional, Union, Tuple
+from typing import Callable, Dict, MutableMapping, Optional
 
 import attr
 
@@ -45,12 +45,6 @@ class HttpMethod(enum.Enum):
     HEAD = 7
 
 
-TConnectTimeout = int
-TReadTimeout = int
-TConnectAndReadTimeout = int
-TTimeoutSeconds = Union[Tuple[TConnectTimeout, TReadTimeout], TConnectAndReadTimeout]
-
-
 @attr.s(auto_attribs=True, kw_only=True)
 class TransportSettings:
     """Basic transport settings.
@@ -59,7 +53,7 @@ class TransportSettings:
     base_url: str = ""
     api_version: str = "3.1"
     verify_ssl: bool = True
-    timeout: TTimeoutSeconds = (120, 120)
+    timeout: int = 120
     headers: Optional[MutableMapping[str, str]] = None
 
     @property

--- a/python/tests/integration/test_methods.py
+++ b/python/tests/integration/test_methods.py
@@ -1,8 +1,10 @@
+import io
 import json
 from operator import itemgetter
 import re
 from typing import Any, cast, Dict, List, Optional, Union
 
+from PIL import Image
 import pytest  # type: ignore
 
 from looker_sdk.sdk import methods as mtds
@@ -261,7 +263,15 @@ def test_it_runs_inline_query(looker_client: mtds.LookerSDK, queries: TQueries):
         assert isinstance(csv, str)
         assert len(re.findall(r"\n", csv)) == int(limit) + 1
 
-        looker_client.logout()
+    # only do 1 image download since it takes a while
+    png = looker_client.run_inline_query("png", request)
+    assert isinstance(png, bytes)
+    try:
+        Image.open(io.BytesIO(png))
+    except IOError:
+        raise AssertionError("png format failed to return an image")
+
+    looker_client.logout()
 
 
 def test_search_looks_returns_looks(looker_client: mtds.LookerSDK):

--- a/python/tests/rtl/test_requests_transport.py
+++ b/python/tests/rtl/test_requests_transport.py
@@ -20,8 +20,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+from typing import cast, MutableMapping
+
 import attr
 import pytest  # type: ignore
+import requests
 
 from looker_sdk.rtl import requests_transport
 from looker_sdk.rtl import transport
@@ -34,7 +37,8 @@ class Response:
     """
 
     ok: bool
-    text: str
+    content: bytes
+    headers: MutableMapping[str, str]
 
 
 class Session:
@@ -54,7 +58,7 @@ class Session:
         return self.ret_val
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore
 def settings():
     return transport.TransportSettings(
         base_url="/some/path", api_version="3.1", headers=None, verify_ssl=True
@@ -70,36 +74,86 @@ def test_configure(settings):
     assert test.session.headers.get("User-Agent") == f"PY-SDK {constants.sdk_version}"
 
 
-def test_request_ok(settings):
+parametrize = [
+    ({"Content-Type": "application/json"}, "utf-8", transport.ResponseMode.STRING),
+    ({"Content-Type": "image/png"}, "utf-8", transport.ResponseMode.BINARY),
+    (
+        {"Content-Type": "text/xml; charset=latin1"},
+        "latin1",
+        transport.ResponseMode.STRING,
+    ),
+    (
+        {"Content-Type": "text/plain; charset=arabic"},
+        "arabic",
+        transport.ResponseMode.STRING,
+    ),
+    (
+        {"Content-Type": "text/plain; charset=utf-8"},
+        "utf-8",
+        transport.ResponseMode.STRING,
+    ),
+    ({"Content-Type": "audio/gzip"}, "utf-8", transport.ResponseMode.BINARY),
+]
+
+
+@pytest.mark.parametrize(  # type: ignore
+    "headers, expected_encoding, expected_response_mode", parametrize
+)
+def test_request_ok(
+    settings: transport.TransportSettings,
+    headers: MutableMapping[str, str],
+    expected_response_mode: transport.ResponseMode,
+    expected_encoding: str,
+):
     """Test basic successful round trip
     """
-    ret_val = Response(ok=True, text="yay!")
-    session = Session(ret_val)
+    value = b"yay!"
+    ret_val = Response(
+        ok=True, content=value, headers=requests.structures.CaseInsensitiveDict(headers)
+    )
+    session = cast(requests.Session, Session(ret_val))
     test = requests_transport.RequestsTransport(settings, session)
     resp = test.request(transport.HttpMethod.GET, "/some/path")
     assert isinstance(resp, transport.Response)
-    assert resp.value == "yay!"
+    assert resp.value == value
     assert resp.ok is True
+    assert resp.response_mode == expected_response_mode
+    assert resp.encoding == expected_encoding
 
 
-def test_request_not_ok(settings):
+@pytest.mark.parametrize(  # type: ignore
+    "headers, expected_encoding, expected_response_mode", parametrize
+)
+def test_request_not_ok(
+    settings: transport.TransportSettings,
+    headers: MutableMapping[str, str],
+    expected_response_mode: transport.ResponseMode,
+    expected_encoding: str,
+):
     """Test API error response
     """
-    ret_val = Response(ok=False, text="Some API error")
-    session = Session(ret_val)
+    value = b"Some API error"
+    ret_val = Response(
+        ok=False,
+        content=value,
+        headers=requests.structures.CaseInsensitiveDict(headers),
+    )
+    session = cast(requests.Session, Session(ret_val))
     test = requests_transport.RequestsTransport(settings, session)
     resp = test.request(transport.HttpMethod.GET, "/some/path")
     assert isinstance(resp, transport.Response)
-    assert resp.value == "Some API error"
+    assert resp.value == value
     assert resp.ok is False
+    assert resp.response_mode == expected_response_mode
+    assert resp.encoding == expected_encoding
 
 
 def test_request_error(settings):
     """Test network error response
     """
-    session = Session(None, True)
+    session = cast(requests.Session, Session(None, True))
     test = requests_transport.RequestsTransport(settings, session)
     resp = test.request(transport.HttpMethod.GET, "/some/path")
     assert isinstance(resp, transport.Response)
-    assert resp.value == "(54, 'Connection reset by peer')"
+    assert resp.value == b"(54, 'Connection reset by peer')"
     assert resp.ok is False

--- a/python/tests/rtl/test_transport.py
+++ b/python/tests/rtl/test_transport.py
@@ -20,16 +20,19 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-looker_version = "6.21"
-api_version = "3.1"
-sdk_version = f"{api_version}.{looker_version}"
-environment_prefix = "LOOKERSDK"
+import pytest  # type: ignore
 
-RESPONSE_STRING_MODE = (
-    r"(^application/.*"
-    r"(\bjson\b|\bxml\b|\bsql\b|\bgraphql\b|\bjavascript\b|\bx-www-form-urlencoded\b)"
-    r"|^text/|;.*charset=)"
+from looker_sdk.rtl import transport
+
+
+@pytest.mark.parametrize(  # type: ignore
+    "content_type, expected_response_mode",
+    [
+        ("application/json", transport.ResponseMode.STRING),
+        ("image/png", transport.ResponseMode.BINARY),
+        ("text/xml", transport.ResponseMode.STRING),
+        ("audio/gzip", transport.ResponseMode.BINARY),
+    ],
 )
-
-# note: string mode must be checked first
-RESPONSE_BINARY_MODE = r"^image/|^audio/|^video/|^font/|^application/|^multipart/"
+def test_response_mode(content_type, expected_response_mode):
+    assert transport.response_mode(content_type) == expected_response_mode

--- a/src/python.gen.spec.ts
+++ b/src/python.gen.spec.ts
@@ -102,17 +102,30 @@ describe('python generator', () => {
     it('add_group_group', () => {
       const method = apiModel.methods['add_group_group']
       const args = gen.httpArgs('', method).trim()
-      expect(args).toEqual('models.Group, body=body, transport_options=transport_options')
+      const expected = `f"/groups/{group_id}/groups",
+            models.Group,
+            body=body,
+            transport_options=transport_options`
+      expect(args).toEqual(expected)
     })
     it('create_query', () => {
       const method = apiModel.methods['create_query']
       const args = gen.httpArgs('', method).trim()
-      expect(args).toEqual('models.Query, query_params={"fields": fields}, body=body, transport_options=transport_options')
+      const expected = `f"/queries",
+            models.Query,
+            query_params={"fields": fields},
+            body=body,
+            transport_options=transport_options`
+      expect(args).toEqual(expected)
     })
     it('create_dashboard', () => {
       const method = apiModel.methods['create_dashboard']
       const args = gen.httpArgs('', method).trim()
-      expect(args).toEqual('models.Dashboard, body=body, transport_options=transport_options')
+      const expected = `f"/dashboards",
+            models.Dashboard,
+            body=body,
+            transport_options=transport_options`
+      expect(args).toEqual(expected)
     })
   })
 
@@ -129,13 +142,50 @@ def all_datagroups(
       const actual = gen.methodSignature('', method)
       expect(actual).toEqual(expected)
     })
+    it('binary return type render_task_results', () => {
+      const method = apiModel.methods['render_task_results']
+      const expected =
+        `# GET /render_tasks/{render_task_id}/results -> bytes
+def render_task_results(
+    self,
+    # Id of render task
+    render_task_id: str,
+    transport_options: Optional[transport.TransportSettings] = None,
+) -> bytes:
+`
+      const actual = gen.methodSignature('', method)
+      expect(actual).toEqual(expected)
+    })
+    it('binary or string return type run_url_encoded_query', () => {
+      const method = apiModel.methods['run_url_encoded_query']
+      const expected =
+`# GET /queries/models/{model_name}/views/{view_name}/run/{result_format} -> Union[str, bytes]
+def run_url_encoded_query(
+    self,
+    # Model name
+    model_name: str,
+    # View name
+    view_name: str,
+    # Format of result
+    result_format: str,
+    transport_options: Optional[transport.TransportSettings] = None,
+) -> Union[str, bytes]:
+`
+      const actual = gen.methodSignature('', method)
+      expect(actual).toEqual(expected)
+    })
   })
 
   describe('method body', () => {
     it('assert response is model add_group_group', () => {
       const method = apiModel.methods['add_group_group']
       const expected =
-        `response = self.post(f"/groups/{group_id}/groups", models.Group, body=body, transport_options=transport_options)
+`response = self.post(
+            f"/groups/{group_id}/groups",
+            models.Group,
+            body=body,
+            transport_options=transport_options
+)
 assert isinstance(response, models.Group)
 return response`
       const actual = gen.httpCall(indent, method)
@@ -144,7 +194,11 @@ return response`
     it('assert response is None delete_group_from_group', () => {
       const method = apiModel.methods['delete_group_from_group']
       const expected =
-        `response = self.delete(f"/groups/{group_id}/groups/{deleting_group_id}", None, transport_options=transport_options)
+`response = self.delete(
+            f"/groups/{group_id}/groups/{deleting_group_id}",
+            None,
+            transport_options=transport_options
+)
 assert response is None
 return response`
       const actual = gen.httpCall(indent, method)
@@ -153,7 +207,12 @@ return response`
     it('assert response is list active_themes', () => {
       const method = apiModel.methods['active_themes']
       const expected =
-        `response = self.get(f"/themes/active", Sequence[models.Theme], query_params={"name": name, "ts": ts, "fields": fields}, transport_options=transport_options)
+`response = self.get(
+            f"/themes/active",
+            Sequence[models.Theme],
+            query_params={"name": name, "ts": ts, "fields": fields},
+            transport_options=transport_options
+)
 assert isinstance(response, list)
 return response`
       const actual = gen.httpCall(indent, method)
@@ -162,8 +221,38 @@ return response`
     it('assert response is dict query_task_results', () => {
       const method = apiModel.methods['query_task_results']
       const expected =
-        `response = self.get(f"/query_tasks/{query_task_id}/results", MutableMapping[str, str], transport_options=transport_options)
+`response = self.get(
+            f"/query_tasks/{query_task_id}/results",
+            MutableMapping[str, str],
+            transport_options=transport_options
+)
 assert isinstance(response, dict)
+return response`
+      const actual = gen.httpCall(indent, method)
+      expect(actual).toEqual(expected)
+    })
+    it('assert response is bytes render_task_results', () => {
+      const method = apiModel.methods['render_task_results']
+      const expected =
+`response = self.get(
+            f"/render_tasks/{render_task_id}/results",
+            bytes,
+            transport_options=transport_options
+)
+assert isinstance(response, bytes)
+return response`
+      const actual = gen.httpCall(indent, method)
+      expect(actual).toEqual(expected)
+    })
+    it('assert response is bytes or str run_url_encoded_query', () => {
+      const method = apiModel.methods['run_url_encoded_query']
+      const expected =
+`response = self.get(
+            f"/queries/models/{model_name}/views/{view_name}/run/{result_format}",
+            Union[str, bytes],  # type: ignore
+            transport_options=transport_options
+)
+assert isinstance(response, (str, bytes))
 return response`
       const actual = gen.httpCall(indent, method)
       expect(actual).toEqual(expected)
@@ -232,7 +321,12 @@ class WriteCreateQueryTask(model.Model):
     look_id: Optional[int] = None
     dashboard_id: Optional[str] = None
 
-    def __init__(self, *, query_id: int, result_format: str, source: Optional[str] = None, deferred: Optional[bool] = None, look_id: Optional[int] = None, dashboard_id: Optional[str] = None):
+    def __init__(self, *, query_id: int,
+            result_format: str,
+            source: Optional[str] = None,
+            deferred: Optional[bool] = None,
+            look_id: Optional[int] = None,
+            dashboard_id: Optional[str] = None):
         self.query_id = query_id
         self.result_format = result_format
         self.source = source


### PR DESCRIPTION
Modified the transport interface so that it always returns bytes as well
as whether the "response mode" is binary or string and finally the text
encoding if any. The caller then decides how to de-serialize the
response.

fixes:#56