### PR TITLE
Bug fixes and enhancements for `BrowserTransport`

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -53,19 +53,21 @@
         },
         "regex": {
             "hashes": [
-                "sha256:1e9f9bc44ca195baf0040b1938e6801d2f3409661c15fe57f8164c678cfc663f",
-                "sha256:587b62d48ca359d2d4f02d486f1f0aa9a20fbaf23a9d4198c4bed72ab2f6c849",
-                "sha256:835ccdcdc612821edf132c20aef3eaaecfb884c9454fdc480d5887562594ac61",
-                "sha256:93f6c9da57e704e128d90736430c5c59dd733327882b371b0cae8833106c2a21",
-                "sha256:a46f27d267665016acb3ec8c6046ec5eae8cf80befe85ba47f43c6f5ec636dcd",
-                "sha256:c5c8999b3a341b21ac2c6ec704cfcccbc50f1fedd61b6a8ee915ca7fd4b0a557",
-                "sha256:d4d1829cf97632673aa49f378b0a2c3925acd795148c5ace8ef854217abbee89",
-                "sha256:d96479257e8e4d1d7800adb26bf9c5ca5bab1648a1eddcac84d107b73dc68327",
-                "sha256:f20f4912daf443220436759858f96fefbfc6c6ba9e67835fd6e4e9b73582791a",
-                "sha256:f2b37b5b2c2a9d56d9e88efef200ec09c36c7f323f9d58d0b985a90923df386d",
-                "sha256:fe765b809a1f7ce642c2edeee351e7ebd84391640031ba4b60af8d91a9045890"
+                "sha256:15454b37c5a278f46f7aa2d9339bda450c300617ca2fca6558d05d870245edc7",
+                "sha256:1ad40708c255943a227e778b022c6497c129ad614bb7a2a2f916e12e8a359ee7",
+                "sha256:5e00f65cc507d13ab4dfa92c1232d004fa202c1d43a32a13940ab8a5afe2fb96",
+                "sha256:604dc563a02a74d70ae1f55208ddc9bfb6d9f470f6d1a5054c4bd5ae58744ab1",
+                "sha256:720e34a539a76a1fedcebe4397290604cc2bdf6f81eca44adb9fb2ea071c0c69",
+                "sha256:7caf47e4a9ac6ef08cabd3442cc4ca3386db141fb3c8b2a7e202d0470028e910",
+                "sha256:7faf534c1841c09d8fefa60ccde7b9903c9b528853ecf41628689793290ca143",
+                "sha256:b4e0406d822aa4993ac45072a584d57aa4931cf8288b5455bbf30c1d59dbad59",
+                "sha256:c31eaf28c6fe75ea329add0022efeed249e37861c19681960f99bbc7db981fb2",
+                "sha256:c7393597191fc2043c744db021643549061e12abe0b3ff5c429d806de7b93b66",
+                "sha256:d2b302f8cdd82c8f48e9de749d1d17f85ce9a0f082880b9a4859f66b07037dc6",
+                "sha256:e3d8dd0ec0ea280cf89026b0898971f5750a7bd92cb62c51af5a52abd020054a",
+                "sha256:ec032cbfed59bd5a4b8eab943c310acfaaa81394e14f44454ad5c9eba4f24a74"
             ],
-            "version": "==2019.8.19"
+            "version": "==2019.11.1"
         },
         "toml": {
             "hashes": [

--- a/src/typescript.gen.spec.ts
+++ b/src/typescript.gen.spec.ts
@@ -58,7 +58,7 @@ query_id: number`)
       expect(actual).toEqual(`/**
  * @param {number} limit Row limit (may override the limit in the saved query).
  */
-limit: number = 0`)
+limit?: number`)
     })
 
     it('required typed parameter', () => {
@@ -175,7 +175,7 @@ async create_user_credentials_email(
   /**
    * @param {string} fields Requested fields.
    */
-  fields: string = '',
+  fields?: string,
   options?: Partial<ITransportSettings>) {
 `
       const actual = gen.methodSignature('', method)

--- a/src/typescript.gen.ts
+++ b/src/typescript.gen.ts
@@ -363,24 +363,25 @@ export interface IDictionary<T> {
 
   typeMap(type: IType): IMappedType {
     super.typeMap(type)
+    const mt = ''
 
     const tsTypes: Record<string, IMappedType> = {
-      'number': {name: 'number', default: '0.0'},
-      'float': {name: 'number', default: '0.0'},
-      'double': {name: 'number', default: '0.0'},
-      'integer': {name: 'number', default: '0'},
-      'int32': {name: 'number', default: '0'},
-      'int64': {name: 'number', default: '0'},
-      'string': {name: 'string', default: "''"},
-      'password': {name: 'Password', default: this.nullStr},
-      'byte': {name: 'binary', default: this.nullStr},
-      'boolean': {name: 'boolean', default: ''},
-      'uri': {name: 'URL', default: this.nullStr},
-      'url': {name: 'URL', default: this.nullStr},
-      'datetime': {name: 'Date', default: ''}, // TODO is there a default expression for datetime?
-      'date': {name: 'Date', default: ''}, // TODO is there a default expression for date?
-      'object': {name: 'any', default: ''},
-      'void': {name: 'void', default: ''}
+      'number': {name: 'number', default: mt},
+      'float': {name: 'number', default: mt},
+      'double': {name: 'number', default: mt},
+      'integer': {name: 'number', default: mt},
+      'int32': {name: 'number', default: mt},
+      'int64': {name: 'number', default: mt},
+      'string': {name: 'string', default: mt},
+      'password': {name: 'Password', default: mt},
+      'byte': {name: 'binary', default: mt},
+      'boolean': {name: 'boolean', default: mt},
+      'uri': {name: 'URL', default: mt},
+      'url': {name: 'URL', default: mt},
+      'datetime': {name: 'Date', default: mt}, // TODO is there a default expression for datetime?
+      'date': {name: 'Date', default: mt}, // TODO is there a default expression for date?
+      'object': {name: 'any', default: mt},
+      'void': {name: 'void', default: mt}
     }
 
     if (type.elementType) {

--- a/typescript/looker/README.md
+++ b/typescript/looker/README.md
@@ -199,7 +199,7 @@ export class EmbedSession extends ProxySession {
     // get the auth token from the proxy server
     const token = await getProxyToken()
     if (token) {
-      // Assign the token, which will track its expiratin time automatically
+      // Assign the token, which will track its expiration time automatically
       this.activeToken.setToken(token)
     }
 

--- a/typescript/looker/package.json
+++ b/typescript/looker/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@looker/sdk",
-    "version": "0.1.3-beta.19",
+    "version": "0.1.3-beta.20",
     "description": "Looker SDK",
     "main": "dist/index.js",
     "typings": "dist/index.d.ts",

--- a/typescript/looker/package.json
+++ b/typescript/looker/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@looker/sdk",
-    "version": "0.2.0-beta.21",
+    "version": "0.2.0-beta.22",
     "description": "Looker SDK",
     "main": "dist/index.js",
     "typings": "dist/index.d.ts",

--- a/typescript/looker/package.json
+++ b/typescript/looker/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@looker/sdk",
-    "version": "0.1.3-beta.20",
+    "version": "0.2.0-beta.21",
     "description": "Looker SDK",
     "main": "dist/index.js",
     "typings": "dist/index.d.ts",

--- a/typescript/looker/package.json
+++ b/typescript/looker/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@looker/sdk",
-    "version": "0.1.3-beta.13",
+    "version": "0.1.3-beta.16",
     "description": "Looker SDK",
     "main": "dist/index.js",
     "typings": "dist/index.d.ts",

--- a/typescript/looker/package.json
+++ b/typescript/looker/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@looker/sdk",
-    "version": "0.1.3-beta.16",
+    "version": "0.1.3-beta.19",
     "description": "Looker SDK",
     "main": "dist/index.js",
     "typings": "dist/index.d.ts",

--- a/typescript/looker/rtl/apiMethods.ts
+++ b/typescript/looker/rtl/apiMethods.ts
@@ -27,7 +27,7 @@ import {
   HttpMethod,
   sdkError,
   IAuthorizer,
-  ITransportSettings,
+  ITransportSettings, Values,
 } from './transport'
 import { Readable } from "readable-stream"
 
@@ -81,7 +81,7 @@ export class APIMethods {
   async authRequest<TSuccess, TError>(
     method: HttpMethod,
     path: string,
-    queryParams?: any,
+    queryParams?: Values,
     body?: any,
     options?: Partial<ITransportSettings>,
   ): Promise<SDKResponse<TSuccess, TError>> {
@@ -111,7 +111,7 @@ export class APIMethods {
     callback: (readable: Readable) => Promise<T>,
     method: HttpMethod,
     path: string,
-    queryParams?: any,
+    queryParams?: Values,
     body?: any,
     options?: Partial<ITransportSettings>
   )
@@ -146,7 +146,7 @@ export class APIMethods {
   /** Make a GET request */
   async get<TSuccess, TError>(
     path: string,
-    queryParams?: any,
+    queryParams?: Values,
     body?: any,
     options?: Partial<ITransportSettings>,
   ): Promise<SDKResponse<TSuccess, TError>> {
@@ -162,7 +162,7 @@ export class APIMethods {
   /** Make a HEAD request */
   async head<TSuccess, TError>(
     path: string,
-    queryParams?: any,
+    queryParams?: Values,
     body?: any,
     options?: Partial<ITransportSettings>,
   ): Promise<SDKResponse<TSuccess, TError>> {
@@ -178,7 +178,7 @@ export class APIMethods {
   /** Make a DELETE request */
   async delete<TSuccess, TError>(
     path: string,
-    queryParams?: any,
+    queryParams?: Values,
     body?: any,
     options?: Partial<ITransportSettings>,
   ): Promise<SDKResponse<TSuccess, TError>> {
@@ -194,7 +194,7 @@ export class APIMethods {
   /** Make a POST request */
   async post<TSuccess, TError>(
     path: string,
-    queryParams?: any,
+    queryParams?: Values,
     body?: any,
     options?: Partial<ITransportSettings>,
   ): Promise<SDKResponse<TSuccess, TError>> {
@@ -210,7 +210,7 @@ export class APIMethods {
   /** Make a PUT request */
   async put<TSuccess, TError>(
     path: string,
-    queryParams?: any,
+    queryParams?: Values,
     body?: any,
     options?: Partial<ITransportSettings>,
   ): Promise<SDKResponse<TSuccess, TError>> {
@@ -226,7 +226,7 @@ export class APIMethods {
   /** Make a PATCH request */
   async patch<TSuccess, TError>(
     path: string,
-    queryParams?: any,
+    queryParams?: Values,
     body?: any,
     options?: Partial<ITransportSettings>,
   ): Promise<SDKResponse<TSuccess, TError>> {

--- a/typescript/looker/rtl/baseTransport.ts
+++ b/typescript/looker/rtl/baseTransport.ts
@@ -1,0 +1,109 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Looker Data Sciences, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+import {
+  addQueryParams,
+  Authenticator,
+  HttpMethod,
+  ITransport,
+  ITransportSettings,
+  SDKResponse,
+  Values,
+} from './transport'
+import { Readable } from 'readable-stream'
+
+export abstract class BaseTransport implements ITransport {
+  apiPath = ''
+
+  constructor(protected readonly options: ITransportSettings) {
+    this.options = options
+    this.apiPath = `${options.base_url}/api/${options.api_version}`
+  }
+
+  /**
+   * Request a streaming response
+   * @param {HttpMethod} method
+   * @param {string} path Request path
+   * @param queryParams query parameters for the request
+   * @param body http body to include with request
+   * @param {Authenticator} authenticator callback to add authentication information to the request
+   * @param {Partial<ITransportSettings>} options transport option overrides
+   * @returns {Promise<TSuccess>} the streaming response
+   */
+  abstract async request<TSuccess, TError>(
+    method: HttpMethod,
+    path: string,
+    queryParams?: any,
+    body?: any,
+    authenticator?: Authenticator,
+    options?: Partial<ITransportSettings>,
+  ): Promise<SDKResponse<TSuccess, TError>>
+
+  /**
+   * Request a streaming response
+   * @param {(readable: _Readable.Readable) => Promise<TSuccess>} callback A function will be called with a Node.js or
+   *  Browser `Readable` object. The readable object represents the streaming data.
+   * @param {HttpMethod} method
+   * @param {string} path Request path
+   * @param queryParams query parameters for the request
+   * @param body http body to include with request
+   * @param {Authenticator} authenticator callback to add authentication information to the request
+   * @param {Partial<ITransportSettings>} options transport option overrides
+   * @returns {Promise<TSuccess>} the streaming response
+   */
+  abstract async stream<TSuccess>(
+    callback: (readable: Readable) => Promise<TSuccess>,
+    method: HttpMethod,
+    path: string,
+    queryParams?: Values,
+    body?: any,
+    authenticator?: Authenticator,
+    options?: Partial<ITransportSettings>
+  )
+    : Promise<TSuccess>
+
+  /**
+   * Determine whether the path should be an API path, a fully specified override, or relative from base_url
+   * @param path Request path
+   * @param options Transport settings
+   * @param queryParams Collection of query Params
+   * @param authenticator optional callback
+   * @returns the fully specified request path including any query string parameters
+   */
+  makePath(
+    path: string,
+    options: Partial<ITransportSettings>,
+    queryParams?: Values,
+    authenticator?: Authenticator,
+  ) {
+    // is this an API-versioned call?
+    let base = (authenticator ? this.apiPath : options.base_url)!
+    if (!path.match(/^(http:\/\/|https:\/\/)/gi)) {
+      path = `${base}${path}` // path was relative
+    }
+    path = addQueryParams(path, queryParams)
+    return path
+  }
+
+}

--- a/typescript/looker/rtl/browserSession.ts
+++ b/typescript/looker/rtl/browserSession.ts
@@ -67,19 +67,21 @@ export class BrowserSession implements IAuthorizer {
   }
 
   async login(sudoId?: string | number): Promise<IAccessToken> {
-    if (!!sudoId) {
+    // TODO support sudo directly in the Browser session?
+    if (!sudoId) {
+      return this.getToken()
+    } else {
       throw new Error(
         'Sudo functionality is not currently supported in BrowserSession',
       )
     }
-    // TODO support sudo directly in the Browser session?
-    return this.getToken()
   }
 
   async logout(): Promise<boolean> {
     return new Promise<boolean>(() => false)
   }
 
+  // tslint:disable-next-line:no-empty
   reset(): void {
   }
 }

--- a/typescript/looker/rtl/browserSession.ts
+++ b/typescript/looker/rtl/browserSession.ts
@@ -25,10 +25,9 @@
 import { IApiSettings } from './apiSettings'
 import { IAuthorizer, IRequestInit, ITransport } from './transport'
 import { BrowserTransport } from './browserTransport'
-import { IAccessToken } from '../sdk/models'
+import { AuthToken } from './authToken'
 
 export class BrowserSession implements IAuthorizer {
-  sudoId: string = ''
   transport: ITransport
 
   constructor(public settings: IApiSettings, transport?: ITransport) {
@@ -56,27 +55,10 @@ export class BrowserSession implements IAuthorizer {
     return init
   }
 
-  async getToken(): Promise<IAccessToken> {
-    return new Promise<IAccessToken>(() => {
-      return {} as IAccessToken
-    })
-  }
-
-  isSudo(): boolean {
-    return !!this.sudoId
-  }
-
-  async login(sudoId?: string | number): Promise<IAccessToken> {
-    // TODO support sudo directly in the Browser session?
-    if (!sudoId) {
-      return this.getToken()
-    } else {
-      throw new Error(
-        'Sudo functionality is not currently supported in BrowserSession',
-      )
-    }
-  }
-
+  /**
+   * Logout is not supported for a Browser Session
+   * @returns {Promise<boolean>}
+   */
   async logout(): Promise<boolean> {
     return new Promise<boolean>(() => false)
   }
@@ -85,3 +67,52 @@ export class BrowserSession implements IAuthorizer {
   reset(): void {
   }
 }
+
+/**
+ * An AuthSession class intended for use with proxied authentication
+ *
+ * Override the `authenticate()` method to implmenent a browser authentication hook
+ *
+ * Override `logout()` if you want to support session logout
+ *
+ */
+export abstract class ProxySession implements IAuthorizer {
+  activeToken = new AuthToken()
+  transport: ITransport
+
+  constructor(public settings: IApiSettings, transport?: ITransport) {
+    this.settings = settings
+    this.transport = transport || new BrowserTransport(settings)
+  }
+
+  /**
+   * Is the session active and authenticated?
+   * @returns `true` if the session is active
+   */
+  isAuthenticated() {
+    return this.activeToken.isActive()
+  }
+
+  /**
+   * Decorate the request properties with the required authentication information
+   *
+   * Override this class with the implementation for a specific proxied authentication workflow
+   *
+   * @param props the properties of the request
+   * @returns the same properties with authentication added
+   */
+  abstract async authenticate(props: any): Promise<any>
+
+  /**
+   * Logout does nothing for a proxy session by default.
+   *
+   * Override to support telling the proxy to log out the session
+   *
+   * @returns a false Promise
+   */
+  async logout(): Promise<boolean> {
+    return new Promise<boolean>(() => false)
+  }
+
+}
+

--- a/typescript/looker/rtl/browserTransport.ts
+++ b/typescript/looker/rtl/browserTransport.ts
@@ -25,8 +25,6 @@
 import {
   ISDKError,
   SDKResponse,
-  ITransport,
-  addQueryParams,
   ITransportSettings,
   HttpMethod, Authenticator, agentTag, trace,
 } from './transport'
@@ -52,7 +50,8 @@ export class BrowserTransport extends BaseTransport {
     const props = await this.initRequest(method, body, authenticator, options)
     const req = fetch(
       requestPath,
-      props,
+      // @ts-ignore
+      props, // Weird package issues with unresolved imports for RequestInit :(
     )
 
     try {
@@ -76,7 +75,7 @@ export class BrowserTransport extends BaseTransport {
     }
   }
 
-  protected async initRequest(
+  private async initRequest(
     method: HttpMethod,
     body?: any,
     authenticator?: Authenticator,
@@ -93,7 +92,7 @@ export class BrowserTransport extends BaseTransport {
     // if ('encoding' in options) init.encoding = options.encoding
     //
 
-    let init: RequestInit = {
+    let init = {
       body: body ? JSON.stringify(body) : undefined,
       headers: headers,
       credentials: 'same-origin',

--- a/typescript/looker/rtl/browserTransport.ts
+++ b/typescript/looker/rtl/browserTransport.ts
@@ -82,34 +82,26 @@ export class BrowserTransport extends BaseTransport {
     options?: Partial<ITransportSettings>,
   ) {
     options = options ? {...this.options, ...options} : this.options
-    let headers = new Headers({'User-Agent': agentTag})
+    let headers: {[key:string]: string} = {'x-looker-appid': agentTag}
     if (options && options.headers) {
       Object.keys(options.headers).forEach(key => {
-        headers.append(key, options!.headers![key])
+        headers[key] = options!.headers![key]
       })
     }
 
-    // if ('encoding' in options) init.encoding = options.encoding
-    //
-
-    let init = {
+    let props = {
       body: body ? JSON.stringify(body) : undefined,
       headers: headers,
       credentials: 'same-origin',
-      // resolveWithFullResponse: true,
-      // rejectUnauthorized: this.verifySsl(options),
-      // timeout: this.timeout(options) * 1000,
-      // encoding: null, // null = requests are returned as binary so `Content-Type` dictates response format
-      // method,
       method,
     }
 
     if (authenticator) {
       // Add authentication information to the request
-      init = await authenticator(init)
+      props = await authenticator(props)
     }
 
-    return init
+    return props
   }
 
   // TODO finish this method

--- a/typescript/looker/rtl/browserTransport.ts
+++ b/typescript/looker/rtl/browserTransport.ts
@@ -28,30 +28,15 @@ import {
   ITransport,
   addQueryParams,
   ITransportSettings,
-  HttpMethod, Authenticator, agentTag,
+  HttpMethod, Authenticator, agentTag, trace,
 } from './transport'
 import { PassThrough, Readable } from 'readable-stream'
+import { BaseTransport } from './baseTransport'
 
-/**
- * Set to `true` to follow streaming process
- */
-const tracing = false
+export class BrowserTransport extends BaseTransport {
 
-function trace(entry: string, info?: any) {
-  if (tracing) {
-    console.debug(entry)
-    if (info) {
-      console.debug(info)
-    }
-  }
-}
-
-export class BrowserTransport implements ITransport {
-  apiPath = ''
-
-  constructor(private readonly options: ITransportSettings) {
-    this.options = options
-    this.apiPath = `${options.base_url}/api/${options.api_version}`
+  constructor(protected readonly options: ITransportSettings) {
+    super(options)
   }
 
   async request<TSuccess, TError>(
@@ -91,30 +76,7 @@ export class BrowserTransport implements ITransport {
     }
   }
 
-  /**
-   * Determine whether the path should be an API path, a fully specified override, or relative from base_url
-   * @param path Request path
-   * @param options Transport settings
-   * @param queryParams Collection of query Params
-   * @param authenticator optional callback
-   * @returns the fully specified request path including any query string parameters
-   */
-  private makePath(
-    path: string,
-    options: Partial<ITransportSettings>,
-    queryParams?: any,
-    authenticator?: Authenticator,
-    ) {
-    // is this an API-versioned call?
-    let base = (authenticator ? this.apiPath : options.base_url)!
-    if (!path.match(/^(http:\/\/|https:\/\/)/gi)) {
-      path = `${base}${path}` // path was relative
-    }
-    path = addQueryParams(path, queryParams)
-    return path
-  }
-
-  private async initRequest(
+  protected async initRequest(
     method: HttpMethod,
     body?: any,
     authenticator?: Authenticator,

--- a/typescript/looker/rtl/nodeTransport.spec.ts
+++ b/typescript/looker/rtl/nodeTransport.spec.ts
@@ -1,0 +1,75 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Looker Data Sciences, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+import { NodeTransport } from './nodeTransport'
+import { Authenticator, ITransportSettings } from './transport'
+
+describe('NodeTransport', () => {
+
+  const hostname = 'https://looker.sdk'
+  const apiVersion = '3.1'
+  const settings = { base_url: hostname, api_version: apiVersion } as ITransportSettings
+  const xp = new NodeTransport(settings)
+  const fullPath = 'https://github.com/looker-open-source/sdk-codegen'
+  const mockAuth: Authenticator = (props:any) => props
+  const queryParams = {a:"b c", d: false, nil: null, skip: undefined}
+
+  it('retrieves fully qualified url', async () => {
+    const response = await xp.request<string,Error>(
+      'GET',
+      fullPath,
+      )
+    expect(response).toBeDefined()
+    expect(response.ok).toEqual(true)
+    if (response.ok) {
+      const content = response.value
+      expect(content).toContain('One SDK to rule them all, and in the codegen bind them')
+    }
+  })
+
+  it('relative path without auth is just base', () => {
+    const actual = xp.makePath('/login', settings)
+    expect(actual).toEqual(`${hostname}/login`)
+  })
+
+  it('relative path with auth is api path', () => {
+    const actual = xp.makePath('/login', settings, null, mockAuth)
+    expect(actual).toEqual(`${hostname}/api/${apiVersion}/login`)
+  })
+
+  it('full path without auth is just full path', () => {
+    const actual = xp.makePath(fullPath, settings)
+    expect(actual).toEqual(fullPath)
+  })
+
+  it('full path with query has params', () => {
+    const actual = xp.makePath(fullPath, settings, queryParams)
+    expect(actual).toEqual(`${fullPath}?a=b%20c&d=false&nil=null`)
+  })
+
+  it('full path with auth is just full path', () => {
+    const actual = xp.makePath(fullPath, settings, undefined, mockAuth)
+    expect(actual).toEqual(fullPath)
+  })
+})

--- a/typescript/looker/rtl/nodeTransport.ts
+++ b/typescript/looker/rtl/nodeTransport.ts
@@ -42,7 +42,6 @@ import { BaseTransport } from './baseTransport'
 
 type RequestOptions = rq.RequiredUriUrl & rp.RequestPromiseOptions
 
-
 export class NodeTransport extends BaseTransport {
 
   constructor(protected readonly options: ITransportSettings) {
@@ -200,14 +199,14 @@ export class NodeTransport extends BaseTransport {
     return defaultTimeout
   }
 
-  protected async initRequest(
+  private async initRequest(
     method: HttpMethod,
     path: string,
     queryParams?: any,
     body?: any,
     authenticator?: Authenticator,
     options?: Partial<ITransportSettings>,
-  ): Promise<RequestOptions> {
+  ) {
     options = options ? {...this.options, ...options} : this.options
     let headers: any = {
       'User-Agent': agentTag,

--- a/typescript/looker/rtl/transport.ts
+++ b/typescript/looker/rtl/transport.ts
@@ -329,6 +329,11 @@ export function addQueryParams(path: string, obj?: Values ) {
   return `${path}${qp ? '?' + qp : ''}`
 }
 
+/**
+ * SDK error handler
+ * @param result any kind of error
+ * @returns a new `Error` object with the failure message
+ */
 export function sdkError(result: any) {
   if ('message' in result && typeof result.message === 'string') {
     return new Error(result.message)

--- a/typescript/looker/rtl/transport.ts
+++ b/typescript/looker/rtl/transport.ts
@@ -35,6 +35,26 @@ import { Readable } from "readable-stream"
 export const agentTag = `TS-SDK ${sdkVersion}`
 
 /**
+ * Set to `true` to follow streaming process
+ */
+const tracing = false
+
+/**
+ * trivial tracing function that should be replaced with a log plugin
+ * @param message description for trace
+ * @param info any additional information to produce for output
+ */
+export function trace(message: string, info?: any) {
+  if (tracing) {
+    console.debug(message)
+    if (info) {
+      console.debug({ info })
+    }
+  }
+}
+
+
+/**
  * ResponseMode for an HTTP request - either binary or "string"
  */
 export enum ResponseMode {
@@ -149,7 +169,7 @@ export interface ITransport {
   request<TSuccess, TError>(
     method: HttpMethod,
     path: string,
-    queryParams?: any,
+    queryParams?: Values,
     body?: any,
     authenticator?: Authenticator,
     options?: Partial<ITransportSettings>,
@@ -159,7 +179,7 @@ export interface ITransport {
     callback: (readable: Readable) => Promise<T>,
     method: HttpMethod,
     path: string,
-    queryParams?: any,
+    queryParams?: Values,
     body?: any,
     authenticator?: Authenticator,
     options?: Partial<ITransportSettings>,
@@ -276,24 +296,37 @@ export function isUtf8(contentType: string) {
 }
 
 /**
+ * Used for name/value pair collections like for QueryParams
+ */
+export type Values = {[key:string]: any} | null | undefined
+
+/**
+ * Converts `Values` to query string parameter format
+ * @param values Name/value collection to encode
+ * @returns {string} query string parameter formatted values. Both `false` and `null` are included. Only `undefined` are omitted.
+ */
+export function encodeParams(values?: Values) {
+  if (!values) return ""
+
+  const keys = Object.keys(values)
+  const params = keys
+    .filter(k => values[k] !== undefined) // `null` and `false` will both be passe
+    .map(k => k + '=' + encodeURIComponent(values[k]))
+    .join('&')
+  return params
+}
+
+/**
  * constructs the path argument including any optional query parameters
  * @param path the base path of the request
  * @param obj optional collection of query parameters to encode and append to the path
  */
-export function addQueryParams(path: string, obj?: { [key: string]: string }) {
+export function addQueryParams(path: string, obj?: Values ) {
   if (!obj) {
     return path
   }
-  const keys = Object.keys(obj)
-  if (keys.length === 0) {
-    return path
-  } else {
-    const qp = keys
-      .filter(k => obj[k]) // TODO test for "undefined" or omitted parameters
-      .map(k => k + '=' + encodeURIComponent(obj[k]))
-      .join('&')
-    return `${path}${qp ? '?' + qp : ''}`
-  }
+  const qp = encodeParams(obj)
+  return `${path}${qp ? '?' + qp : ''}`
 }
 
 export function sdkError(result: any) {
@@ -306,16 +339,3 @@ export function sdkError(result: any) {
   const error = JSON.stringify(result)
   return new Error(`Unknown error with SDK method ${error}`)
 }
-
-// TODO remove this permanently
-// /**
-//  * is the SDK running in node.js?
-//  */
-// export function isNodejs() {
-//   return (
-//     typeof 'process' !== 'undefined' &&
-//     process &&
-//     process.versions &&
-//     process.versions.node
-//   )
-// }


### PR DESCRIPTION
- authenticator callback now works
- requests can now be
  - automatically relative to the base url (`/path` with no authenticator)
  - automatically relative to the api url paths (`/path` *with* authenticator)
  - direct requests (path starts with `http://` or `https://`)

This way, the `BrowserTransport` instance can be used for ALL browser requests with the added bonus of giving typed responses back.

e.g. to create a proxy server call to retrieve the auth token from the web server:

```typescript
const getProxyToken = async () => {
  const token = await gSDK.ok(gSDK.authSession.transport.request<IAccessToken,IError>(
    'GET',
    'http://join.demo:8080/token'
  ))
  return token.access_token
}
```