### PR TITLE
[EMBED-547] Fix Kubernetes (GCP) cert errors.

### DIFF
--- a/kotlin/src/main/com/looker/rtl/UserSession.kt
+++ b/kotlin/src/main/com/looker/rtl/UserSession.kt
@@ -133,11 +133,12 @@ class UserSession(val apiSettings: ApiSettings,
         }
 
         if (!authToken.isActive()) {
+            val apiPath = "/api/${apiSettings.apiVersion}"
             val clientId = System.getenv("${ENVIRONMENT_PREFIX}_CLIENT_ID") ?: apiSettings.clientId
             val clientSecret = System.getenv("${ENVIRONMENT_PREFIX}_CLIENT_SECRET") ?: apiSettings.clientSecret
             val token = ok<AuthToken>(
                     transport.request<AuthToken>(HttpMethod.POST,
-                            "/login",
+                            "${apiPath}/login",
                             mapOf("client_id" to clientId, "client_secret" to clientSecret)
                     )
             )

--- a/swift/looker/Tests/lookerTests/authSessionTests.swift
+++ b/swift/looker/Tests/lookerTests/authSessionTests.swift
@@ -24,14 +24,14 @@ class authSessionTests: XCTestCase {
         let settings = config!
         let xp = BaseTransport(settings)
         let auth = AuthSession(settings, xp)
-        XCTAssertFalse(auth.isAuthenticated())
+        XCTAssertFalse(auth.isAuthenticated(), "should not be authenticated")
         let token = auth.login()
-        XCTAssertTrue(auth.isAuthenticated())
+        XCTAssertTrue(auth.isAuthenticated(), "should be authenticated")
         XCTAssertNotNil(token)
-        XCTAssertNotNil(token.access_token)
-        XCTAssertNotNil(token.token_type)
+        XCTAssertNotNil(token.access_token, "access token should be assigned")
+        XCTAssertNotNil(token.token_type, "token type should be assigned")
         _ = auth.logout()
-        XCTAssertFalse(auth.isAuthenticated())
+        XCTAssertFalse(auth.isAuthenticated(), "should not be authenticated")
     }
     
 }

--- a/swift/looker/Tests/lookerTests/constantsTests.swift
+++ b/swift/looker/Tests/lookerTests/constantsTests.swift
@@ -18,6 +18,27 @@ class constantsTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
+    func testStringBool() {
+        XCTAssertEqual("".bool, nil)
+        XCTAssertEqual("boo".bool, nil)
+        XCTAssertEqual("1".bool, true)
+        XCTAssertEqual("Y".bool, true)
+        XCTAssertEqual("yes".bool, true)
+        XCTAssertEqual("0".bool, false)
+        XCTAssertEqual("n".bool, false)
+        XCTAssertEqual("NO".bool, false)
+    }
+    
+    func testStringInt() {
+        XCTAssertEqual("".int, nil)
+        XCTAssertEqual("0".int, 0)
+        XCTAssertEqual("1".int, 1)
+        XCTAssertEqual("-1".int, -1)
+        XCTAssertEqual("6,000".int, nil, "6,000 doesn't cast to Int")
+        XCTAssertEqual("6000".int, 6000)
+        XCTAssertEqual("-i".int, nil)
+    }
+    
     func testAsQ() {
         var val: Any? = "foo bar"
         XCTAssertEqual(asQ(val), "foo%20bar")

--- a/swift/looker/rtl/apiConfig.swift
+++ b/swift/looker/rtl/apiConfig.swift
@@ -79,7 +79,7 @@ func parseConfig(_ filename : String) -> Config {
     return config
 }
 
-struct ApiConfig : IApiSettings {
+struct ApiConfig: IApiSettings {
     func readConfig(_ section: String? = nil) -> IApiSection {
         let config = parseConfig(self.fileName)
         return config[section ?? self.section] ?? [:]
@@ -112,19 +112,26 @@ struct ApiConfig : IApiSettings {
         self.assign(settings)
     }
     
-    // TODO figure out how to use Codable and PropertyListDecoder?
-    // similar to https://www.raywenderlich.com/3418439-encoding-and-decoding-in-swift
+    /// Get SDK settings from a configuration file with environment variable overrides
     init(_ fileName: String, _ section: String = "Looker") throws {
         self.fileName = fileName
         self.section = section
         let config = parseConfig(fileName)
         let values = config[section]
         let defaults = DefaultSettings()
-        self.base_url = values?["base_url"] as String? ?? defaults.base_url
-        self.api_version = values?["api_version"] as String? ?? defaults.api_version
+        self.base_url = ProcessInfo.processInfo.environment[strLookerBaseUrl]
+            ?? values?["base_url"] as String?
+            ?? defaults.base_url
+        self.api_version = ProcessInfo.processInfo.environment[strLookerApiVersion]
+            ?? values?["api_version"] as String?
+            ?? defaults.api_version
+        self.verify_ssl = (ProcessInfo.processInfo.environment[strLookerBaseUrl] ?? "").bool
+            ?? values?["verify_ssl"]?.bool
+            ?? defaults.verify_ssl
+        self.timeout = (ProcessInfo.processInfo.environment[strLookerBaseUrl] ?? "").int
+            ?? Int((values?["timeout"])!)
+            ?? defaults.timeout
         self.headers = values?["headers"] as Any? ?? defaults.headers
-        self.verify_ssl = values?["verify_ssl"]?.bool ?? defaults.verify_ssl
-        self.timeout = Int((values?["timeout"])!) ?? defaults.timeout
         self.encoding = values?["encoding"] ?? defaults.encoding
     }
     

--- a/swift/looker/rtl/apiSettings.swift
+++ b/swift/looker/rtl/apiSettings.swift
@@ -73,17 +73,17 @@ struct DefaultSettings : IApiSettings {
  *  - <environmentPrefix>_TIMEOUT
  */
 func ValueSettings(_ values: StringDictionary<String>) -> IApiSettings {
-    var settings = DefaultSettings()
-    settings.api_version = values[strLookerApiVersion] ?? settings.api_version
-    settings.base_url = values[strLookerBaseUrl] ?? settings.base_url
+    var defaults = DefaultSettings()
+    defaults.api_version = values[strLookerApiVersion] ?? defaults.api_version
+    defaults.base_url = values[strLookerBaseUrl] ?? defaults.base_url
     if (values[strLookerVerifySsl] != nil) {
         let v = values[strLookerVerifySsl]!.lowercased()
-        settings.verify_ssl = v == "true" || v == "1"
+        defaults.verify_ssl = v == "true" || v == "1"
     }
     if (values[strLookerTimeout] != nil) {
-        settings.timeout = Int(values[strLookerTimeout]!)!
+        defaults.timeout = Int(values[strLookerTimeout]!)!
     }
-    return settings
+    return defaults
 }
 
 /**
@@ -103,9 +103,7 @@ struct ApiSettings: IApiSettings {
     var headers: Headers?
     var encoding: String?
     
-    init() {
-        
-    }
+    init() { }
     
     init(_ settings: IApiSettings) throws {
         let defaults = DefaultSettings()

--- a/swift/looker/rtl/authSession.swift
+++ b/swift/looker/rtl/authSession.swift
@@ -35,6 +35,7 @@ protocol IAuthSession: IAuthorizer {
 @available(OSX 10.15, *)
 class AuthSession: IAuthSession {
   
+    private var apiPath = ""
     var _authToken = AuthToken()
     var _sudoToken = AuthToken()
     var sudoId: String = ""
@@ -52,6 +53,7 @@ class AuthSession: IAuthSession {
     init(_ settings: IApiSettings, _ transport: ITransport? = nil) {
         self.settings = settings
         self.transport = transport ?? BaseTransport(settings)
+        self.apiPath = "/api/\(settings.api_version!)"
     }
     
     func getToken() -> AuthToken {
@@ -131,7 +133,7 @@ class AuthSession: IAuthSession {
             }
             let response : SDKResponse<AccessToken, SDKError> = self.transport.request(
                 HttpMethod.POST,
-                "/login",
+                "\(self.apiPath)/login",
                 ["client_id": client_id!, "client_secret": client_secret!],
                 nil,
                 nil,
@@ -145,6 +147,7 @@ class AuthSession: IAuthSession {
             let token = self.activeToken
             let response : SDKResponse<AccessToken, SDKError> = self.transport.request(
                 HttpMethod.POST,
+                // Don't set Api path here since authenticator presence will cause it to be added in request
                 "/login/\(newId)",
                 nil,
                 nil,
@@ -175,6 +178,7 @@ class AuthSession: IAuthSession {
         let token = self.activeToken
         let response : SDKResponse<Voidable, SDKError> = self.transport.request(
             HttpMethod.DELETE,
+            // Because this request uses an authenticator call back, api path will be automatically added. Don't add it here.
             "/logout",
             nil,
             nil,

--- a/swift/looker/rtl/constants.swift
+++ b/swift/looker/rtl/constants.swift
@@ -107,6 +107,9 @@ extension String {
             return nil
         }
     }
+    var int: Int? {
+        return Int(self)
+    }
 }
 
 /// Structure that represents "Void" return results for the SDK response

--- a/typescript/looker/package.json
+++ b/typescript/looker/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@looker/sdk",
-    "version": "0.2.0-beta.22",
+    "version": "0.2.0-beta.23",
     "description": "Looker SDK",
     "main": "dist/index.js",
     "typings": "dist/index.d.ts",

--- a/typescript/looker/rtl/nodeSession.ts
+++ b/typescript/looker/rtl/nodeSession.ts
@@ -71,6 +71,7 @@ export interface IAuthSession extends IAuthorizer {
 }
 
 export class NodeSession implements IAuthSession {
+  private apiPath = ""
   _authToken: AuthToken = new AuthToken()
   _sudoToken: AuthToken = new AuthToken()
   sudoId: string = ''
@@ -79,6 +80,7 @@ export class NodeSession implements IAuthSession {
   constructor(public settings: IApiSettingsConfig, transport?: ITransport) {
     this.settings = settings
     this.transport = transport || new NodeTransport(settings)
+    this.apiPath = `/api/${settings.api_version}`
   }
 
   /**
@@ -209,7 +211,7 @@ export class NodeSession implements IAuthSession {
       const token = await this.ok(
         this.transport.request<IAccessToken, IError>(
           strPost,
-          '/login',
+          `${this.apiPath}/login`,
           {
             client_id,
             client_secret,
@@ -224,6 +226,7 @@ export class NodeSession implements IAuthSession {
       let token = this.activeToken
       const promise = this.transport.request<IAccessToken, IError>(
         strPost,
+        // Don't use api path here since authenticator presence will cause it to be added
         encodeURI(`/login/${newId}`),
         null,
         null,
@@ -249,6 +252,7 @@ export class NodeSession implements IAuthSession {
     const token = this.activeToken
     const promise = this.transport.request<string, IError>(
       strDelete,
+      // Do not add api path here, since the authenticator will cause the request method to add it automatically
       '/logout',
       null,
       null,

--- a/typescript/looker/test/methods.spec.ts
+++ b/typescript/looker/test/methods.spec.ts
@@ -269,12 +269,12 @@ describe('LookerNodeSDK', () => {
       'login/logout',
       async () => {
         const sdk = new LookerSDK(session)
-        const apiUser = await sdk.ok(sdk.me())
         let all = await sdk.ok(
           sdk.all_users({
             fields: 'id,is_disabled'
           })
         )
+        const apiUser = await sdk.ok(sdk.me())
 
         // find users who are not the API user
         const others = all


### PR DESCRIPTION
Needed to use `/api/3.1/login` path for session managers rather than `/login`

Fixed for
- Typescript
- Swift
- Kotlin

The Python SDK was already correct