### PR TITLE
Content type detection for string and binary mime types

### DIFF
--- a/kotlin/src/main/com/looker/rtl/Constants.kt
+++ b/kotlin/src/main/com/looker/rtl/Constants.kt
@@ -30,7 +30,7 @@ const val ENVIRONMENT_PREFIX = "LOOKERSDK"
 const val LOOKER_VERSION = "7.2"
 const val API_VERSION = "4.0"
 const val SDK_VERSION = "${API_VERSION}.${LOOKER_VERSION}"
-const val AGENT_TAG = "SDK-KT ${SDK_VERSION}"
+const val AGENT_TAG = "KT-SDK ${SDK_VERSION}"
 const val LOOKER_APPID = "x-looker-appid"
 
 const val MATCH_CHARSET = ";.*charset="

--- a/python/looker_sdk/rtl/constants.py
+++ b/python/looker_sdk/rtl/constants.py
@@ -28,7 +28,7 @@ environment_prefix = "LOOKERSDK"
 RESPONSE_STRING_MODE = (
     r"(^application/.*"
     r"(\bjson\b|\bxml\b|\bsql\b|\bgraphql\b|\bjavascript\b|\bx-www-form-urlencoded\b)"
-    r"|^text/|.*\+xml\b;.*charset=)"
+    r"|^text/|.*\+xml\b|;.*charset=)"
 )
 
 # note: string mode must be checked first

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -41,6 +41,13 @@ def users(_test_data) -> List[Dict[str, str]]:
 def email_domain(_test_data) -> str:
     return _test_data["email_domain"]
 
+@pytest.fixture(scope="session")
+def string_content_types(_test_data) -> List[str]:
+    return _test_data["content_types"]["string"]
+
+@pytest.fixture(scope="session")
+def binary_content_types(_test_data) -> List[str]:
+    return _test_data["content_types"]["binary"]
 
 TTestData = Dict[str, Union[str, List[Dict[str, str]]]]
 

--- a/python/tests/rtl/test_transport.py
+++ b/python/tests/rtl/test_transport.py
@@ -25,14 +25,22 @@ import pytest  # type: ignore
 from looker_sdk.rtl import transport
 
 
-@pytest.mark.parametrize(
-    "content_type, expected_response_mode",
-    [
-        ("application/json", transport.ResponseMode.STRING),
-        ("image/png", transport.ResponseMode.BINARY),
-        ("text/xml", transport.ResponseMode.STRING),
-        ("audio/gzip", transport.ResponseMode.BINARY),
-    ],
-)
-def test_response_mode(content_type, expected_response_mode):
-    assert transport.response_mode(content_type) == expected_response_mode
+# @pytest.mark.parametrize(
+#     "content_type, expected_response_mode",
+#     [
+#         ("application/json", transport.ResponseMode.STRING),
+#         ("image/png", transport.ResponseMode.BINARY),
+#         ("text/xml", transport.ResponseMode.STRING),
+#         ("audio/gzip", transport.ResponseMode.BINARY),
+#     ],
+# )
+# def test_response_mode(content_type, expected_response_mode):
+#     assert transport.response_mode(content_type) == expected_response_mode
+
+def test_string_mode(string_content_types):
+    for content_type in string_content_types:
+        assert transport.response_mode(content_type) == transport.ResponseMode.STRING
+
+def test_binary_mode(binary_content_types):
+    for content_type in binary_content_types:
+        assert transport.response_mode(content_type) == transport.ResponseMode.BINARY

--- a/python/tests/rtl/test_transport.py
+++ b/python/tests/rtl/test_transport.py
@@ -25,18 +25,6 @@ import pytest  # type: ignore
 from looker_sdk.rtl import transport
 
 
-# @pytest.mark.parametrize(
-#     "content_type, expected_response_mode",
-#     [
-#         ("application/json", transport.ResponseMode.STRING),
-#         ("image/png", transport.ResponseMode.BINARY),
-#         ("text/xml", transport.ResponseMode.STRING),
-#         ("audio/gzip", transport.ResponseMode.BINARY),
-#     ],
-# )
-# def test_response_mode(content_type, expected_response_mode):
-#     assert transport.response_mode(content_type) == expected_response_mode
-
 def test_string_mode(string_content_types):
     for content_type in string_content_types:
         assert transport.response_mode(content_type) == transport.ResponseMode.STRING

--- a/swift/looker/Tests/lookerTests/baseTransportTests.swift
+++ b/swift/looker/Tests/lookerTests/baseTransportTests.swift
@@ -8,10 +8,12 @@
 import XCTest
 @testable import looker
 
-fileprivate let testRootPath = URL(fileURLWithPath: #file).pathComponents
-    .prefix(while: { $0 != "Tests" }).joined(separator: "/").dropFirst()
+fileprivate let rootPath = URL(fileURLWithPath: #file).pathComponents
+    .prefix(while: { $0 != "swift" })
+    .joined(separator: "/").dropFirst()
 
-fileprivate let repoPath : String = testRootPath + "/../../"
+fileprivate let testRootPath: String = rootPath + "/test"
+fileprivate let repoPath : String = rootPath + ""
 fileprivate let localIni : String = ProcessInfo.processInfo.environment["LOOKERSDK_INI"] ?? (repoPath + "looker.ini")
 
 
@@ -23,8 +25,8 @@ class TestConfig {
     lazy var dataFile = testFile("data.yml.json")
     lazy var localIni = envVar("LOOKERSDK_INI", self.rootFile("looker.ini"))!
     lazy var dataContents = try! Data(String(contentsOfFile: dataFile).utf8)
-    lazy var testData = try! JSONSerialization.jsonObject(with: dataContents, options: []) as! AnyCodable
-    lazy var testIni = rootFile((testData["iniFile"] as? String)!)
+    lazy var testData = try! JSONDecoder().decode([String: AnyCodable].self, from: dataContents)
+    lazy var testIni = rootFile((testData["iniFile"]?.value as! String))
     lazy var settings = try! ApiConfig(localIni, "Looker")
     lazy var testsettings = try! ApiConfig(testIni)
     lazy var xp = BaseTransport(settings)

--- a/swift/looker/Tests/lookerTests/constantsTests.swift
+++ b/swift/looker/Tests/lookerTests/constantsTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import looker
 
+@available(OSX 10.15, *)
 class constantsTests: XCTestCase {
 
     override func setUp() {

--- a/swift/looker/Tests/lookerTests/transportTests.swift
+++ b/swift/looker/Tests/lookerTests/transportTests.swift
@@ -8,53 +8,13 @@
 import XCTest
 @testable import looker
 
-let binaryTypes = """
-application/zip
-application/pdf
-application/msword
-application/vnd.ms-excel
-application/vnd.openxmlformats-officedocument.wordprocessingml.document
-application/vnd.ms-excel
-application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
-application/vnd.ms-powerpoint
-application/vnd.openxmlformats-officedocument.presentationml.presentation
-application/vnd.oasis.opendocument.text
-multipart/form-data
-audio/mpeg
-audio/ogg
-image/png
-image/jpeg
-image/gif
-font/
-audio/
-video/
-image/
-""".split(separator: "\n")
-
-let textTypes = """
-image/svg+xml
-application/javascript
-application/json
-application/x-www-form-urlencoded
-application/xml
-application/sql
-application/graphql
-application/ld+json
-text/css
-text/html
-text/xml
-text/csv
-text/plain
-application/vnd.api+json
-""".split(separator: "\n")
-
 struct SimpleUser : SDKModel {
     var first: String
     var last: String
     var email : String?
 }
 
-@available(OSX 10.12, *)
+@available(OSX 10.15, *)
 class transportTests: XCTestCase {
 
     override func setUp() {
@@ -92,20 +52,23 @@ class transportTests: XCTestCase {
         XCTAssertNotNil(contentPatternString, "String should be compiled")
     }
 
-    func testBinaryMode() {
-        for (item) in binaryTypes {
-            let val = String(item)
-            let actual = responseMode(val)
-            XCTAssertEqual(actual, .binary, val)
+    func testStringMode() {
+        let data = config.testData["content_types"]?.value
+        let contentTypes = data as! [String:[String]]
+        let types = contentTypes["string"]!
+        for t in types {
+            let mode = responseMode(t)
+            XCTAssertEqual(ResponseMode.string, mode, "\(t) should be string")
         }
     }
-
-    func testStringMode() {
-        print(Constants.matchModeString)
-        for (item) in textTypes {
-            let val = String(item)
-            let actual = responseMode(val)
-            XCTAssertEqual(actual, .string, val)
+    
+    func testBinaryMode() {
+        let data = config.testData["content_types"]?.value
+        let contentTypes = data as! [String:[String]]
+        let types = contentTypes["binary"]!
+        for t in types {
+            let mode = responseMode(t)
+            XCTAssertEqual(ResponseMode.binary, mode, "\(t) should be binary")
         }
     }
 

--- a/typescript/looker/rtl/transport.spec.ts
+++ b/typescript/looker/rtl/transport.spec.ts
@@ -25,41 +25,11 @@
 // Discussion of MIME types at https://en.wikipedia.org/wiki/Media_type#Mime.types
 
 import { ResponseMode, responseMode } from './transport'
+import { TestConfig } from './nodeSettings.spec'
 
-const binaryTypes = `application/zip
-application/pdf
-application/msword
-application/vnd.ms-excel
-application/vnd.openxmlformats-officedocument.wordprocessingml.document
-application/vnd.ms-excel
-application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
-application/vnd.ms-powerpoint
-application/vnd.openxmlformats-officedocument.presentationml.presentation
-application/vnd.oasis.opendocument.text
-multipart/form-data
-audio/mpeg
-audio/ogg
-image/png
-image/jpeg
-image/gif
-font/
-audio/
-video/
-image/`.split('\n')
-
-const textTypes = `application/javascript
-application/json
-application/x-www-form-urlencoded
-application/xml
-application/sql
-application/graphql
-application/ld+json
-text/css
-text/html
-text/xml
-text/csv
-text/plain
-application/vnd.api+json`.split('\n')
+const config = TestConfig()
+const binaryTypes = config.testData["content_types"]["binary"] as [string]
+const textTypes = config.testData["content_types"]["string"] as [string]
 
 describe('Transport', () => {
 


### PR DESCRIPTION
Using `test/data.yml` content type values for binary and string mode detection tests for Typescript, Swift, and Python