### PR TITLE
typescript formatter: optional only if not required

### DIFF
--- a/src/typescript.gen.spec.ts
+++ b/src/typescript.gen.spec.ts
@@ -283,5 +283,39 @@ body?: Partial<ICreateDashboardRenderTask>`)
   supported_versions?: IApiVersionElement[]
 }`)
     })
+    it('required properties', () => {
+      const type = apiModel.types['CreateQueryTask']
+      const actual = gen.declareType(indent, type)
+      expect(actual).toEqual(`export interface ICreateQueryTask{
+  /**
+   * Id of query to run
+   */
+  query_id: number
+  /**
+   * Desired result format
+   */
+  result_format: string
+  /**
+   * Source of query task
+   */
+  source?: string
+  /**
+   * Create the task but defer execution
+   */
+  deferred?: boolean
+  /**
+   * Id of look associated with query.
+   */
+  look_id?: number
+  /**
+   * Id of dashboard associated with query.
+   */
+  dashboard_id?: string
+  /**
+   * Operations the current user is able to perform on this object (read-only)
+   */
+  can?: IDictionary<boolean>
+}`)
+    })
   })
 })

--- a/src/typescript.gen.ts
+++ b/src/typescript.gen.ts
@@ -134,7 +134,7 @@ export interface IDictionary<T> {
   }
 
   declareProperty(indent: string, property: IProperty) {
-    const optional = (property.nullable || !property.required) ? '?' : ''
+    const optional = !property.required ? '?' : ''
     if (property.name === strBody) {
       // TODO refactor this hack to track context when the body parameter is created for the request type
       property.type.refCount++


### PR DESCRIPTION
explicitly setting a property to null (being "nullable") is different
from whether the presence of a property is required ("required").