### PR TITLE
Added tests that show how to override ApiSettings.readConfig() for Kotlin

### DIFF
--- a/bin/smoke
+++ b/bin/smoke
@@ -1,21 +1,52 @@
 #!/bin/bash
 
-echo "Smoking Typescript SDK ..."
-JEST_JUNIT_OUTPUT_DIR=results JEST_JUNIT_OUTPUT_NAME=smoketypescript.xml yarn jest --reporters=default --reporters=jest-junit
+for arg in "$@"
+do
+    if [ "$arg" == "--help" ] || [ "$arg" == "-h" ]
+    then
+        echo "Test options: all, typescript, kotlin, swift, python"
+        echo "Multiple languages can be specified at the same time"
+        echo "'all' is the default"
+    fi
+done
 
-echo "Smoking Python SDK ..."
-cd python
-pipenv run pytest --junitxml=../results/smokepython.xml tests/
-cd ..
+if [ $# == 0 ] || [ "$1" == "all" ]
+then
+  tests="typescript kotlin swift python"
+else
+  tests="$*"
+fi
 
-echo "Smoking Kotlin SDK ..."
-cd kotlin
-gradle test
-cd ..
+echo "Smoking SDKs: ${tests} ..."
 
-echo "Smoking Swift SDK ..."
-cd swift/looker
-xcodebuild test -project looker.xcodeproj -scheme looker-Package -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 11,OS=13.3' | xcpretty --test --color
-cd ../..
+if [[ $tests == *typescript* ]]
+then
+  echo "Smoking Typescript SDK ..."
+  JEST_JUNIT_OUTPUT_DIR=results JEST_JUNIT_OUTPUT_NAME=smoketypescript.xml yarn jest --reporters=default --reporters=jest-junit
+fi
+
+if [[ $tests == *python* ]]
+then
+  echo "Smoking Python SDK ..."
+  cd python
+  pipenv run pytest --junitxml=../results/smokepython.xml tests/
+  cd ..
+fi
+
+if [[ $tests == *kotlin* ]]
+then
+  echo "Smoking Kotlin SDK ..."
+  cd kotlin
+  gradle test
+  cd ..
+fi
+
+if [[ $tests == *swift* ]]
+then
+  echo "Smoking Swift SDK ..."
+  cd swift/looker
+  xcodebuild test -project looker.xcodeproj -scheme looker-Package -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 11,OS=13.3' | xcpretty --test --color
+  cd ../..
+fi
 
 echo "Smoke tests completed"

--- a/kotlin/src/test/TestApiSettings.kt
+++ b/kotlin/src/test/TestApiSettings.kt
@@ -1,6 +1,6 @@
 import com.looker.rtl.ApiSettings
-import com.looker.rtl.DEFAULT_API_VERSION
 import com.looker.rtl.DEFAULT_TIMEOUT
+import com.looker.rtl.UserSession
 import org.junit.Test
 import kotlin.test.assertEquals
 
@@ -14,20 +14,58 @@ val quotedMinimum = """
 base_url='https://my.looker.com:19999'
 """.trimIndent()
 
+val mockId = "IdOverride"
+val mockSecret = "SecretOverride"
+
+class MockSettings(contents: String) : ApiSettings(contents) {
+    override fun readConfig(): Map<String, String> {
+        return mapOf(
+                "base_url" to baseUrl,
+                "verify_ssl" to verifySSL.toString(),
+                "timeout" to timeout.toString(),
+                "headers" to headers.toString(),
+                "client_id" to mockId,
+                "client_secret" to mockSecret
+        )
+    }
+}
+
 class TestApiSettings {
     @Test fun testApiSettingsDefaults() {
         val settings = ApiSettings(bareMinimum)
-        assertEquals(settings.apiVersion, DEFAULT_API_VERSION, "API version defaults to 3.1")
+        val config = settings.readConfig()
         assertEquals(settings.baseUrl, "https://my.looker.com:19999", "Base URL is read")
         assertEquals(settings.verifySSL, true)
         assertEquals(settings.timeout, DEFAULT_TIMEOUT)
+        assertEquals(config["client_id"], null)
+        assertEquals(config["client_secret"], null)
     }
 
     @Test fun testApiSettingsQuotes() {
         val settings = ApiSettings(quotedMinimum)
-        assertEquals(settings.apiVersion, DEFAULT_API_VERSION, "API version defaults to 3.1")
         assertEquals(settings.baseUrl, "https://my.looker.com:19999", "Base URL has no quotes")
         assertEquals(settings.verifySSL, true)
         assertEquals(settings.timeout, DEFAULT_TIMEOUT)
+    }
+
+    @Test fun testApiSettingsOverrides() {
+        val settings = MockSettings(bareMinimum)
+        val config = settings.readConfig()
+        assertEquals(settings.baseUrl, "https://my.looker.com:19999", "Base URL is read")
+        assertEquals(settings.verifySSL, true)
+        assertEquals(settings.timeout, DEFAULT_TIMEOUT)
+        assertEquals(config["client_id"], mockId)
+        assertEquals(config["client_secret"], mockSecret)
+    }
+
+    @Test fun testSessionOverride() {
+        val settings = MockSettings(bareMinimum)
+        val session = UserSession(settings)
+        val config = session.apiSettings.readConfig()
+        assertEquals(settings.baseUrl, "https://my.looker.com:19999", "Base URL is read")
+        assertEquals(settings.verifySSL, true)
+        assertEquals(settings.timeout, DEFAULT_TIMEOUT)
+        assertEquals(config["client_id"], mockId)
+        assertEquals(config["client_secret"], mockSecret)
     }
 }

--- a/kotlin/src/test/Utils.kt
+++ b/kotlin/src/test/Utils.kt
@@ -28,7 +28,7 @@ val rootPath = File("./").absoluteFile.parentFile.parentFile.absolutePath
 val testPath  = "${rootPath}/test"
 val dataFile = testFile("data.yml")
 val envIni = System.getenv("LOOKERSDK_INI")
-val localIni = if (envIni === "") rootFile("looker.ini") else envIni
+val localIni = if (envIni === null) rootFile("looker.ini") else envIni
 
 fun rootFile(fileName: String): String {
     return "${rootPath}/${fileName}"


### PR DESCRIPTION

- also added language test switch options to `bin/smoke` along with a `-h` `--help` option