### PR TITLE
Improved the legacy code generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,13 @@ A Looker SDK has several parts:
 
 - **API bindings** using the legacy [OpenAPI Generator](https://github.com/OpenAPITools/openapi-generator) can also be produced. This process converts the API specification to language-specific code. Most of these template-based generators are written by different language enthusiasts, so the pattern and quality of the generated code varies widely, even though most generated code tends to work acceptably.
 
-
 ## Multi-API support with Looker 7.2 and later
 
 Looker 7.2 introduces an **Experimental** version of API 4.0. Therefore, the SDKs now support multiple API versions in the same SDK package.
- 
+
 The main change to the SDKs is that `api_version` is no longer used from any configuration value. Instead, for all SDKs but Swift, API-specific SDKs are now created and put in the same SDK package, and share the same run-time code.
 
-API 3.0 is not included. At the time of this writing, API 3.1 and API 4.0 are included in most SDK packages. For an SDK that supports multiple API versions, there will be a `methods.*` and `models.*` generated for each API version. 
+API 3.0 is not included. At the time of this writing, API 3.1 and API 4.0 are included in most SDK packages. For an SDK that supports multiple API versions, there will be a `methods.*` and `models.*` generated for each API version.
 
 The class names representing these API versions are distinct, and factories for creating initialized SDK objects are also distinctly named.
 
@@ -36,19 +35,24 @@ These API-specific files still use all the same Run-Time Library (RTL) code in t
 
 Please review the following table for a breakdown of the options to initialize the desired SDK object.
 
-| SDK | API 3.1 | API 4.0 | Notes                                                                                                                                                           |
-| ---- | ------ | --------| --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Python  | `looker_sdk.init31()` | `looker_sdk.init40()` | Both API 3.1 and 4.0 are supported, and can be initialized with the functions shown                                                   |
-| Typescript | `Looker31SDK()`, `LookerNodeSDK.init31()`, or `LookerBrowserSDK.init31()` | `Looker40SDK()`, `LookerNodeSDK.init40()` or `LookerBrowserSDK.init40()` | Both API 3.1 and 4.0 are supported and can be initialized with the functions shown | 
-| Kotlin  | Do not use | `LookerSDK()` | API 4.0 was specifically created to correct the endpoint payloads for strongly-typed languages like Kotlin and Swift. Because Kotlin really requires API 4.0, API 4.0 is the default namespace for it |
-| Swift | Not applicable | `Looker40SDK()` | Swift only has SDK definitions for API 4.0 |                                                                                                     |
+| SDK        | API 3.1                                                                   | API 4.0                                                                  | Notes                                                                                                                                                                                                 |
+| ---------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Python     | `looker_sdk.init31()`                                                     | `looker_sdk.init40()`                                                    | Both API 3.1 and 4.0 are supported, and can be initialized with the functions shown                                                                                                                   |
+| Typescript | `Looker31SDK()`, `LookerNodeSDK.init31()`, or `LookerBrowserSDK.init31()` | `Looker40SDK()`, `LookerNodeSDK.init40()` or `LookerBrowserSDK.init40()` | Both API 3.1 and 4.0 are supported and can be initialized with the functions shown                                                                                                                    |
+| Kotlin     | Do not use                                                                | `LookerSDK()`                                                            | API 4.0 was specifically created to correct the endpoint payloads for strongly-typed languages like Kotlin and Swift. Because Kotlin really requires API 4.0, API 4.0 is the default namespace for it |
+| Swift      | Not applicable                                                            | `Looker40SDK()`                                                          | Swift only has SDK definitions for API 4.0                                                                                                                                                            |  |
 
 By supporting both API versions in the same SDK package, we hope the migration path to the latest API is simplified. Both SDK versions can be used at the same time, in the same source file, which should allow for iterative work to move to the new API version.
- 
+
 For example:
 
 ```typescript
-import { Looker40SDK, Looker31SDK, NodeSession, NodeSettingsIniFile } from '@looker/sdk'
+import {
+  Looker40SDK,
+  Looker31SDK,
+  NodeSession,
+  NodeSettingsIniFile
+} from '@looker/sdk'
 
 const settings = new NodeSettingsIniFile()
 const session = new NodeSession(settings)
@@ -63,7 +67,7 @@ const me31 = await sdk.ok(sdk31.me()) // or sdk31.ok(sdk31.me())
 
 TL;DR: don't URL encode your inputs because the SDKs will automatically handle it.
 
-All SDKs URL encode (also known as [percent encoding](https://en.wikipedia.org/wiki/Percent-encoding)) input values for passing to the API endpoints automatically. Furthermore, except for Swift, which has problematic URL decoding support, the other SDKs will avoid double-encoding inputs that may already be encoded. 
+All SDKs URL encode (also known as [percent encoding](https://en.wikipedia.org/wiki/Percent-encoding)) input values for passing to the API endpoints automatically. Furthermore, except for Swift, which has problematic URL decoding support, the other SDKs will avoid double-encoding inputs that may already be encoded.
 
 ## Using existing, pre-generated SDKs
 
@@ -169,11 +173,13 @@ This command will start a local web server that allows you to browse and search 
 
 To generate a language currently not supported by Looker's SDK code generator with the OpenAPI generator:
 
-- configure the desired language in [`languages.ts`](src/languages.ts)
+- configure the desired language in [`languages.ts`](src/languages.ts). Currently, only C# is defined for the legacy language generator.
 
-- use `yarn legacy` to call the OpenAPI generator
+- the legacy generator defaults to using the API 4.0 specification, which is more accurate for strongly typed languages. To use API 3.1, put `api_version=3.1` in the `Looker` section of your `looker.ini`
 
-#### Additional scripts
+- use `yarn legacy` to call the OpenAPI generator. This will use the OpenAPI generator to output files to the `./api/*` path
+
+### Additional scripts
 
 Use
 
@@ -262,7 +268,3 @@ The following table describes the environment variables. By default, the SDK "na
 | LOOKERSDK_TIMEOUT       | Request timeout in seconds. Defaults to `120` for most platforms.                                                                                                     |
 | LOOKERSDK_CLIENT_ID     | API3 credentials `client_id`. This and `client_secret` must be provided in some fashion to the Node SDK, or no calls to the API will be authorized. No default value. |
 | LOOKERSDK_CLIENT_SECRET | API3 credentials `client_secret`. No default value.                                                                                                                   |
-
-## SDK Examples
-
-Looker hosts an open source repository for SDK examples at <https://github.com/looker-open-source/sdk-examples>. We welcome members of the community to submit additional examples.

--- a/src/convert.spec.ts
+++ b/src/convert.spec.ts
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2019 Looker Data Sciences, Inc.
+ * Copyright (c) 2020 Looker Data Sciences, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/convert.spec.ts
+++ b/src/convert.spec.ts
@@ -1,0 +1,75 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Looker Data Sciences, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+import { swapXLookerNullable } from './convert'
+
+describe('spec conversion', () => {
+  it('swaps out x-looker-nullable', () => {
+    const input = `
+"can": {
+  "type": "object",
+  "additionalProperties": {
+    "type": "boolean"
+  },
+  "readOnly": true,
+  "description": "Operations the current user is able to perform on this object",
+  "x-looker-nullable": false
+},
+"content_favorite_id": {
+  "type": "integer",
+  "format": "int64",
+  "readOnly": true,
+  "description": "Content Favorite Id",
+  "x-looker-nullable": true
+},
+"content_metadata_id": {
+  "type": "integer",
+  "format": "int64",
+  "readOnly": true,
+  "description": "Id of content metadata",
+  "x-looker-nullable": true
+},
+"description": {
+  "type": "string",
+  "readOnly": true,
+  "description": "Description",
+  "x-looker-nullable": true
+},
+"hidden": {
+  "type": "boolean",
+  "readOnly": true,
+  "description": "Is Hidden",
+  "x-looker-nullable": false
+},
+`
+    const actual = swapXLookerNullable(input)
+    const puzzle = input.replace(/x-looker-nullable/gi, 'nullable')
+    expect(actual).toEqual(puzzle)
+
+    expect(actual).toContain('"nullable": true')
+    expect(actual).not.toContain('"x-looker-nullable": true')
+  })
+
+})

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -76,13 +76,13 @@ export const swapXLookerNullable = (contents: string) => {
  * @param {string} openApiFile name of the Open API file to process
  * @returns {Promise<string>} name of the file written
  */
-export const swapNullableInFile = async (openApiFile: string) => {
+export const swapNullableInFile = (openApiFile: string) => {
   if (!isFileSync(openApiFile)) {
     return quit(`${openApiFile} was not found`)
   }
   log(`replacing "x-looker-nullable" with "nullable" in ${openApiFile} ...`)
   const contents = swapXLookerNullable(readFileSync(openApiFile))
-  await fs.writeFileSync(openApiFile, contents)
+  fs.writeFileSync(openApiFile, contents)
   return openApiFile
 }
 
@@ -92,7 +92,7 @@ export const swapNullableInFile = async (openApiFile: string) => {
  * @param {string} openApiFile
  * @returns {Promise<string>}
  */
-const convertSpec = async (fileName: string, openApiFile: string) => {
+const convertSpec = (fileName: string, openApiFile: string) => {
   if (isFileSync(openApiFile)) {
     log(`${openApiFile} already exists.`)
     return openApiFile
@@ -107,7 +107,7 @@ const convertSpec = async (fileName: string, openApiFile: string) => {
     if (!isFileSync(openApiFile)) {
       return fail('convertSpec', `creating ${openApiFile} failed`)
     }
-    return await swapNullableInFile(openApiFile)
+    return swapNullableInFile(openApiFile)
   } catch (e) {
     return quit(e)
   }
@@ -124,7 +124,7 @@ export const logConvert = async (name: string, props: ISDKConfigProps) => {
   if (isFileSync(oaFile)) return oaFile
 
   const specFile = await logFetch(name, props)
-  const openApiFile = await convertSpec(specFile, oaFile)
+  const openApiFile = convertSpec(specFile, oaFile)
   if (!openApiFile) {
     return fail('logConvert', 'No file name returned for openAPI upgrade')
   }

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -24,7 +24,7 @@
  * THE SOFTWARE.
  */
 
-import { ISDKConfigProps, SDKConfig } from './sdkConfig'
+import { ISDKConfigProps } from './sdkConfig'
 import { openApiFileName, logFetch } from './fetchSpec'
 import { fail, isFileSync, log, quit, readFileSync, run } from './utils'
 import * as fs from 'fs'
@@ -45,7 +45,7 @@ const lintCheck = async (fileName: string) => {
     linter
       .run({
         parsed: spec,
-        getLocationForJsonPath
+        getLocationForJsonPath,
       })
       .then(console.log)
     return ''

--- a/src/fetchSpec.spec.ts
+++ b/src/fetchSpec.spec.ts
@@ -22,21 +22,13 @@
  * THE SOFTWARE.
  */
 
-import * as fs from 'fs'
-import * as yaml from 'js-yaml'
-import { SDKConfig } from './sdkConfig'
 import { authGetUrl, getVersionInfo, login, specFileUrl } from './fetchSpec'
-import { readFileSync } from './utils'
+import { TestConfig } from '../typescript/looker/rtl/nodeSettings.spec'
 
-const dataFile = 'test/data.yml'
-// slightly hackish data path determination for tests
-const root = fs.existsSync(dataFile) ? '' : '../../'
-const testData = yaml.safeLoad(readFileSync(`${root}${dataFile}`))
-const localIni = `${root}${testData['iniFile']}`
-const config = SDKConfig(localIni)
-const props = config['Looker']
+const testConfig = TestConfig()
+const props = testConfig.section
 // api_version is no longer part of the INI, now set by sdkGen iterator
-props.api_version = '3.1'
+props.api_version = '4.0'
 
 describe('fetch operations', () => {
   it('gets version info', async () => {

--- a/src/languages.ts
+++ b/src/languages.ts
@@ -34,80 +34,91 @@ export interface IGeneratorSpec {
   language: string // name of Open API Generator language to produce
   path?: string
   factory?: (api: ApiModel, versions?: IVersionInfo) => ICodeGen
-  options: string // generator options
+  options?: string // generator options
   legacy?: string // legacy language tag
 }
 
 // To disable generation of any language specification, you can just comment it out
-export const Languages: Array<IGeneratorSpec> =
-  [
-    {
-      language: 'csharp',
-      legacy: 'csharp',
-      factory: undefined,
-      options: '-DapiPackage=Looker -DpackageName=looker'
-    },
-    {
-      language: 'kotlin',
-      legacy: 'kotlin',
-      factory: (api: ApiModel, versions?: IVersionInfo) => new KotlinGen(api, versions),
-      options: '-DapiPackage=com.looker.sdk -DpackageName=com.looker.sdk'
-    },
-    { language: 'swift',
-      legacy: 'swift4',
-      factory: (api: ApiModel, versions?: IVersionInfo) => new SwiftGen(api, versions),
-      options: '-DapiPackage=Looker -DpackageName=looker'
-    },
-    // {
-    //   language: 'php',
-    //   path: 'php',
-    //   options: '-DapiPackage=Looker -DpackageName=looker'
-    // },
-    {
-      language: 'python',
-      factory: (api: ApiModel, versions?: IVersionInfo) => new PythonGen(api, versions),
-      options: '-DapiPackage=Looker -DpackageName=looker'
-    },
-    {
-      language: 'typescript',
-      legacy: 'typescript-node', // OpenAPI generate uses this for the language
-      factory: (api: ApiModel, versions?: IVersionInfo) => new TypescriptGen(api, versions),
-      options: '-DapiPackage=Looker -DpackageName=looker'
-    },
-    // {
-    //   language: 'r',
-    //   options: '-DapiPackage=Looker -DpackageName=looker'
-    // },
-    // {
-    //   language: 'ruby',
-    //   options: '-DapiPackage=Looker -DpackageName=looker'
-    // },
-    // {
-    //   language: 'rust',
-    //   options: '-DapiPackage=Looker -DpackageName=looker'
-    // },
-    // {
-    //   language: 'typescript-node',
-    //   path: 'ts_node',
-    //   options: '-DapiPackage=Looker -DpackageName=looker'
-    // },
-    // {
-    //   language: 'typescript-fetch',
-    //   path: 'ts_fetch',
-    //   options: '-DapiPackage=looker -DpackageName=looker'
-    // },
-  ]
+export const Languages: Array<IGeneratorSpec> = [
+  {
+    language: 'csharp',
+    legacy: 'csharp',
+    factory: undefined,
+    options: '-papiPackage=Looker -ppackageName=looker'
+  },
+  {
+    language: 'kotlin',
+    factory: (api: ApiModel, versions?: IVersionInfo) =>
+      new KotlinGen(api, versions)
+  },
+  {
+    language: 'swift',
+    factory: (api: ApiModel, versions?: IVersionInfo) =>
+      new SwiftGen(api, versions)
+  },
+  // {
+  //   language: 'php',
+  //   legacy: 'php',
+  //   options: '-papiPackage=Looker -ppackageName=looker'
+  // },
+  {
+    language: 'python',
+    factory: (api: ApiModel, versions?: IVersionInfo) =>
+      new PythonGen(api, versions)
+  },
+  {
+    language: 'typescript',
+    factory: (api: ApiModel, versions?: IVersionInfo) =>
+      new TypescriptGen(api, versions)
+  }
+  // {
+  //   language: 'r',
+  //   legacy: 'r'
+  //   options: '-papiPackage=Looker -ppackageName=looker'
+  // },
+  // {
+  //   language: 'ruby',
+  //   options: '-papiPackage=Looker -ppackageName=looker'
+  // },
+  // {
+  //   language: 'rust',
+  //   options: '-papiPackage=Looker -ppackageName=looker'
+  // },
+  // {
+  //   language: 'typescript-node',
+  //   path: 'ts_node',
+  //   options: '-papiPackage=Looker -ppackageName=looker'
+  // },
+  // {
+  //   language: 'typescript-fetch',
+  //   path: 'ts_fetch',
+  //   options: '-papiPackage=looker -ppackageName=looker'
+  // },
+]
 
-export const getFormatter = (format: string, api: ApiModel, versions?: IVersionInfo): ICodeGen | undefined => {
+export const getFormatter = (
+  format: string,
+  api: ApiModel,
+  versions?: IVersionInfo
+): ICodeGen | undefined => {
   const generators = Languages.filter(x => x.factory !== undefined)
-  const language = generators
-    .find((item) => item.language.toLowerCase() === format.toLowerCase())
+  const language = generators.find(
+    item => item.language.toLowerCase() === format.toLowerCase()
+  )
   if (!language) {
-    const langs = generators.map((item) => item.language)
-    quit(`"${format}" is not a recognized language. Supported languages are: all, ${langs.join(', ')}`)
+    const langs = generators.map(item => item.language)
+    quit(
+      `"${format}" is not a recognized language. Supported languages are: all, ${langs.join(
+        ', '
+      )}`
+    )
   }
   if (language && language.factory) {
     return language.factory(api, versions)
   }
   return undefined
+}
+
+export const legacyLanguages = (): Array<IGeneratorSpec> => {
+  return Languages.filter(x => !!x.legacy)
 }

--- a/src/legacy.ts
+++ b/src/legacy.ts
@@ -29,6 +29,10 @@ import { ISDKConfigProps, SDKConfig } from './sdkConfig'
 import { log, quit, run } from './utils'
 import { logConvert } from './convert'
 
+const defaultApiVersion = (props: ISDKConfigProps) => {
+  return props.api_version || '4.0'
+}
+
 // Warning: deprecated. This is using the legacy code generator
 // perform the generation for specific API version, configuration, and language
 const generate = async (

--- a/src/legacy.ts
+++ b/src/legacy.ts
@@ -75,6 +75,7 @@ const runConfig = async (name: string, props: ISDKConfigProps) => {
 
   return results
 }
+
 ;(async () => {
   try {
     const config = SDKConfig()

--- a/src/legacy.ts
+++ b/src/legacy.ts
@@ -24,41 +24,61 @@
  * THE SOFTWARE.
  */
 
-import { Languages, IGeneratorSpec as LanguageSpec } from './languages'
+import { IGeneratorSpec as LanguageSpec, legacyLanguages } from './languages'
 import { ISDKConfigProps, SDKConfig } from './sdkConfig'
 import { log, quit, run } from './utils'
 import { logConvert } from './convert'
 
 // Warning: deprecated. This is using the legacy code generator
 // perform the generation for specific API version, configuration, and language
-const generate = async (fileName: string, spec: LanguageSpec, props: ISDKConfigProps) => {
+const generate = async (
+  fileName: string,
+  spec: LanguageSpec,
+  props: ISDKConfigProps
+) => {
   const path = spec.path ? spec.path : spec.language
   const language = spec.legacy ? spec.legacy : spec.language
-  const apiPath = `./api/${props.api_version}/${path}`
-  return run('openapi-generator',
-    // ['generate', '-i', fileName, '-g', language, '-o', apiPath, '--enable-post-process-file', spec.options])
-    ['generate', spec.options, '-i', fileName, '-g', language, '-o', apiPath, '--enable-post-process-file'])
+  const apiVersion = defaultApiVersion(props)
+  const apiPath = `./api/${apiVersion}/${path}`
+  const options = spec.options || ''
+  return run('openapi-generator', [
+    'generate',
+    '-i',
+    fileName,
+    '-g',
+    language,
+    '-o',
+    apiPath,
+    '--enable-post-process-file',
+    options
+  ])
 }
 
 // generate all languages for the specified configuration
 const runConfig = async (name: string, props: ISDKConfigProps) => {
   log(`processing ${name} configuration ...`)
-
+  const apiVersion = defaultApiVersion(props)
+  props.api_version = apiVersion
   const openApiFile = await logConvert(name, props)
+  const languages = legacyLanguages()
 
   let results: any[] = []
-  for (const language of Languages) {
-    const tag = `${name} API ${language.language} version ${props.api_version}`
+  for (const language of languages) {
+    const tag = `${name} API ${language.language} version ${apiVersion}`
     log(`generating ${tag} ...`)
     results.push(await generate(openApiFile, language, props))
   }
 
   return results
 }
-
-try {
-  const config = SDKConfig()
-  Object.entries(config).forEach(async ([name, props]) => runConfig(name, props))
-} catch (e) {
-  quit(e)
-}
+;(async () => {
+  try {
+    const config = SDKConfig()
+    // Look for the Looker config section and only run that one
+    const name = 'Looker'
+    const props = config[name]
+    await runConfig(name, props)
+  } catch (e) {
+    quit(e)
+  }
+})()

--- a/typescript/looker/rtl/nodeSettings.spec.ts
+++ b/typescript/looker/rtl/nodeSettings.spec.ts
@@ -73,6 +73,8 @@ export function TestConfig(rootPath: string = '') {
     testData,
     testIni,
     configContents,
+    config,
+    section,
     testConfig,
     testSection,
   }


### PR DESCRIPTION
- The API 4.0 specification is now used by default for `yarn legacy`
- fixed namespace parameter specifier for the OpenAPI generator
- `x-looker-nullable` is replaced with `nullable` in the converted OpenAPI spec files
- legacy now only generates C# by default because the other active languages are supported by our code generator
- updated readme with more instructions for the legacy generator