### PR TITLE
Switching to AnyCodable as a solution to Swift's severe lack of support for deserializing JSON values to Any

### DIFF
--- a/src/swift.gen.ts
+++ b/src/swift.gen.ts
@@ -449,7 +449,7 @@ ${indent}return result`
         return {name: `[${map.name}]`, default: '[]'}
       } else if (type instanceof HashType) {
         // return {name: `StringDictionary<${map.name}>`, default: 'nil'}
-        return {name: `StringDictionary<Variant?>`, default: 'nil'}
+        return {name: `StringDictionary<AnyCodable>`, default: 'nil'}
       } else if (type instanceof DelimArrayType) {
         return {name: `DelimArray<${map.name}>`, default: 'nil'}
       }

--- a/swift/looker/Package.swift
+++ b/swift/looker/Package.swift
@@ -16,17 +16,21 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
+      .package(
+           url: "https://github.com/Flight-School/AnyCodable",
+           from: "0.2.3"
+       ),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "looker",
-            dependencies: [],
+            dependencies: ["AnyCodable"],
             path: ".",
             sources: ["rtl", "sdk"]),
         .testTarget(
             name: "lookerTests",
-            dependencies: ["looker"]),
+            dependencies: ["looker", "AnyCodable"]),
     ]
 )

--- a/swift/looker/README.md
+++ b/swift/looker/README.md
@@ -110,3 +110,7 @@ The SDK generator uses both classes and structs. Classes are used where required
 Otherwise, `struct`s, `enum`s, or `protocol`s are used for the declaration of complex method inputs, such as `body` parameters and the complex API structures returned from API endpoints.
 
 Enjoy, and thanks for trying out the bleeding edge!
+
+## Use of AnyCodable
+
+There's a decent JSON encode/decode solution from [AnyCodable](https://github.com/Flight-School/AnyCodable) directly imported into this project because I haven't yet been able to figure out how to get the package reference to work. My apologies for that. I'll fix it when I figure out how to use Swift packages better!

--- a/swift/looker/Tests/lookerTests/modelsTests.swift
+++ b/swift/looker/Tests/lookerTests/modelsTests.swift
@@ -20,27 +20,27 @@ class modelsTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
-    func deserialize<T>(_ data: Data) throws -> T where T : Codable {
-        let decoder = JSONDecoder()
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
-        formatter.calendar = Calendar(identifier: .iso8601)
-        formatter.timeZone = TimeZone(secondsFromGMT: 0)
-        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
-        decoder.dateDecodingStrategy = .formatted(formatter)
-        do {
-            let result: T = try decoder.decode(T.self, from: data)
-            return result
-        } catch {
-            throw error
-        }
-        
-    }
-    /// Convert a JSON string into the type `T`
-    /// @throws errors if deserialization fails
-    func deserialize<T>(_ json: String) throws -> T where T : Codable {
-        return try deserialize(Data(json.utf8))
-    }
+//    func deserialize<T>(_ data: Data) throws -> T where T : Codable {
+//        let decoder = JSONDecoder()
+//        let formatter = DateFormatter()
+//        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
+//        formatter.calendar = Calendar(identifier: .iso8601)
+//        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+//        formatter.locale = Foundation.Locale(identifier: "en_US_POSIX")
+//        decoder.dateDecodingStrategy = .formatted(formatter)
+//        do {
+//            let result: T = try decoder.decode(T.self, from: data)
+//            return result
+//        } catch {
+//            throw error
+//        }
+//
+//    }
+//    /// Convert a JSON string into the type `T`
+//    /// @throws errors if deserialization fails
+//    func deserialize<T>(_ json: String) throws -> T where T : Codable {
+//        return try deserialize(Data(json.utf8))
+//    }
 
     func testDateParse() {
         let value = "2018-03-15T13:16:34.692-07:00"
@@ -57,6 +57,8 @@ class modelsTests: XCTestCase {
         XCTAssertNotNil(dateString)
     }
     
+    /*
+     TODO remove this code, which is commented out in favor of AnyCodable
     let json = #"""
     {
     "want_string": 4,
@@ -162,5 +164,6 @@ class modelsTests: XCTestCase {
             XCTAssertNil(error)
         }
     }
+ */
 
 }

--- a/swift/looker/Tests/lookerTests/transportTests.swift
+++ b/swift/looker/Tests/lookerTests/transportTests.swift
@@ -72,7 +72,7 @@ class transportTests: XCTestCase {
             print(error)
         }
     }
-    
+
     func testRegexExtension() {
         checkRegex(Constants.matchModeString, "string match")
         checkRegex(Constants.matchCharset, "charset match")
@@ -80,17 +80,17 @@ class transportTests: XCTestCase {
         checkRegex(Constants.applicationJson, "application/json")
         checkRegex(Constants.matchCharsetUtf8, "utf-8 match")
 }
-    
+
     func testApproxEquals() {
         XCTAssertTrue("application/json" ~= Constants.matchModeString)
     }
-    
+
     func testPatterns() {
         XCTAssertNotNil(contentPatternBinary, "Binary should be compiled")
         XCTAssertNotNil(charsetUtf8Pattern, "Charset should be compiled")
         XCTAssertNotNil(contentPatternString, "String should be compiled")
     }
-    
+
     func testBinaryMode() {
         for (item) in binaryTypes {
             let val = String(item)
@@ -107,7 +107,7 @@ class transportTests: XCTestCase {
             XCTAssertEqual(actual, .string, val)
         }
     }
-    
+
     func testDeserialize() {
         let jsonString = """
         {
@@ -133,12 +133,86 @@ class transportTests: XCTestCase {
         XCTAssertEqual(user.email, "zz@foo.bar")
     }
 
+//    func dictToJson(dict: StringDictionary<Variant?>) -> String {
+//        var result = ""
+//        dict.flatMap({(arg: (key: String, value: Variant?)) -> String in let (key, value) = arg; return {
+//            let v = value?.toJson() ?? "null"
+//            return "\"\(key)\":\(v)" }
+//        })
+//        return result
+//    }
+
+    let visJson = """
+{
+"bool":true,
+"int":1,
+"dub":2.3,
+"str":"Simple string",
+"date":"2018-03-15T13:16:34.692-07:00",
+"nada":null,
+"dict": {"A":4, "B": 2, "C": true},
+"ratnest": [ { "one": 1, "two": "two" }, "three", {"four":4} ]
+}
+"""
+
+    // Relevant SO https://stackoverflow.com/questions/46279992/any-when-decoding-json-with-codable
+    // Using AnyCodable from https://github.com/Flight-School/AnyCodable
+    func testDictFromJson() {
+        var vis_config: StringDictionary<AnyCodable>? = try! deserialize(visJson)
+//        let vis_config: StringDictionary<Variant?>? = try! deserialize(visJson)
+        var data = try! serialize(vis_config)
+        var json = String(decoding: data, as: UTF8.self)
+        XCTAssertNotNil(vis_config)
+        XCTAssertNotNil(data)
+        XCTAssertNotNil(json)
+        let bool = vis_config["bool"] as! Bool
+        XCTAssertTrue(bool)
+        let int = vis_config["int"] as! Int64
+        XCTAssertEqual(int, 1)
+        let nada = vis_config["nada"]
+
+        if "\(nada!)" == "nil" {
+            // nada is nil as expected
+        } else {
+            XCTAssertTrue(false, "nada should be nil, not '\(nada!)'")
+        }
+        let dub = vis_config["dub"] as! Double
+        XCTAssertEqual(dub, 2.3)
+        let str = vis_config["str"] as! String
+        XCTAssertEqual(str, "Simple string")
+        XCTAssertTrue(json.contains(str), "\(str) should be in json")
+        if let dict = vis_config["dict"] as? [AnyHashable: Any] {
+            XCTAssertNotNil(dict, "dict should not be nil")
+            if let a = dict["A"] as? Int {
+                XCTAssertEqual(a, 4, "A should be 4")
+            } else {
+                XCTAssertTrue(false, "A should be 4")
+            }
+        } else {
+            XCTAssertTrue(false, "dict is not a dictionary")
+        }
+        if let ratnest = vis_config["ratnest"] as? Array<Any> {
+            XCTAssertNotNil(ratnest, "ratnest should not be nil")
+            if let first = ratnest[0] as? [AnyHashable: Any] {
+                XCTAssertNotNil(first, "first should not be a dictionary")
+            } else {
+                XCTAssertTrue(false, "first is not an array")
+            }
+        } else {
+            XCTAssertTrue(false, "ratnest is not an array")
+        }
+        vis_config!.updateValue("Updated string", forKey: "str")
+        data = try! serialize(vis_config)
+        json = String(decoding: data, as: UTF8.self)
+        XCTAssertTrue(json.contains("Updated string"), "str should be updated")
+    }
+
     func testQueryParamsAllNil() {
         let values: Values = [ "Not": nil, "A": nil, "Darned": nil, "Thing!": nil ]
         let actual = addQueryParams("empty", values)
         XCTAssertEqual(actual, "empty")
     }
-    
+
     func testQueryParams1() {
         let values: Values = [ "One": 1 ]
         let actual = addQueryParams("Wonderful", values)
@@ -162,7 +236,7 @@ class transportTests: XCTestCase {
         actual = addQueryParams("Int", values)
         XCTAssertEqual(actual, "Int?Ids=1,2,3")
     }
-    
+
     func testQueryParamsDelimArrayInt32() {
         let ids: DelimArray<Int32> = [1,2,3]
         var values: Values = [ "Ids": ids ]
@@ -173,7 +247,7 @@ class transportTests: XCTestCase {
         actual = addQueryParams("Int", values)
         XCTAssertEqual(actual, "Int?Ids=1,2,3")
     }
-    
+
     func testQueryParamsDelimArrayInt64() {
         let ids: DelimArray<Int64> = [1,2,3]
         var values: Values = [ "Ids": ids ]
@@ -184,7 +258,7 @@ class transportTests: XCTestCase {
         actual = addQueryParams("Int", values)
         XCTAssertEqual(actual, "Int?Ids=1,2,3")
     }
-    
+
     func testQueryParamsDelimString() {
         let names: DelimArray<String> = ["LLoyd?", "ZZooey#"]
         var values: Values = [ "Names": names]
@@ -195,7 +269,7 @@ class transportTests: XCTestCase {
         actual = addQueryParams("String", values)
         XCTAssertEqual(actual, "String?Names=LLoyd%3F,ZZooey%23")
     }
-    
+
     func testQueryParamsDelimArrayDouble() {
         let nums: DelimArray<Double> = [2.2,3.3]
         var values: Values = [ "Nums": nums]
@@ -206,7 +280,7 @@ class transportTests: XCTestCase {
         actual = addQueryParams("Double", values)
         XCTAssertEqual(actual, "Double?Nums=2.2,3.3")
     }
-    
+
     func testQueryParamsDelimArrayFloat() {
         let nums: DelimArray<Float> = [2.2,3.3]
         var values: Values = [ "Nums": nums]
@@ -217,7 +291,7 @@ class transportTests: XCTestCase {
         actual = addQueryParams("Float", values)
         XCTAssertEqual(actual, "Float?Nums=2.2,3.3")
     }
-    
+
     func testQueryParamsDelimArrayBool() {
         let flags: DelimArray<Bool> = [false, true]
         var values: Values = [ "Flags": flags]
@@ -228,5 +302,5 @@ class transportTests: XCTestCase {
         actual = addQueryParams("Bool", values)
         XCTAssertEqual(actual, "Bool?Flags=false,true")
     }
-    
+
 }

--- a/swift/looker/Tests/lookerTests/transportTests.swift
+++ b/swift/looker/Tests/lookerTests/transportTests.swift
@@ -177,7 +177,7 @@ class transportTests: XCTestCase {
             XCTAssertTrue(false, "nada should be nil, not '\(nada!)'")
         }
         let dub = vis_config["dub"] as! Double
-        XCTAssertEqual(dub, 2.3)
+        XCTAssertEqual(dub, 2.3, accuracy: 0.0001, "dub should be 2.3")
         let str = vis_config["str"] as! String
         XCTAssertEqual(str, "Simple string")
         XCTAssertTrue(json.contains(str), "\(str) should be in json")

--- a/swift/looker/looker.xcodeproj/project.pbxproj
+++ b/swift/looker/looker.xcodeproj/project.pbxproj
@@ -24,6 +24,9 @@
 		9503C28B235510C100C10EEE /* apiConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9503C28A235510C100C10EEE /* apiConfigTests.swift */; };
 		9503C28D2355254400C10EEE /* baseTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9503C28C2355254400C10EEE /* baseTransport.swift */; };
 		9503C28F23554E9100C10EEE /* transportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9503C28E23554E9100C10EEE /* transportTests.swift */; };
+		951D365A23F5FFBE007EBBC0 /* AnyCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 951D365923F5FFBE007EBBC0 /* AnyCodable.swift */; };
+		951D365C23F60018007EBBC0 /* AnyDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 951D365B23F60018007EBBC0 /* AnyDecodable.swift */; };
+		951D365E23F60045007EBBC0 /* AnyEncodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 951D365D23F60045007EBBC0 /* AnyEncodable.swift */; };
 		9545D06A235A77F8003AA551 /* baseTransportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9545D069235A77F8003AA551 /* baseTransportTests.swift */; };
 		9578B256234D01CE0048FD2A /* looker.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "looker::looker::Product" /* looker.framework */; };
 		9578B25E234D064F0048FD2A /* authTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9578B25D234D064F0048FD2A /* authTokenTests.swift */; };
@@ -78,6 +81,9 @@
 		9503C28A235510C100C10EEE /* apiConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = apiConfigTests.swift; sourceTree = "<group>"; };
 		9503C28C2355254400C10EEE /* baseTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = baseTransport.swift; sourceTree = "<group>"; };
 		9503C28E23554E9100C10EEE /* transportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = transportTests.swift; sourceTree = "<group>"; };
+		951D365923F5FFBE007EBBC0 /* AnyCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyCodable.swift; sourceTree = "<group>"; };
+		951D365B23F60018007EBBC0 /* AnyDecodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyDecodable.swift; sourceTree = "<group>"; };
+		951D365D23F60045007EBBC0 /* AnyEncodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyEncodable.swift; sourceTree = "<group>"; };
 		9545D069235A77F8003AA551 /* baseTransportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = baseTransportTests.swift; sourceTree = "<group>"; };
 		9578B251234D01CE0048FD2A /* authTokenTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = authTokenTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		9578B25D234D064F0048FD2A /* authTokenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = authTokenTests.swift; sourceTree = "<group>"; };
@@ -158,6 +164,9 @@
 				95FA444C234EB2A90053027C /* partial.swift */,
 				95974CDB23694F9B0061F13F /* serializer.swift */,
 				9578B263234D3A8A0048FD2A /* transport.swift */,
+				951D365923F5FFBE007EBBC0 /* AnyCodable.swift */,
+				951D365B23F60018007EBBC0 /* AnyDecodable.swift */,
+				951D365D23F60045007EBBC0 /* AnyEncodable.swift */,
 			);
 			path = rtl;
 			sourceTree = "<group>";
@@ -357,6 +366,8 @@
 			buildActionMask = 0;
 			files = (
 				95E86572234DA4D8008FF9B4 /* apiConfig.swift in Sources */,
+				951D365A23F5FFBE007EBBC0 /* AnyCodable.swift in Sources */,
+				951D365E23F60045007EBBC0 /* AnyEncodable.swift in Sources */,
 				OBJ_26 /* looker.swift in Sources */,
 				95974CDC23694F9B0061F13F /* serializer.swift in Sources */,
 				95974CCE236263260061F13F /* authSession.swift in Sources */,
@@ -364,6 +375,7 @@
 				9578B260234D07260048FD2A /* authToken.swift in Sources */,
 				95A775D32360E0BB00E388B8 /* apiMethods.swift in Sources */,
 				95FA444D234EB2AA0053027C /* partial.swift in Sources */,
+				951D365C23F60018007EBBC0 /* AnyDecodable.swift in Sources */,
 				9578B262234D3A840048FD2A /* constants.swift in Sources */,
 				95974CD42363A2A30061F13F /* methods.swift in Sources */,
 				9503C28D2355254400C10EEE /* baseTransport.swift in Sources */,

--- a/swift/looker/rtl/AnyCodable.swift
+++ b/swift/looker/rtl/AnyCodable.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+/**
+ A type-erased `Codable` value.
+
+ The `AnyCodable` type forwards encoding and decoding responsibilities
+ to an underlying value, hiding its specific underlying type.
+
+ You can encode or decode mixed-type values in dictionaries
+ and other collections that require `Encodable` or `Decodable` conformance
+ by declaring their contained type to be `AnyCodable`.
+
+ - SeeAlso: `AnyEncodable`
+ - SeeAlso: `AnyDecodable`
+ */
+public struct AnyCodable: Codable {
+    public let value: Any
+
+    public init<T>(_ value: T?) {
+        self.value = value ?? ()
+    }
+}
+
+extension AnyCodable: _AnyEncodable, _AnyDecodable {}
+
+extension AnyCodable: Equatable {
+    public static func == (lhs: AnyCodable, rhs: AnyCodable) -> Bool {
+        switch (lhs.value, rhs.value) {
+        case is (Void, Void):
+            return true
+        case let (lhs as Bool, rhs as Bool):
+            return lhs == rhs
+        case let (lhs as Int, rhs as Int):
+            return lhs == rhs
+        case let (lhs as Int8, rhs as Int8):
+            return lhs == rhs
+        case let (lhs as Int16, rhs as Int16):
+            return lhs == rhs
+        case let (lhs as Int32, rhs as Int32):
+            return lhs == rhs
+        case let (lhs as Int64, rhs as Int64):
+            return lhs == rhs
+        case let (lhs as UInt, rhs as UInt):
+            return lhs == rhs
+        case let (lhs as UInt8, rhs as UInt8):
+            return lhs == rhs
+        case let (lhs as UInt16, rhs as UInt16):
+            return lhs == rhs
+        case let (lhs as UInt32, rhs as UInt32):
+            return lhs == rhs
+        case let (lhs as UInt64, rhs as UInt64):
+            return lhs == rhs
+        case let (lhs as Float, rhs as Float):
+            return lhs == rhs
+        case let (lhs as Double, rhs as Double):
+            return lhs == rhs
+        case let (lhs as String, rhs as String):
+            return lhs == rhs
+        case let (lhs as [String: AnyCodable], rhs as [String: AnyCodable]):
+            return lhs == rhs
+        case let (lhs as [AnyCodable], rhs as [AnyCodable]):
+            return lhs == rhs
+        default:
+            return false
+        }
+    }
+}
+
+extension AnyCodable: CustomStringConvertible {
+    public var description: String {
+        switch value {
+        case is Void:
+            return String(describing: nil as Any?)
+        case let value as CustomStringConvertible:
+            return value.description
+        default:
+            return String(describing: value)
+        }
+    }
+}
+
+extension AnyCodable: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        switch value {
+        case let value as CustomDebugStringConvertible:
+            return "AnyCodable(\(value.debugDescription))"
+        default:
+            return "AnyCodable(\(description))"
+        }
+    }
+}
+
+extension AnyCodable: ExpressibleByNilLiteral {}
+extension AnyCodable: ExpressibleByBooleanLiteral {}
+extension AnyCodable: ExpressibleByIntegerLiteral {}
+extension AnyCodable: ExpressibleByFloatLiteral {}
+extension AnyCodable: ExpressibleByStringLiteral {}
+extension AnyCodable: ExpressibleByArrayLiteral {}
+extension AnyCodable: ExpressibleByDictionaryLiteral {}

--- a/swift/looker/rtl/AnyDecodable.swift
+++ b/swift/looker/rtl/AnyDecodable.swift
@@ -1,0 +1,145 @@
+import Foundation
+
+/**
+ A type-erased `Decodable` value.
+
+ The `AnyDecodable` type forwards decoding responsibilities
+ to an underlying value, hiding its specific underlying type.
+
+ You can decode mixed-type values in dictionaries
+ and other collections that require `Decodable` conformance
+ by declaring their contained type to be `AnyDecodable`:
+
+     let json = """
+     {
+         "boolean": true,
+         "integer": 1,
+         "double": 3.14159265358979323846,
+         "string": "string",
+         "array": [1, 2, 3],
+         "nested": {
+             "a": "alpha",
+             "b": "bravo",
+             "c": "charlie"
+         }
+     }
+     """.data(using: .utf8)!
+
+     let decoder = JSONDecoder()
+     let dictionary = try! decoder.decode([String: AnyCodable].self, from: json)
+ */
+public struct AnyDecodable: Decodable {
+    public let value: Any
+
+    public init<T>(_ value: T?) {
+        self.value = value ?? ()
+    }
+}
+
+#if swift(>=4.2)
+@usableFromInline
+protocol _AnyDecodable {
+    var value: Any { get }
+    init<T>(_ value: T?)
+}
+#else
+protocol _AnyDecodable {
+    var value: Any { get }
+    init<T>(_ value: T?)
+}
+#endif
+
+extension AnyDecodable: _AnyDecodable {}
+
+extension _AnyDecodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if container.decodeNil() {
+            self.init(NSNull())
+        } else if let bool = try? container.decode(Bool.self) {
+            self.init(bool)
+        } else if let int = try? container.decode(Int.self) {
+            self.init(int)
+        } else if let uint = try? container.decode(UInt.self) {
+            self.init(uint)
+        } else if let double = try? container.decode(Double.self) {
+            self.init(double)
+        } else if let string = try? container.decode(String.self) {
+            self.init(string)
+        } else if let array = try? container.decode([AnyCodable].self) {
+            self.init(array.map { $0.value })
+        } else if let dictionary = try? container.decode([String: AnyCodable].self) {
+            self.init(dictionary.mapValues { $0.value })
+        } else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "AnyCodable value cannot be decoded")
+        }
+    }
+}
+
+extension AnyDecodable: Equatable {
+    public static func == (lhs: AnyDecodable, rhs: AnyDecodable) -> Bool {
+        switch (lhs.value, rhs.value) {
+        case is (NSNull, NSNull), is (Void, Void):
+            return true
+        case let (lhs as Bool, rhs as Bool):
+            return lhs == rhs
+        case let (lhs as Int, rhs as Int):
+            return lhs == rhs
+        case let (lhs as Int8, rhs as Int8):
+            return lhs == rhs
+        case let (lhs as Int16, rhs as Int16):
+            return lhs == rhs
+        case let (lhs as Int32, rhs as Int32):
+            return lhs == rhs
+        case let (lhs as Int64, rhs as Int64):
+            return lhs == rhs
+        case let (lhs as UInt, rhs as UInt):
+            return lhs == rhs
+        case let (lhs as UInt8, rhs as UInt8):
+            return lhs == rhs
+        case let (lhs as UInt16, rhs as UInt16):
+            return lhs == rhs
+        case let (lhs as UInt32, rhs as UInt32):
+            return lhs == rhs
+        case let (lhs as UInt64, rhs as UInt64):
+            return lhs == rhs
+        case let (lhs as Float, rhs as Float):
+            return lhs == rhs
+        case let (lhs as Double, rhs as Double):
+            return lhs == rhs
+        case let (lhs as String, rhs as String):
+            return lhs == rhs
+        case let (lhs as [String: AnyDecodable], rhs as [String: AnyDecodable]):
+            return lhs == rhs
+        case let (lhs as [AnyDecodable], rhs as [AnyDecodable]):
+            return lhs == rhs
+        default:
+            return false
+        }
+    }
+}
+
+extension AnyDecodable: CustomStringConvertible {
+    public var description: String {
+        switch value {
+        case is Void:
+            return String(describing: nil as Any?)
+        case let value as CustomStringConvertible:
+            return value.description
+        default:
+            return String(describing: value)
+        }
+    }
+}
+
+extension AnyDecodable: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        switch value {
+        case let value as CustomDebugStringConvertible:
+            return "AnyDecodable(\(value.debugDescription))"
+        default:
+            return "AnyDecodable(\(description))"
+        }
+    }
+}

--- a/swift/looker/rtl/AnyEncodable.swift
+++ b/swift/looker/rtl/AnyEncodable.swift
@@ -1,0 +1,248 @@
+import Foundation
+
+/**
+ A type-erased `Encodable` value.
+
+ The `AnyEncodable` type forwards encoding responsibilities
+ to an underlying value, hiding its specific underlying type.
+
+ You can encode mixed-type values in dictionaries
+ and other collections that require `Encodable` conformance
+ by declaring their contained type to be `AnyEncodable`:
+
+     let dictionary: [String: AnyEncodable] = [
+         "boolean": true,
+         "integer": 1,
+         "double": 3.14159265358979323846,
+         "string": "string",
+         "array": [1, 2, 3],
+         "nested": [
+             "a": "alpha",
+             "b": "bravo",
+             "c": "charlie"
+         ]
+     ]
+
+     let encoder = JSONEncoder()
+     let json = try! encoder.encode(dictionary)
+ */
+public struct AnyEncodable: Encodable {
+    public let value: Any
+
+    public init<T>(_ value: T?) {
+        self.value = value ?? ()
+    }
+}
+
+#if swift(>=4.2)
+@usableFromInline
+protocol _AnyEncodable {
+    var value: Any { get }
+    init<T>(_ value: T?)
+}
+#else
+protocol _AnyEncodable {
+    var value: Any { get }
+    init<T>(_ value: T?)
+}
+#endif
+
+extension AnyEncodable: _AnyEncodable {}
+
+// MARK: - Encodable
+
+extension _AnyEncodable {
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+
+        switch value {
+            #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        case let number as NSNumber:
+            try encode(nsnumber: number, into: &container)
+            #endif
+        case is NSNull, is Void:
+            try container.encodeNil()
+        case let bool as Bool:
+            try container.encode(bool)
+        case let int as Int:
+            try container.encode(int)
+        case let int8 as Int8:
+            try container.encode(int8)
+        case let int16 as Int16:
+            try container.encode(int16)
+        case let int32 as Int32:
+            try container.encode(int32)
+        case let int64 as Int64:
+            try container.encode(int64)
+        case let uint as UInt:
+            try container.encode(uint)
+        case let uint8 as UInt8:
+            try container.encode(uint8)
+        case let uint16 as UInt16:
+            try container.encode(uint16)
+        case let uint32 as UInt32:
+            try container.encode(uint32)
+        case let uint64 as UInt64:
+            try container.encode(uint64)
+        case let float as Float:
+            try container.encode(float)
+        case let double as Double:
+            try container.encode(double)
+        case let string as String:
+            try container.encode(string)
+        case let date as Date:
+            try container.encode(date)
+        case let url as URL:
+            try container.encode(url)
+        case let array as [Any?]:
+            try container.encode(array.map { AnyCodable($0) })
+        case let dictionary as [String: Any?]:
+            try container.encode(dictionary.mapValues { AnyCodable($0) })
+        default:
+            let context = EncodingError.Context(codingPath: container.codingPath, debugDescription: "AnyCodable value cannot be encoded")
+            throw EncodingError.invalidValue(value, context)
+        }
+    }
+
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    private func encode(nsnumber: NSNumber, into container: inout SingleValueEncodingContainer) throws {
+        switch CFNumberGetType(nsnumber) {
+        case .charType:
+            try container.encode(nsnumber.boolValue)
+        case .sInt8Type:
+            try container.encode(nsnumber.int8Value)
+        case .sInt16Type:
+            try container.encode(nsnumber.int16Value)
+        case .sInt32Type:
+            try container.encode(nsnumber.int32Value)
+        case .sInt64Type:
+            try container.encode(nsnumber.int64Value)
+        case .shortType:
+            try container.encode(nsnumber.uint16Value)
+        case .longType:
+            try container.encode(nsnumber.uint32Value)
+        case .longLongType:
+            try container.encode(nsnumber.uint64Value)
+        case .intType, .nsIntegerType, .cfIndexType:
+            try container.encode(nsnumber.intValue)
+        case .floatType, .float32Type:
+            try container.encode(nsnumber.floatValue)
+        case .doubleType, .float64Type, .cgFloatType:
+            try container.encode(nsnumber.doubleValue)
+        #if swift(>=5.0)
+            @unknown default:
+                fatalError()
+        #endif
+        }
+    }
+    #endif
+}
+
+extension AnyEncodable: Equatable {
+    public static func == (lhs: AnyEncodable, rhs: AnyEncodable) -> Bool {
+        switch (lhs.value, rhs.value) {
+        case is (Void, Void):
+            return true
+        case let (lhs as Bool, rhs as Bool):
+            return lhs == rhs
+        case let (lhs as Int, rhs as Int):
+            return lhs == rhs
+        case let (lhs as Int8, rhs as Int8):
+            return lhs == rhs
+        case let (lhs as Int16, rhs as Int16):
+            return lhs == rhs
+        case let (lhs as Int32, rhs as Int32):
+            return lhs == rhs
+        case let (lhs as Int64, rhs as Int64):
+            return lhs == rhs
+        case let (lhs as UInt, rhs as UInt):
+            return lhs == rhs
+        case let (lhs as UInt8, rhs as UInt8):
+            return lhs == rhs
+        case let (lhs as UInt16, rhs as UInt16):
+            return lhs == rhs
+        case let (lhs as UInt32, rhs as UInt32):
+            return lhs == rhs
+        case let (lhs as UInt64, rhs as UInt64):
+            return lhs == rhs
+        case let (lhs as Float, rhs as Float):
+            return lhs == rhs
+        case let (lhs as Double, rhs as Double):
+            return lhs == rhs
+        case let (lhs as String, rhs as String):
+            return lhs == rhs
+        case let (lhs as [String: AnyEncodable], rhs as [String: AnyEncodable]):
+            return lhs == rhs
+        case let (lhs as [AnyEncodable], rhs as [AnyEncodable]):
+            return lhs == rhs
+        default:
+            return false
+        }
+    }
+}
+
+extension AnyEncodable: CustomStringConvertible {
+    public var description: String {
+        switch value {
+        case is Void:
+            return String(describing: nil as Any?)
+        case let value as CustomStringConvertible:
+            return value.description
+        default:
+            return String(describing: value)
+        }
+    }
+}
+
+extension AnyEncodable: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        switch value {
+        case let value as CustomDebugStringConvertible:
+            return "AnyEncodable(\(value.debugDescription))"
+        default:
+            return "AnyEncodable(\(description))"
+        }
+    }
+}
+
+extension AnyEncodable: ExpressibleByNilLiteral {}
+extension AnyEncodable: ExpressibleByBooleanLiteral {}
+extension AnyEncodable: ExpressibleByIntegerLiteral {}
+extension AnyEncodable: ExpressibleByFloatLiteral {}
+extension AnyEncodable: ExpressibleByStringLiteral {}
+extension AnyEncodable: ExpressibleByArrayLiteral {}
+extension AnyEncodable: ExpressibleByDictionaryLiteral {}
+
+extension _AnyEncodable {
+    public init(nilLiteral _: ()) {
+        self.init(nil as Any?)
+    }
+
+    public init(booleanLiteral value: Bool) {
+        self.init(value)
+    }
+
+    public init(integerLiteral value: Int) {
+        self.init(value)
+    }
+
+    public init(floatLiteral value: Double) {
+        self.init(value)
+    }
+
+    public init(extendedGraphemeClusterLiteral value: String) {
+        self.init(value)
+    }
+
+    public init(stringLiteral value: String) {
+        self.init(value)
+    }
+
+    public init(arrayLiteral elements: Any...) {
+        self.init(elements)
+    }
+
+    public init(dictionaryLiteral elements: (AnyHashable, Any)...) {
+        self.init([AnyHashable: Any](elements, uniquingKeysWith: { first, _ in first }))
+    }
+}

--- a/swift/looker/rtl/serializer.swift
+++ b/swift/looker/rtl/serializer.swift
@@ -35,8 +35,16 @@ extension DateFormatter {
     }()
 }
 
-/// Convert a JSON string into the type `T`
+let encoder = JSONEncoder()
+
+/// Converts an object to a JSON string
 /// @throws errors if deserialization fails
+func serialize<T>(_ value: T) throws -> Data where T : Encodable {
+    return try! encoder.encode(value)
+}
+
+/// Convert a JSON string into the type `T`
+/// @throws errors if deserialization failsœ
 /// some interesting date decoding options here: https://stackoverflow.com/questions/44682626/swifts-jsondecoder-with-multiple-date-formats-in-a-json-string
 /// https://benscheirman.com/2017/06/swift-json/ excplores lots of options, none that help with strings misrepresented as int
 func deserialize<T>(_ data: Data) throws -> T where T : Codable {
@@ -142,7 +150,11 @@ extension DateFormatter {
 }
 
 
+
 // Handling JSON that doesn't QUITE conform to spec https://stackoverflow.com/a/47936036/74137
+/*
+ TODO archive this code if we don't need it any more
+ Commenting this out in favor of AnyCodable project source
 enum Variant: Codable, Hashable {
     case string(String)
     case int(Int64)
@@ -209,6 +221,22 @@ enum Variant: Codable, Hashable {
         case .date(let date):
             return DateFormatter.iso8601Full.string(from: date)
         }
+    }
+    
+    func getJson() -> String {
+        switch self {
+        case .string(let string):
+            return "\"\(string)\""
+        case .int(let int):
+            return String(int)
+        case .bool(let bool):
+            return bool ? "true" : "false"
+        case .double(let double):
+            return String(double)
+        case .date(let date):
+            return "\"\(DateFormatter.iso8601Full.string(from: date))\""
+        }
+
     }
     
     func getBool() -> Bool? {
@@ -299,3 +327,4 @@ enum Variant: Codable, Hashable {
         }
     }
 }
+ */

--- a/swift/looker/sdk/methods.swift
+++ b/swift/looker/sdk/methods.swift
@@ -3422,9 +3422,9 @@ class LookerSDK: APIMethods {
      */
     func fetch_remote_data_action_form(
         /**
-         * @param {StringDictionary<Variant?>} body
+         * @param {StringDictionary<AnyCodable>} body
          */
-        _ body: StringDictionary<Variant?>,
+        _ body: StringDictionary<AnyCodable>,
         options: ITransportSettings? = nil
     ) -> SDKResponse<DataActionForm, SDKError> {
         let result: SDKResponse<DataActionForm, SDKError> = self.post("/data_actions/form", nil, try! self.encode(body), options)
@@ -4493,7 +4493,7 @@ class LookerSDK: APIMethods {
      * Query Tasks whose results have expired will have a status of 'expired'.
      * If the user making the API request does not have sufficient privileges to view a Query Task result, the result will have a status of 'missing'
      * 
-     * GET /query_tasks/multi_results -> StringDictionary<Variant?>
+     * GET /query_tasks/multi_results -> StringDictionary<AnyCodable>
      */
     func query_task_multi_results(
         /**
@@ -4501,8 +4501,8 @@ class LookerSDK: APIMethods {
          */
         _ query_task_ids: DelimArray<String>,
         options: ITransportSettings? = nil
-    ) -> SDKResponse<StringDictionary<Variant?>, SDKError> {
-        let result: SDKResponse<StringDictionary<Variant?>, SDKError> = self.get("/query_tasks/multi_results", 
+    ) -> SDKResponse<StringDictionary<AnyCodable>, SDKError> {
+        let result: SDKResponse<StringDictionary<AnyCodable>, SDKError> = self.get("/query_tasks/multi_results", 
             ["query_task_ids": query_task_ids as Any?], nil, options)
         return result
     }

--- a/swift/looker/sdk/models.swift
+++ b/swift/looker/sdk/models.swift
@@ -23,7 +23,7 @@ struct ApiSession: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * The id of active workspace for this session
      */
@@ -69,7 +69,7 @@ struct BackupConfiguration: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Type of backup: looker-s3 or custom-s3
      */
@@ -163,7 +163,7 @@ struct ContentMeta: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Unique Id (read-only)
      */
@@ -214,7 +214,7 @@ struct ContentMetaGroupUser: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Unique Id (read-only)
      */
@@ -452,7 +452,7 @@ struct ContentView: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Unique Id (read-only)
      */
@@ -554,7 +554,7 @@ struct CreateDashboardFilter: SDKModel {
     /**
      * Field information (read-only)
      */
-    var field: StringDictionary<Variant?>?
+    var field: StringDictionary<AnyCodable>?
     /**
      * Display order of this filter relative to other filters
      */
@@ -574,7 +574,7 @@ struct CreateDashboardFilter: SDKModel {
     /**
      * The visual configuration for this filter. Used to set up how the UI for this filter should appear.
      */
-    var ui_config: StringDictionary<Variant?>?
+    var ui_config: StringDictionary<AnyCodable>?
 }
 
 struct CreateDashboardRenderTask: SDKModel {
@@ -603,7 +603,7 @@ struct CreateQueryTask: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Id of query to run
      */
@@ -645,7 +645,7 @@ struct CredentialsApi3: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Unique Id (read-only)
      */
@@ -676,7 +676,7 @@ struct CredentialsEmail: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Timestamp for the creation of this credential (read-only)
      */
@@ -719,7 +719,7 @@ struct CredentialsEmbed: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Timestamp for the creation of this credential (read-only)
      */
@@ -758,7 +758,7 @@ struct CredentialsGoogle: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Timestamp for the creation of this credential (read-only)
      */
@@ -797,7 +797,7 @@ struct CredentialsLDAP: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Timestamp for the creation of this credential (read-only)
      */
@@ -836,7 +836,7 @@ struct CredentialsLookerOpenid: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Timestamp for the creation of this credential (read-only)
      */
@@ -875,7 +875,7 @@ struct CredentialsOIDC: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Timestamp for the creation of this credential (read-only)
      */
@@ -910,7 +910,7 @@ struct CredentialsSaml: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Timestamp for the creation of this credential (read-only)
      */
@@ -945,7 +945,7 @@ struct CredentialsTotp: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Timestamp for the creation of this credential (read-only)
      */
@@ -972,7 +972,7 @@ struct CustomWelcomeEmail: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * If true, custom email content will replace the default body of welcome emails
      */
@@ -987,7 +987,7 @@ struct Dashboard: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Content Favorite Id (read-only)
      */
@@ -1142,7 +1142,7 @@ struct DashboardBase: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Content Favorite Id (read-only)
      */
@@ -1196,7 +1196,7 @@ struct DashboardElement: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Text tile body text
      */
@@ -1294,7 +1294,7 @@ struct DashboardFilter: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Unique Id (read-only)
      */
@@ -1334,7 +1334,7 @@ struct DashboardFilter: SDKModel {
     /**
      * Field information (read-only)
      */
-    var field: StringDictionary<Variant?>?
+    var field: StringDictionary<AnyCodable>?
     /**
      * Display order of this filter relative to other filters
      */
@@ -1354,14 +1354,14 @@ struct DashboardFilter: SDKModel {
     /**
      * The visual configuration for this filter. Used to set up how the UI for this filter should appear.
      */
-    var ui_config: StringDictionary<Variant?>?
+    var ui_config: StringDictionary<AnyCodable>?
 }
 
 struct DashboardLayout: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Unique Id (read-only)
      */
@@ -1404,7 +1404,7 @@ struct DashboardLayoutComponent: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Unique Id (read-only)
      */
@@ -1555,11 +1555,11 @@ struct DataActionRequest: SDKModel {
     /**
      * The JSON describing the data action. This JSON should be considered opaque and should be passed through unmodified from the query result it came from.
      */
-    var action: StringDictionary<Variant?>?
+    var action: StringDictionary<AnyCodable>?
     /**
      * User input for any form values the data action might use.
      */
-    var form_values: StringDictionary<Variant?>?
+    var form_values: StringDictionary<AnyCodable>?
 }
 
 struct DataActionResponse: SDKModel {
@@ -1597,7 +1597,7 @@ struct Datagroup: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * UNIX timestamp at which this entry was created. (read-only)
      */
@@ -1640,7 +1640,7 @@ struct DBConnection: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Name of the connection. Also used as the unique identifier
      */
@@ -1777,7 +1777,7 @@ struct DBConnectionBase: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Name of the connection. Also used as the unique identifier (read-only)
      */
@@ -1844,7 +1844,7 @@ struct DBConnectionTestResult: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * JDBC connection string. (only populated in the 'connect' test) (read-only)
      */
@@ -1922,7 +1922,7 @@ struct DialectInfo: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Default number max connections (read-only)
      */
@@ -2067,7 +2067,7 @@ struct EmbedSsoUrlParams: SDKModel {
     /**
      * A dictionary of name-value pairs associating a Looker user attribute name with a value.
      */
-    var user_attributes: StringDictionary<Variant?>?
+    var user_attributes: StringDictionary<AnyCodable>?
     /**
      * Id of the embed secret to use to sign this SSO url. If specified, the value must be an id of a valid (active) secret defined in the Looker instance. If not specified, the URL will be signed with the newest active embed secret defined in the Looker instance.
      */
@@ -2149,7 +2149,7 @@ struct Folder: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Dashboards (read-only)
      */
@@ -2224,14 +2224,14 @@ struct FolderBase: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
 }
 
 struct GitBranch: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * The short name on the local. Updating `name` results in `git checkout <new_name>`
      */
@@ -2302,7 +2302,7 @@ struct GitConnectionTest: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Human readable string describing the test (read-only)
      */
@@ -2317,7 +2317,7 @@ struct GitConnectionTestResult: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * A short string, uniquely naming this test (read-only)
      */
@@ -2355,7 +2355,7 @@ struct LkGroup: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Group can be used in content access controls
      */
@@ -2408,7 +2408,7 @@ struct Homepage: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Id of associated content_metadata record (read-only)
      */
@@ -2459,7 +2459,7 @@ struct HomepageItem: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Name of user who created the content this item is based on (read-only)
      */
@@ -2574,7 +2574,7 @@ struct HomepageSection: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Time at which this section was created. (read-only)
      */
@@ -2644,7 +2644,7 @@ struct Integration: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * ID of the integration. (read-only)
      */
@@ -2715,7 +2715,7 @@ struct IntegrationHub: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * ID of the hub. (read-only)
      */
@@ -2831,7 +2831,7 @@ struct InternalHelpResources: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * If true and internal help resources content is not blank then the link for internal help resources will be shown in the help menu and the content displayed within Looker
      */
@@ -2842,7 +2842,7 @@ struct InternalHelpResourcesContent: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Text to display in the help menu item which will display the internal help resources
      */
@@ -2857,7 +2857,7 @@ struct LDAPConfig: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Allow alternate email-based login via '/login/email' for admins and for specified users with the 'login_special_email' permission. This option is useful as a fallback during ldap setup, if ldap config problems occur later, or if you need to support some users who are not in your ldap directory. Looker email/password logins are always disabled for regular users when ldap is enabled.
      */
@@ -3093,7 +3093,7 @@ struct LDAPUser: SDKModel {
     /**
      * Dictionary of user's attributes (name/value) (read-only)
      */
-    var attributes: StringDictionary<Variant?>?
+    var attributes: StringDictionary<AnyCodable>?
     /**
      * Primary email address (read-only)
      */
@@ -3170,7 +3170,7 @@ struct LegacyFeature: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Unique Id (read-only)
      */
@@ -3251,7 +3251,7 @@ struct Look: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Id of content metadata (read-only)
      */
@@ -3373,7 +3373,7 @@ struct LookBasic: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Id of content metadata (read-only)
      */
@@ -3392,7 +3392,7 @@ struct LookmlModel: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Array of names of connections this model is allowed to use
      */
@@ -4018,7 +4018,7 @@ struct LookmlTest: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Name of model containing this test. (read-only)
      */
@@ -4049,7 +4049,7 @@ struct LookmlTestResult: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Name of model containing this test. (read-only)
      */
@@ -4095,7 +4095,7 @@ struct LookWithDashboards: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Id of content metadata (read-only)
      */
@@ -4221,7 +4221,7 @@ struct LookWithQuery: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Id of content metadata (read-only)
      */
@@ -4348,7 +4348,7 @@ struct Manifest: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Manifest project name (read-only)
      */
@@ -4375,7 +4375,7 @@ struct MergeQuery: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Column Limit
      */
@@ -4411,7 +4411,7 @@ struct MergeQuery: SDKModel {
     /**
      * Visualization Config
      */
-    var vis_config: StringDictionary<Variant?>?
+    var vis_config: StringDictionary<AnyCodable>?
 }
 
 struct MergeQuerySourceQuery: SDKModel {
@@ -4433,7 +4433,7 @@ struct ModelSet: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * (read-only)
      */
@@ -4472,7 +4472,7 @@ struct OIDCConfig: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Allow alternate email-based login via '/login/email' for admins and for specified users with the 'login_special_email' permission. This option is useful as a fallback during ldap setup, if ldap config problems occur later, or if you need to support some users who are not in your ldap directory. Looker email/password logins are always disabled for regular users when ldap is enabled.
      */
@@ -4647,7 +4647,7 @@ struct PasswordConfig: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Minimum number of characters required for a new password.  Must be between 7 and 100
      */
@@ -4670,7 +4670,7 @@ struct Permission: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Permission symbol (read-only)
      */
@@ -4689,7 +4689,7 @@ struct PermissionSet: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * (read-only)
      */
@@ -4717,7 +4717,7 @@ struct Project: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Project Id (read-only)
      */
@@ -4828,7 +4828,7 @@ struct ProjectError: SDKModel {
     /**
      * Error parameters (read-only)
      */
-    var params: StringDictionary<Variant?>?
+    var params: StringDictionary<AnyCodable>?
     /**
      * A version of the error message that does not contain potentially sensitive information. Suitable for situations in which messages are stored or sent to consumers outside of Looker, such as external logs. Sanitized messages will display "(?)" where sensitive information would appear in the corresponding non-sanitized message (read-only)
      */
@@ -4839,7 +4839,7 @@ struct ProjectFile: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * An opaque token uniquely identifying a file within a project. Avoid parsing or decomposing the text of this token. This token is stable within a Looker release but may change between Looker releases (read-only)
      */
@@ -4917,7 +4917,7 @@ struct ProjectWorkspace: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * The id of the project (read-only)
      */
@@ -4945,7 +4945,7 @@ struct Query: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Unique Id (read-only)
      */
@@ -4973,7 +4973,7 @@ struct Query: SDKModel {
     /**
      * Filters
      */
-    var filters: StringDictionary<Variant?>?
+    var filters: StringDictionary<AnyCodable>?
     /**
      * Filter Expression
      */
@@ -5009,11 +5009,11 @@ struct Query: SDKModel {
     /**
      * Visualization configuration properties. These properties are typically opaque and differ based on the type of visualization used. There is no specified set of allowed keys. The values can be any type supported by JSON. A "type" key with a string value is often present, and is used by Looker to determine which visualization to present. Visualizations ignore unknown vis_config properties.
      */
-    var vis_config: StringDictionary<Variant?>?
+    var vis_config: StringDictionary<AnyCodable>?
     /**
      * The filter_config represents the state of the filter UI on the explore page for a given query. When running a query via the Looker UI, this parameter takes precedence over "filters". When creating a query or modifying an existing query, "filter_config" should be set to null. Setting it to any other value could cause unexpected filtering behavior. The format should be considered opaque.
      */
-    var filter_config: StringDictionary<Variant?>?
+    var filter_config: StringDictionary<AnyCodable>?
     /**
      * Visible UI Sections
      */
@@ -5056,7 +5056,7 @@ struct QueryTask: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Unique Id (read-only)
      */
@@ -5132,7 +5132,7 @@ struct RenderTask: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Date/Time render task was created (read-only)
      */
@@ -5211,7 +5211,7 @@ struct RepositoryCredential: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Unique Id (read-only)
      */
@@ -5305,14 +5305,14 @@ struct ResultMakerWithIdVisConfigAndDynamicFields: SDKModel {
     /**
      * Vis config of the constituent Query, or Merge Query. (read-only)
      */
-    var vis_config: StringDictionary<Variant?>?
+    var vis_config: StringDictionary<AnyCodable>?
 }
 
 struct Role: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Unique Id (read-only)
      */
@@ -5345,7 +5345,7 @@ struct RunningQueries: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Unique Id (read-only)
      */
@@ -5420,7 +5420,7 @@ struct SamlConfig: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Enable/Disable Saml authentication for the server
      */
@@ -5573,7 +5573,7 @@ struct SamlMetadataParseResult: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Identify Provider Issuer (read-only)
      */
@@ -5755,7 +5755,7 @@ struct ScheduledPlan: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
 }
 
 struct ScheduledPlanDestination: SDKModel {
@@ -5809,7 +5809,7 @@ struct Session: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Unique Id (read-only)
      */
@@ -5872,7 +5872,7 @@ struct SessionConfig: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Allow users to have persistent sessions when they login
      */
@@ -5974,7 +5974,7 @@ struct Space: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Dashboards (read-only)
      */
@@ -6049,14 +6049,14 @@ struct SpaceBase: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
 }
 
 struct SqlQuery: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * The identifier of the SQL query (read-only)
      */
@@ -6098,7 +6098,7 @@ struct SqlQuery: SDKModel {
     /**
      * Visualization configuration properties. These properties are typically opaque and differ based on the type of visualization used. There is no specified set of allowed keys. The values can be any type supported by JSON. A "type" key with a string value is often present, and is used by Looker to determine which visualization to present. Visualizations ignore unknown vis_config properties.
      */
-    var vis_config: StringDictionary<Variant?>?
+    var vis_config: StringDictionary<AnyCodable>?
 }
 
 struct SqlQueryCreate: SDKModel {
@@ -6121,14 +6121,14 @@ struct SqlQueryCreate: SDKModel {
     /**
      * Visualization configuration properties. These properties are typically opaque and differ based on the type of visualization used. There is no specified set of allowed keys. The values can be any type supported by JSON. A "type" key with a string value is often present, and is used by Looker to determine which visualization to present. Visualizations ignore unknown vis_config properties.
      */
-    var vis_config: StringDictionary<Variant?>?
+    var vis_config: StringDictionary<AnyCodable>?
 }
 
 struct Theme: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Timestamp for when this theme becomes active. Null=always
      */
@@ -6252,7 +6252,7 @@ struct User: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * URL for the avatar image (may be generic) (read-only)
      */
@@ -6351,7 +6351,7 @@ struct User: SDKModel {
     /**
      * Per user dictionary of undocumented state information owned by the Looker UI.
      */
-    var ui_state: StringDictionary<Variant?>?
+    var ui_state: StringDictionary<AnyCodable>?
     /**
      * User is identified as an employee of Looker who has been verified via Looker corporate authentication (read-only)
      */
@@ -6370,7 +6370,7 @@ struct UserAttribute: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Unique Id (read-only)
      */
@@ -6421,7 +6421,7 @@ struct UserAttributeGroupValue: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Unique Id of this group-attribute relation (read-only)
      */
@@ -6452,7 +6452,7 @@ struct UserAttributeWithValue: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Name of user attribute (read-only)
      */
@@ -6499,7 +6499,7 @@ struct UserLoginLockout: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Hash of user's client id (read-only)
      */
@@ -6542,7 +6542,7 @@ struct UserPublic: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Unique Id (read-only)
      */
@@ -6607,7 +6607,7 @@ struct WelcomeEmailTest: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * The content that will be sent as part of a custom welcome email
      */
@@ -6618,7 +6618,7 @@ struct WhitelabelConfiguration: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * Unique Id (read-only)
      */
@@ -6669,7 +6669,7 @@ struct Workspace: SDKModel {
     /**
      * Operations the current user is able to perform on this object (read-only)
      */
-    var can: StringDictionary<Variant?>?
+    var can: StringDictionary<AnyCodable>?
     /**
      * The unique id of this user workspace. Predefined workspace ids include "production" and "dev" (read-only)
      */
@@ -6818,7 +6818,7 @@ struct WriteCreateDashboardFilter: SDKModel {
     /**
      * The visual configuration for this filter. Used to set up how the UI for this filter should appear.
      */
-    var ui_config: StringDictionary<Variant?>?
+    var ui_config: StringDictionary<AnyCodable>?
 }
 
 /**
@@ -7088,7 +7088,7 @@ struct WriteDashboardFilter: SDKModel {
     /**
      * The visual configuration for this filter. Used to set up how the UI for this filter should appear.
      */
-    var ui_config: StringDictionary<Variant?>?
+    var ui_config: StringDictionary<AnyCodable>?
 }
 
 /**
@@ -7756,7 +7756,7 @@ struct WriteMergeQuery: SDKModel {
     /**
      * Visualization Config
      */
-    var vis_config: StringDictionary<Variant?>?
+    var vis_config: StringDictionary<AnyCodable>?
 }
 
 /**
@@ -7978,7 +7978,7 @@ struct WriteQuery: SDKModel {
     /**
      * Filters
      */
-    var filters: StringDictionary<Variant?>?
+    var filters: StringDictionary<AnyCodable>?
     /**
      * Filter Expression
      */
@@ -8014,11 +8014,11 @@ struct WriteQuery: SDKModel {
     /**
      * Visualization configuration properties. These properties are typically opaque and differ based on the type of visualization used. There is no specified set of allowed keys. The values can be any type supported by JSON. A "type" key with a string value is often present, and is used by Looker to determine which visualization to present. Visualizations ignore unknown vis_config properties.
      */
-    var vis_config: StringDictionary<Variant?>?
+    var vis_config: StringDictionary<AnyCodable>?
     /**
      * The filter_config represents the state of the filter UI on the explore page for a given query. When running a query via the Looker UI, this parameter takes precedence over "filters". When creating a query or modifying an existing query, "filter_config" should be set to null. Setting it to any other value could cause unexpected filtering behavior. The format should be considered opaque.
      */
-    var filter_config: StringDictionary<Variant?>?
+    var filter_config: StringDictionary<AnyCodable>?
     /**
      * Visible UI Sections
      */
@@ -8373,7 +8373,7 @@ struct WriteUser: SDKModel {
     /**
      * Per user dictionary of undocumented state information owned by the Looker UI.
      */
-    var ui_state: StringDictionary<Variant?>?
+    var ui_state: StringDictionary<AnyCodable>?
 }
 
 /**


### PR DESCRIPTION
- Modified the Swift generator to use `AnyCodable` instead of `Variant?`
- Commented out all references to `Variant` in the Swift SDK for probable eventual removal
- Added a `serialize` function to produce JSON from an SDK object (the opposite of `deserialize`)
- Added a test called `testDictFromJson` that shows how `vis_config` values can be examined. There are probably better code patterns for this.