### PR TITLE
Closing some quick Kotlin SDK issues

### DIFF
--- a/kotlin/src/main/com/looker/rtl/ApiSettings.kt
+++ b/kotlin/src/main/com/looker/rtl/ApiSettings.kt
@@ -45,13 +45,12 @@ class ApiSettingsIniFile(filename: String = "./looker.ini",
                          section: String = "") : ApiSettings(File(filename).readText(), section)
 
 
-// TODO why not @JvmOverloads here?
+// TODO why no @JvmOverloads here?
 open class ApiSettings(contents: String, var section: String = ""): TransportSettings() {
 
     val clientId: String
     val clientSecret: String
     val embedSecret: String
-    val userId: String
 
     init {
         val config = apiConfig(contents)
@@ -66,6 +65,7 @@ open class ApiSettings(contents: String, var section: String = ""): TransportSet
         clientId = config[section]?.get("client_id") ?: ""
         clientSecret = config[section]?.get("client_secret") ?: ""
         embedSecret = config[section]?.get("embed_secret") ?: ""
-        userId = config[section]?.get("user_id") ?: ""
+        verifySSL = asBoolean(config[section]?.get("verify_ssl")) ?: true
+        timeout = config[section]?.get("timeout")?.toInt() ?: DEFAULT_TIMEOUT
     }
 }

--- a/kotlin/src/main/com/looker/rtl/ApiSettings.kt
+++ b/kotlin/src/main/com/looker/rtl/ApiSettings.kt
@@ -60,7 +60,7 @@ open class ApiSettings(contents: String, var section: String = ""): TransportSet
             throw Error("No section named '$section' was found")
         }
 
-        apiVersion = config[section]?.get("api_version") ?: ""
+        apiVersion = config[section]?.get("api_version") ?: DEFAULT_API_VERSION
         baseUrl = config[section]?.get("base_url") ?: ""
         clientId = config[section]?.get("client_id") ?: ""
         clientSecret = config[section]?.get("client_secret") ?: ""

--- a/kotlin/src/main/com/looker/rtl/Constants.kt
+++ b/kotlin/src/main/com/looker/rtl/Constants.kt
@@ -6,6 +6,8 @@ import org.jetbrains.annotations.NotNull
 const val LOOKER_VERSION = "6.21"
 const val API_VERSION = "3.1"
 const val SDK_VERSION = "${API_VERSION}.${LOOKER_VERSION}"
+const val AGENT_TAG = "SDK-KT ${SDK_VERSION}"
+const val LOOKER_APPID = "x-looker-appid"
 const val ENVIRONMENT_PREFIX = "LOOKERSDK"
 
 const val MATCH_CHARSET = ";.*charset="

--- a/kotlin/src/main/com/looker/rtl/Constants.kt
+++ b/kotlin/src/main/com/looker/rtl/Constants.kt
@@ -30,12 +30,12 @@ class DelimArray<T> : Array<T>() {
 
 fun isTrue(value: String?) : Boolean {
     val low = value?.toLowerCase()
-    return low === "true" || low === "1" || low === "t" || low === "y" || low === "yes"
+    return low == "true" || low == "1" || low == "t" || low == "y" || low == "yes"
 }
 
 fun isFalse(value: String?) : Boolean {
     val low = value?.toLowerCase()
-    return low === "false" || low === "0" || low === "f" || low === "n" || low === "no"
+    return low == "false" || low == "0" || low == "f" || low == "n" || low == "no"
 }
 
 fun asBoolean(value: String?) : Boolean? {

--- a/kotlin/src/main/com/looker/rtl/Constants.kt
+++ b/kotlin/src/main/com/looker/rtl/Constants.kt
@@ -13,6 +13,9 @@ const val MATCH_CHARSET_UTF8 = "${MATCH_CHARSET}.*\\butf-9\\b"
 const val MATCH_MODE_STRING = "(^application\\\\/.*(\\\\bjson\\\\b|\\\\bxml\\\\b|\\\\bsql\\\\b|\\\\bgraphql\\\\b|\\\\bjavascript\\\\b|\\\\bx-www-form-urlencoded\\\\b)|^text\\\\/|${MATCH_CHARSET})"
 const val MATCH_MODE_BINARY = "^image\\\\/|^audio\\\\/|^video\\\\/|^font\\\\/|^application\\\\/|^multipart\\\\/"
 
+const val DEFAULT_TIMEOUT = 120
+const val DEFAULT_API_VERSION = "3.1"
+
 typealias Values = Map<String, Any?>
 
 // TODO ensure DelimArray<t> returns 1,2,3 for the string representation rather than [1,2,3] or some other syntax
@@ -22,6 +25,22 @@ typealias DelimArray<T> = Array<T>
 class DelimArray<T> : Array<T>() {
 }
  */
+
+fun isTrue(value: String?) : Boolean {
+    val low = value?.toLowerCase()
+    return low === "true" || low === "1" || low === "t" || low === "y" || low === "yes"
+}
+
+fun isFalse(value: String?) : Boolean {
+    val low = value?.toLowerCase()
+    return low === "false" || low === "0" || low === "f" || low === "n" || low === "no"
+}
+
+fun asBoolean(value: String?) : Boolean? {
+    if (isTrue(value)) return true
+    if (isFalse(value)) return false
+    return null
+}
 
 // Kludge to work-around current JSON deserialization issues
 object Safe {

--- a/kotlin/src/main/com/looker/rtl/Constants.kt
+++ b/kotlin/src/main/com/looker/rtl/Constants.kt
@@ -6,7 +6,7 @@ import org.jetbrains.annotations.NotNull
 const val LOOKER_VERSION = "6.21"
 const val API_VERSION = "3.1"
 const val SDK_VERSION = "${API_VERSION}.${LOOKER_VERSION}"
-const val AGENT_TAG = "SDK-KT ${SDK_VERSION}"
+const val AGENT_TAG = "Looker SDK-KT ${SDK_VERSION}"
 const val LOOKER_APPID = "x-looker-appid"
 const val ENVIRONMENT_PREFIX = "LOOKERSDK"
 

--- a/kotlin/src/main/com/looker/rtl/Transport.kt
+++ b/kotlin/src/main/com/looker/rtl/Transport.kt
@@ -83,13 +83,15 @@ fun defaultAuthenticator(requestSettings: RequestSettings): RequestSettings = re
 
 open class TransportSettings(
         var baseUrl: String = "",
-        var apiVersion: String = "",
+        var apiVersion: String = DEFAULT_API_VERSION,
+        var verifySSL: Boolean = true,
+        var timeout: Int = DEFAULT_TIMEOUT,
         var headers: Map<String, String> = mapOf())
 
 fun encodeValues(params: Values = mapOf()): String {
     @Suppress("UNCHECKED_CAST")
     return params
-            .filter { (k, v) -> v !== null }
+            .filter { (_, v) -> v !== null }
             .map { (k, v) -> "$k=${URLEncoder.encode("$v", "utf-8")}"}
             .joinToString("&")
 
@@ -138,7 +140,7 @@ class Transport(val options: TransportSettings) {
      * @param authenticator optional authenticator callback for API requests
      * @return a fully qualified path that is the base url, the api path, or a pass through request url
      */
-    fun makePath(
+    fun makeUrl(
             path: String,
             queryParams: Values = mapOf(),
             authenticator: Authenticator? = null // TODO figure out why ::defaultAuthenticator is matching when it shouldn't
@@ -175,7 +177,7 @@ class Transport(val options: TransportSettings) {
         val headers = options.headers.toMutableMap()
         headers["User-Agent"] = agentTag
 
-        val requestPath = makePath(path, queryParams, authenticator)
+        val requestPath = makeUrl(path, queryParams, authenticator)
 
         // TODO review this kludge
         val auth = if (authenticator === null) { ::defaultAuthenticator } else { authenticator }

--- a/kotlin/src/main/com/looker/rtl/Transport.kt
+++ b/kotlin/src/main/com/looker/rtl/Transport.kt
@@ -166,16 +166,16 @@ class Transport(val options: TransportSettings) {
 
         // Request body
         val json = io.ktor.client.features.json.defaultSerializer()
-        // TODO make our request body form encoded
 
         val builder = HttpRequestBuilder()
         // Set the request method
         builder.method = method.value
 
         // Handle the headers
-        val agentTag = "LookerSDK Kotlin ${options.apiVersion}"
+        val agentTag = "KT-SDK ${options.apiVersion}"
         val headers = options.headers.toMutableMap()
         headers["User-Agent"] = agentTag
+        headers["x-looker-appid"] = agentTag
 
         val requestPath = makeUrl(path, queryParams, authenticator)
 

--- a/kotlin/src/main/com/looker/rtl/Transport.kt
+++ b/kotlin/src/main/com/looker/rtl/Transport.kt
@@ -172,10 +172,9 @@ class Transport(val options: TransportSettings) {
         builder.method = method.value
 
         // Handle the headers
-        val agentTag = "KT-SDK ${options.apiVersion}"
         val headers = options.headers.toMutableMap()
-        headers["User-Agent"] = agentTag
-        headers["x-looker-appid"] = agentTag
+        headers["User-Agent"] = AGENT_TAG
+        headers[LOOKER_APPID] = AGENT_TAG
 
         val requestPath = makeUrl(path, queryParams, authenticator)
 

--- a/kotlin/src/test/TestApiSettings.kt
+++ b/kotlin/src/test/TestApiSettings.kt
@@ -1,0 +1,41 @@
+import com.looker.rtl.ApiSettings
+import com.looker.rtl.DEFAULT_API_VERSION
+import com.looker.rtl.DEFAULT_TIMEOUT
+import com.looker.rtl.asBoolean
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+val bareMinimum = """
+[Looker]
+base_url=https://my.looker.com:19999
+""".trimIndent()
+
+class TestApiSettings {
+    @Test fun testApiSettingsDefaults() {
+        val settings = ApiSettings(bareMinimum)
+        assertEquals(settings.apiVersion, DEFAULT_API_VERSION, "API version defaults to 3.1")
+        assertEquals(settings.baseUrl, "https://my.looker.com:19999", "Base URL is read")
+        assertEquals(settings.verifySSL, true)
+        assertEquals(settings.timeout, DEFAULT_TIMEOUT)
+    }
+
+    @Test fun testBoolStrings() {
+        asBoolean("1")?.let { assertTrue(it) }
+        asBoolean("y'")?.let { assertTrue(it) }
+        asBoolean("YES'")?.let { assertTrue(it) }
+        asBoolean("t'")?.let { assertTrue(it) }
+        asBoolean("TRUE'")?.let { assertTrue(it) }
+        asBoolean("true'")?.let { assertTrue(it) }
+        asBoolean("0")?.let { assertFalse(it) }
+        asBoolean("f'")?.let { assertFalse(it) }
+        asBoolean("FALSE'")?.let { assertFalse(it) }
+        asBoolean("n'")?.let { assertFalse(it) }
+        asBoolean("N'")?.let { assertFalse(it) }
+        asBoolean("NO'")?.let { assertFalse(it) }
+        asBoolean("null")?.let { assertNull(it)}
+        asBoolean("boo")?.let { assertNull(it)}
+    }
+}

--- a/kotlin/src/test/TestMethods.kt
+++ b/kotlin/src/test/TestMethods.kt
@@ -9,14 +9,10 @@ import org.apache.http.conn.ssl.TrustSelfSignedStrategy
 import org.apache.http.ssl.SSLContextBuilder
 import kotlin.test.assertEquals
 import org.junit.Test as test
-import junit.framework.Assert.assertTrue
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class TestMethods {
-    // TODO dynamically local ini file in tests. Possibly make into test initializer utils
-//    val localIni = "/Users/Looker/Documents/sdk_codegen/looker.ini"
-    val localIni = "/Users/Looker/sdk-codegen/looker.ini"
     val settings = ApiSettingsIniFile(localIni, "Looker")
 
     val client: HttpClient = HttpClient(Apache) {

--- a/kotlin/src/test/TestTransport.kt
+++ b/kotlin/src/test/TestTransport.kt
@@ -23,7 +23,6 @@
  */
 
 import com.looker.rtl.*
-import com.looker.sdk.LookerSDK
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import org.junit.Test as test
@@ -37,24 +36,24 @@ class TestTransport {
     val options = TransportSettings(base, apiVersion)
     val xp = Transport(options)
     val qp: Values = mapOf("a" to 1, "b" to false, "c" to "d e", "skip" to null)
-    val mockAuth: Authenticator = { init: RequestSettings -> RequestSettings(HttpMethod.GET, "bogus") }
+    val mockAuth: Authenticator = { RequestSettings(HttpMethod.GET, "bogus") }
     val params = "?a=1&b=false&c=d+e"
 
     @test fun testFullPath() {
-        var actual = xp.makePath(fullPath)
+        var actual = xp.makeUrl(fullPath)
         assertEquals(fullPath, actual)
-        actual = xp.makePath(fullPath, authenticator = mockAuth)
+        actual = xp.makeUrl(fullPath, authenticator = mockAuth)
         assertEquals(fullPath, actual)
-        actual = xp.makePath(fullPath, qp, mockAuth)
+        actual = xp.makeUrl(fullPath, qp, mockAuth)
         assertEquals(fullPath+params, actual)
     }
 
     @test fun testRelativePath() {
-        var actual = xp.makePath(userPath)
+        var actual = xp.makeUrl(userPath)
         assertEquals("$base$userPath", actual)
-        actual = xp.makePath(userPath, authenticator = mockAuth)
+        actual = xp.makeUrl(userPath, authenticator = mockAuth)
         assertEquals("$base/api/$apiVersion$userPath", actual)
-        actual = xp.makePath(userPath, qp, mockAuth)
+        actual = xp.makeUrl(userPath, qp, mockAuth)
         assertEquals("$base/api/$apiVersion$userPath$params", actual)
     }
 

--- a/kotlin/src/test/TestUserSession.kt
+++ b/kotlin/src/test/TestUserSession.kt
@@ -38,7 +38,7 @@ import org.junit.Test as test
 
 
 class TestUserSession {
-    // TODO dynamically local ini file in tests. Possibly make into test initializer utils
+    // TODO dynamically locate ini file in tests. Possibly make into test initializer utils
 
     //    val localIni = "/Users/looker/Documents/sdk_codegen/looker.ini"
     val localIni = "/Users/looker/sdk-codegen/looker.ini"

--- a/kotlin/src/test/TestUserSession.kt
+++ b/kotlin/src/test/TestUserSession.kt
@@ -35,13 +35,23 @@ import org.apache.http.ssl.SSLContextBuilder
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import org.junit.Test as test
+import java.io.File
 
+
+val rootPath = File("./").absoluteFile.parentFile.parentFile.absolutePath
+val testPath  = "${rootPath}/test"
+val dataFile = testFile("data.yml")
+val localIni = rootFile("looker.ini")
+
+fun rootFile(fileName: String): String {
+    return "${rootPath}/${fileName}"
+}
+
+fun testFile(fileName: String) : String {
+    return "${testPath}/${fileName}"
+}
 
 class TestUserSession {
-    // TODO dynamically locate ini file in tests. Possibly make into test initializer utils
-
-    //    val localIni = "/Users/looker/Documents/sdk_codegen/looker.ini"
-    val localIni = "/Users/looker/sdk-codegen/looker.ini"
     val settings = ApiSettingsIniFile(localIni, "Looker")
 
     val client: HttpClient = HttpClient(Apache) {
@@ -59,6 +69,11 @@ class TestUserSession {
                 setSSLHostnameVerifier(NoopHostnameVerifier())
             }
         }
+    }
+
+    @test fun testTestFiles() {
+        assertTrue(File(dataFile).exists(), "${dataFile} should exist")
+        assertTrue(File(localIni).exists(), "${localIni} should exist")
     }
 
     @test fun testIsAuthenticated() {


### PR DESCRIPTION
- Additional API configuration settings supported
- Transport support for `verify_ssl` and `timeout` still pending
- Closes #100, #104