### PR TITLE
Implemented error handling by default for Swift

### DIFF
--- a/swift/looker/README.md
+++ b/swift/looker/README.md
@@ -68,8 +68,8 @@ let auth = AuthSession(settings, xp)
 /// Create you Looker SDK instance
 let sdk = LookerSDK(auth)
 
-/// Retrieve the API user record. If this fails, your Looker server or credentials are bad
-let me = sdk.ok(sdk.me())
+/// Retrieve the API user record. If this return nil, your Looker server or credentials are bad
+let me = try? sdk.ok(sdk.me())
 
 /// continue making SDK calls
 ```
@@ -126,9 +126,9 @@ let xp = BaseTransport(settings)
 let auth = AuthSession(settings, xp)
 let sdk = LookerSDK(auth)
 let body = simpleQuery() // However you want to express your query
-let query = sdk.ok(sdk.create_query(body))
-let png = sdk.ok(sdk.stream.run_query(query.id!, "png"))
-let jpg = sdk.ok(sdk.stream.run_query(query.id!, "jpg"))
+let query = try! sdk.ok(sdk.create_query(body))
+let png = try! sdk.ok(sdk.stream.run_query(query.id!, "png"))
+let jpg = try! sdk.ok(sdk.stream.run_query(query.id!, "jpg"))
 ```
 
 

--- a/swift/looker/Tests/lookerTests/authSessionTests.swift
+++ b/swift/looker/Tests/lookerTests/authSessionTests.swift
@@ -22,7 +22,7 @@ class authSessionTests: XCTestCase {
 
     // integration test against Looker instance to verify authSession handles basic authentication
     func testLogin() {
-        let settings = config.config
+        let settings = config.settings
         let xp = BaseTransport(settings)
         let auth = AuthSession(settings, xp)
         XCTAssertFalse(auth.isAuthenticated(), "should not be authenticated")

--- a/swift/looker/rtl/apiMethods.swift
+++ b/swift/looker/rtl/apiMethods.swift
@@ -37,19 +37,19 @@ class APIMethods {
         return try! encoder.encode(value)
     }
     
-    func ok<TSuccess, TError>(_ response: SDKResponse<TSuccess, TError>) -> TSuccess {
+    func ok<TSuccess, TError>(_ response: SDKResponse<TSuccess, TError>) throws -> TSuccess {
         switch response {
         case .success(let response):
             return response
         case .error(let error):
             // TODO implement logging
-            let message = error.errorDescription
-                ?? error.failureReason
-                ?? error.recoverySuggestion
-                ?? error.helpAnchor
-                ?? "Unknown SDK Error"
-            print("Error: \(message)")
-            return "" as! TSuccess
+//            let message = error.errorDescription
+//                ?? error.failureReason
+//                ?? error.recoverySuggestion
+//                ?? error.helpAnchor
+//                ?? "Unknown SDK Error"
+//            print("Error: \(message)")
+            throw error
         }
     }
     

--- a/swift/looker/rtl/constants.swift
+++ b/swift/looker/rtl/constants.swift
@@ -219,37 +219,6 @@ func asQ(_ value: Any?) -> String {
     return result
 }
 
-///
-/// OK with `try` that will throw an error
-/// Use with
-/// ```
-/// let me = try? oke(sdk.me()
-/// ```
-/// or
-/// ```
-/// do {
-///   let me = try oke(sdk.me()
-/// } catch {
-///   // handle error here
-/// }
-/// ```
-func okt<TSuccess, TError>(_ response: SDKResponse<TSuccess, TError>) throws -> TSuccess {
-    switch response {
-    case .success(let response):
-        return response
-    case .error(let error):
-        // TODO implement logging
-//        let message = error.errorDescription
-//            ?? error.failureReason
-//            ?? error.recoverySuggestion
-//            ?? error.helpAnchor
-//            ?? "Unknown SDK Error"
-        throw error
-    }
-}
-
-
-
 extension StringProtocol {
     subscript(bounds: CountableClosedRange<Int>) -> SubSequence {
         let start = index(startIndex, offsetBy: bounds.lowerBound)


### PR DESCRIPTION
- `sdk.ok()` now throws if an error is encountered
- created a `listGetter` test harness like the one for Kotlin
- updated `methodsTests.swift` to use `listGetter`