### PR TITLE
This fix failure of SDK in extensions as path is prefixed by API version

### DIFF
--- a/typescript/looker/rtl/apiMethods.spec.ts
+++ b/typescript/looker/rtl/apiMethods.spec.ts
@@ -27,7 +27,7 @@ import { defaultApiVersion } from './constants'
 import { NodeTransport } from './nodeTransport'
 import { APIMethods } from './apiMethods'
 import { IAuthSession } from './authSession'
-import { IApiSettings } from './apiSettings'
+import { DefaultSettings, IApiSettings } from './apiSettings'
 
 describe('NodeTransport', () => {
 
@@ -57,6 +57,11 @@ describe('NodeTransport', () => {
   it('full path with auth is just full path', () => {
     const actual = api.makePath(fullPath, settings, mockAuth)
     expect(actual).toEqual(fullPath)
+  })
+
+  it('path not prefixed if base url not set', () => {
+    const actual = api.makePath('/all_connections', DefaultSettings())
+    expect(actual).toEqual(`/all_connections`)
   })
 
 })

--- a/typescript/looker/rtl/apiMethods.ts
+++ b/typescript/looker/rtl/apiMethods.ts
@@ -38,7 +38,7 @@ export class APIMethods {
     this.authSession = authSession
     this.apiVersion = apiVersion
     this.authSession.settings.agentTag = `${agentPrefix} ${lookerVersion}.${this.apiVersion}`
-    this.apiPath = `${authSession.settings.base_url}/api/${this.apiVersion}`
+    this.apiPath = authSession.settings.base_url === '' ? '' : `${authSession.settings.base_url}/api/${this.apiVersion}`
   }
 
   /** A helper method for simplifying error handling of SDK responses.


### PR DESCRIPTION
…ion.

Prefix now does not happen if base_url is not set (as is the case for extension transport). Node and browser transports must set the base url.