### PR TITLE
Python: fix for netrc creds overriding http auth headers

### DIFF
--- a/python/looker_sdk/rtl/requests_transport.py
+++ b/python/looker_sdk/rtl/requests_transport.py
@@ -78,6 +78,7 @@ class RequestsTransport(transport.Transport):
             resp = self.session.request(
                 method.name,
                 url,
+                auth=NullAuth(),
                 params=query_params,
                 data=body,
                 headers=headers,
@@ -102,3 +103,12 @@ class RequestsTransport(transport.Transport):
                 ret.encoding = encoding
 
         return ret
+
+
+class NullAuth(requests.auth.AuthBase):
+    """A custom auth class which ensures requests does not override authorization
+    headers with netrc file credentials if present.
+    """
+
+    def __call__(self, r):
+        return r

--- a/python/tests/integration/test_netrc.py
+++ b/python/tests/integration/test_netrc.py
@@ -8,7 +8,7 @@ from looker_sdk.sdk import models as ml
 NETRC_LOCATION = os.path.expanduser("~/.netrc")
 
 
-def can_netrc_file_be_created():
+def can_create_netrc_file():
     """Check if netrc can be created in home directory."""
     can = False
     if NETRC_LOCATION.startswith("~") or os.path.exists(NETRC_LOCATION):
@@ -37,7 +37,7 @@ def create_netrc_file(looker_client: mtds.LookerSDK):
 
 
 @pytest.mark.skipif(
-    not can_netrc_file_be_created(),
+    not can_create_netrc_file(),
     reason="netrc file cannot be created because it already exists or $HOME is undefined",  # noqa: B950
 )
 @pytest.mark.usefixtures("create_netrc_file")

--- a/python/tests/integration/test_netrc.py
+++ b/python/tests/integration/test_netrc.py
@@ -1,0 +1,50 @@
+import os
+import pytest  # type: ignore
+from urllib.parse import urlparse
+
+from looker_sdk.sdk import methods as mtds
+from looker_sdk.sdk import models as ml
+
+NETRC_LOCATION = os.path.expanduser("~/.netrc")
+
+
+def can_netrc_file_be_created():
+    """Check if netrc can be created in home directory."""
+    can = False
+    if NETRC_LOCATION.startswith("~") or os.path.exists(NETRC_LOCATION):
+        can = False
+    else:
+        can = True
+    return can
+
+
+@pytest.fixture()
+def create_netrc_file(looker_client: mtds.LookerSDK):
+    """Create a sample netrc meant to cause conflicts with the looker.ini file"""
+    host = urlparse(looker_client.auth.settings.base_url).netloc.split(":")[0]
+    netrc_contents = (
+        f"machine {host}"
+        f"\n  login netrc_client_id"
+        f"\n  password netrc_client_secret"
+    )
+
+    with open(NETRC_LOCATION, "w") as netrc_file:
+        netrc_file.write(netrc_contents)
+
+    yield
+
+    os.remove(NETRC_LOCATION)
+
+
+@pytest.mark.skipif(
+    not can_netrc_file_be_created(),
+    reason="netrc file cannot be created because it already exists or $HOME is undefined",  # noqa: B950
+)
+@pytest.mark.usefixtures("create_netrc_file")
+def test_netrc_does_not_override_ini_creds(looker_client: mtds.LookerSDK):
+    """The requests library overrides HTTP authorization headers if the auth= parameter
+    is not specified, resulting in an authentication error. This test makes sure this
+    does not happen when netrc files are found on the system.
+    """
+    me = looker_client.me()
+    assert isinstance(me, ml.User)

--- a/python/tests/rtl/test_requests_transport.py
+++ b/python/tests/rtl/test_requests_transport.py
@@ -50,7 +50,7 @@ class Session:
         self.ret_val = ret_val
         self.error = error
 
-    def request(self, method, url, params, data, headers, timeout):
+    def request(self, method, url, auth, params, data, headers, timeout):
         """Fake request.Session.request
         """
         if self.error:


### PR DESCRIPTION
As per https://3.python-requests.org/user/quickstart/#custom-headers, the requests library overrides auth headers with credentials specified in netrc if the auth parameter is not specified when calling requests.

The fix for now (until we support netrc files), is a NullAuth class that prevents this from happening, effectively ignoring the presence of netrc files on the system.

Fixes #61 