### PR TITLE
Fix typescript test failures when tests run from root directory

### DIFF
--- a/tsconfig.common.json
+++ b/tsconfig.common.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noImplicitReturns": true,
+    "noImplicitAny": true,
+    "noFallthroughCasesInSwitch": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "plugins": [
+      {
+        "name": "tslint-language-service",
+        "alwaysShowRuleFailuresAsWarnings": true
+      }
+    ]
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,19 +1,6 @@
 {
+  "extends": "./tsconfig.common",
   "compilerOptions": {
-    "declaration": true,
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "noImplicitReturns": true,
-    "noImplicitAny": true,
-    "noFallthroughCasesInSwitch": true,
-    "strict": true,
-    "esModuleInterop": true,
-    "plugins": [
-      {
-        "name": "tslint-language-service",
-        "alwaysShowRuleFailuresAsWarnings": true
-      }
-    ],
     "target": "es6",
     "lib": ["es6", "es2017.object", "dom"],
     "allowSyntheticDefaultImports": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,12 @@
 {
   "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
-    "noFallthroughCasesInSwitch": true,
+    "declaration": true,
+    "module": "commonjs",
+    "moduleResolution": "node",
     "noImplicitReturns": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
+    "noImplicitAny": true,
+    "noFallthroughCasesInSwitch": true,
+    "strict": true,
     "esModuleInterop": true,
     "plugins": [
       {
@@ -12,13 +14,10 @@
         "alwaysShowRuleFailuresAsWarnings": true
       }
     ],
-    "skipLibCheck": true,
-    "strict": true,
-    "module": "commonjs",
-    "moduleResolution": "node",
     "target": "es6",
     "lib": ["es6", "es2017.object", "dom"],
-    "noImplicitAny": true,
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true,
     "baseUrl": "./"
   },
   "include": ["./*.ts", "./src/*.ts"]

--- a/typescript/looker/tsconfig.json
+++ b/typescript/looker/tsconfig.json
@@ -1,20 +1,22 @@
-{
+  {
   "compilerOptions": {
     "declaration": true,
     "module": "commonjs",
     "moduleResolution": "node",
     "noImplicitReturns": true,
-    "outDir": "dist",
+    "noImplicitAny": true,
+    "noFallthroughCasesInSwitch": true,
     "strict": true,
-    "target": "ES5",
     "esModuleInterop": true,
-    "lib": ["es2015", "es6", "dom", "es2015.promise"],
     "plugins": [
       {
         "name": "typescript-tslint-plugin",
         "alwaysShowRuleFailuresAsWarnings": true
       }
-    ]
+    ],
+    "target": "ES5",
+    "lib": ["es2015", "es6", "dom", "es2015.promise"],
+    "outDir": "dist"
   },
   "exclude": [
     "node_modules"

--- a/typescript/looker/tsconfig.json
+++ b/typescript/looker/tsconfig.json
@@ -1,19 +1,6 @@
-  {
+{
+  "extends": "../../tsconfig.common",
   "compilerOptions": {
-    "declaration": true,
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "noImplicitReturns": true,
-    "noImplicitAny": true,
-    "noFallthroughCasesInSwitch": true,
-    "strict": true,
-    "esModuleInterop": true,
-    "plugins": [
-      {
-        "name": "typescript-tslint-plugin",
-        "alwaysShowRuleFailuresAsWarnings": true
-      }
-    ],
     "target": "ES5",
     "lib": ["es2015", "es6", "dom", "es2015.promise"],
     "outDir": "dist"


### PR DESCRIPTION
Test failures were caused by tslint issues. When the tests were added, the tests were run from the typescript/looker directory and worked. This is because the tsconfig at root and in typescript/looker were different. This change makes an attempt at reconciling the differences. The format of the two tsconfig files are now similar so they can be compared side by side. Matching options are at the top, options with different values next, followed lastly by different options.

The options causing the test failures were:
    "noUnusedLocals": true,
    "noUnusedParameters": true,
These were not in the tsconfig in typescript/looker. Fixing not an option as this caused the typescript/looker build to fail. Also tried tslint disable but for some reason jest did not honour these. In the end removed those options in the root tsconfig to bring into line with typescript/looker tsconfig. yarn test from root no longer fail due to typescript issues.

Note that yarn lint fails from root (fine in typescript/looker). sdkConfig.ts has this line which fails with ERROR: 45:9  strict-type-predicates  Expression is always false.
 if (props.verify_ssl === undefined) props.verify_ssl  = true
I suspect this is because verify_ssl is a required property and as such should never be undefined. The code seems a little odd anyway but I would prefer to fix it in a separate PR.