### PR TITLE
Python SDK: settings refactor

### DIFF
--- a/python/looker_sdk/__init__.py
+++ b/python/looker_sdk/__init__.py
@@ -21,7 +21,6 @@
 # THE SOFTWARE.
 
 from typing import Optional
-import warnings
 
 from looker_sdk.rtl import api_settings
 from looker_sdk.rtl import requests_transport
@@ -47,21 +46,16 @@ def init31(
 ) -> methods31.Looker31SDK:
     """Default dependency configuration
     """
-    settings = api_settings.ApiSettings.configure(config_file, section)
-    if settings.api_version is not None:
-        warnings.warn(message=DeprecationWarning(API_SETTINGS_API_VERSION_DEPRECATED))
-    settings.api_version = "3.1"
-    settings.headers = {"Content-Type": "application/json"}
+    settings = api_settings.ApiSettings(config_file, section)
     if not settings.is_configured():
-        raise InitError(
-            f"Missing required configuration values like base_url and api_version."
-        )
+        raise InitError(f"Missing required configuration values.")
     transport = requests_transport.RequestsTransport.configure(settings)
     return methods31.Looker31SDK(
-        auth_session.AuthSession(settings, transport, serialize.deserialize31),
+        auth_session.AuthSession(settings, transport, serialize.deserialize31, "3.1"),
         serialize.deserialize31,
         serialize.serialize,
         transport,
+        "3.1",
     )
 
 
@@ -70,19 +64,14 @@ def init40(
 ) -> methods40.Looker40SDK:
     """Default dependency configuration
     """
-    settings = api_settings.ApiSettings.configure(config_file, section)
-    if settings.api_version is not None:
-        warnings.warn(message=DeprecationWarning(API_SETTINGS_API_VERSION_DEPRECATED))
-    settings.api_version = "4.0"
-    settings.headers = {"Content-Type": "application/json"}
+    settings = api_settings.ApiSettings(config_file, section)
     if not settings.is_configured():
-        raise InitError(
-            f"Missing required configuration values like base_url and api_version."
-        )
+        raise InitError(f"Missing required configuration values.")
     transport = requests_transport.RequestsTransport.configure(settings)
     return methods40.Looker40SDK(
-        auth_session.AuthSession(settings, transport, serialize.deserialize40),
+        auth_session.AuthSession(settings, transport, serialize.deserialize40, "4.0"),
         serialize.deserialize40,
         serialize.serialize,
         transport,
+        "4.0",
     )

--- a/python/looker_sdk/__init__.py
+++ b/python/looker_sdk/__init__.py
@@ -48,7 +48,7 @@ def init31(
     """
     settings = api_settings.ApiSettings(config_file, section)
     if not settings.is_configured():
-        raise InitError(f"Missing required configuration values.")
+        raise InitError("Missing required configuration values.")
     transport = requests_transport.RequestsTransport.configure(settings)
     return methods31.Looker31SDK(
         auth_session.AuthSession(settings, transport, serialize.deserialize31, "3.1"),
@@ -66,7 +66,7 @@ def init40(
     """
     settings = api_settings.ApiSettings(config_file, section)
     if not settings.is_configured():
-        raise InitError(f"Missing required configuration values.")
+        raise InitError("Missing required configuration values.")
     transport = requests_transport.RequestsTransport.configure(settings)
     return methods40.Looker40SDK(
         auth_session.AuthSession(settings, transport, serialize.deserialize40, "4.0"),

--- a/python/looker_sdk/rtl/api_settings.py
+++ b/python/looker_sdk/rtl/api_settings.py
@@ -26,10 +26,8 @@ with the settings as attributes
 import configparser as cp
 import os
 import sys
-from typing import cast, Dict, Optional
-
-import attr
-import cattr
+from typing import Dict, Optional, Set
+import warnings
 
 from looker_sdk.rtl import transport
 from looker_sdk.rtl import constants
@@ -40,34 +38,24 @@ else:
     from typing_extensions import Protocol
 
 
-def _convert_bool(val: str, _: bool) -> bool:
-    converted: bool
-    if val.lower() in ("yes", "y", "true", "t", "1"):
-        converted = True
-    elif val.lower() in ("", "no", "n", "false", "f", "0"):
-        converted = False
-    else:
-        raise TypeError
-    return converted
-
-
 class PApiSettings(transport.PTransportSettings, Protocol):
-    def get_client_id(self) -> Optional[str]:
+    looker_url: Optional[str]
+    redirect_uri: Optional[str]
+
+    @property
+    def client_id(self) -> Optional[str]:
         ...
 
-    def get_client_secret(self) -> Optional[str]:
+    @property
+    def client_secret(self) -> Optional[str]:
         ...
 
 
-@attr.s(auto_attribs=True, kw_only=True)
-class ApiSettings(transport.TransportSettings):
-    filename: str
-    section: Optional[str] = None
+class ApiSettings(PApiSettings):
+    deprecated_settings: Set[str] = {"api_version", "embed_secret", "user_id"}
+    secure_settings: Set[str] = {"client_id", "client_secret"}
 
-    @classmethod
-    def configure(
-        cls, filename: str = "looker.ini", section: Optional[str] = None
-    ) -> PApiSettings:
+    def __init__(self, filename: str = "looker.ini", section: Optional[str] = None):
         """Configure using a config file and/or environment variables.
 
         Environment variables will override config file settings. Neither
@@ -75,70 +63,100 @@ class ApiSettings(transport.TransportSettings):
         instantiate ApiSettings.
 
         ENV variables map like this:
-            <package-prefix>_API_VERSION -> api_version
             <package-prefix>_BASE_URL -> base_url
             <package-prefix>_VERIFY_SSL -> verify_ssl
         """
-        api_settings = cls(filename=filename, section=section)
-        config_data = api_settings.read_config()
-        converter = cattr.Converter()
-        converter.register_structure_hook(bool, _convert_bool)
-        settings = converter.structure(config_data, ApiSettings)
-        return settings
+        self.filename = filename
+        self.section = section
+        data = self._read_config()
+        verify_ssl = data.get("verify_ssl")
+        if verify_ssl is None:
+            self.verify_ssl = True
+        else:
+            self.verify_ssl = self._bool(verify_ssl)
+        self.base_url = data.get("base_url", "")
+        self.timeout = int(data.get("timeout", 120))
+        self.headers = {"Content-Type": "application/json"}
+        self.agent_tag = f"{transport.AGENT_PREFIX} {constants.sdk_version}"
+        self.looker_url = data.get("looker_url")
+        self.redirect_uri = data.get("redirect_uri")
 
-    def read_config(self) -> Dict[str, Optional[str]]:
+    @property
+    def client_id(self) -> Optional[str]:
+        return self._read_config().get("client_id")
+
+    @property
+    def client_secret(self) -> Optional[str]:
+        return self._read_config().get("client_secret")
+
+    def _read_config(self) -> Dict[str, str]:
         cfg_parser = cp.ConfigParser()
         try:
-            cfg_parser.read_file(open(self.filename))
+            config_file = open(self.filename)
         except FileNotFoundError:
-            config_data: Dict[str, Optional[str]] = {}
+            data: Dict[str, str] = {}
         else:
+            cfg_parser.read_file(config_file)
             # If section is not specified, use first section in file
             section = self.section or cfg_parser.sections()[0]
-            config_data = self._clean_input(dict(cfg_parser[section]))
+            data = dict(cfg_parser[section])
 
-        env_api_version = cast(
-            str, os.getenv(f"{constants.environment_prefix}_API_VERSION")
-        )
-        if env_api_version:
-            config_data["api_version"] = env_api_version
+        data.update(self._override_from_env())
+        return self._clean_input(data)
 
-        env_base_url = cast(str, os.getenv(f"{constants.environment_prefix}_BASE_URL"))
-        if env_base_url:
-            config_data["base_url"] = env_base_url
+    @staticmethod
+    def _bool(val: str) -> bool:
+        if val.lower() in ("yes", "y", "true", "t", "1"):
+            converted = True
+        elif val.lower() in ("", "no", "n", "false", "f", "0"):
+            converted = False
+        else:
+            raise TypeError
+        return converted
 
-        env_verify_ssl = cast(
-            str, os.getenv(f"{constants.environment_prefix}_VERIFY_SSL")
-        )
-        if env_verify_ssl:
-            config_data["verify_ssl"] = env_verify_ssl
+    @staticmethod
+    def _override_from_env() -> Dict[str, str]:
+        overrides = {}
+        env_prefix = constants.environment_prefix
+        base_url = os.getenv(f"{env_prefix}_BASE_URL")
+        if base_url:
+            overrides["base_url"] = base_url
 
-        config_data["filename"] = self.filename
-        config_data["section"] = self.section
-        config_data = self._clean_input(config_data)
+        verify_ssl = os.getenv(f"{env_prefix}_VERIFY_SSL")
+        if verify_ssl:
+            overrides["verify_ssl"] = verify_ssl
 
-        return config_data
+        timeout = os.getenv(f"{env_prefix}_TIMEOUT")
+        if timeout:
+            overrides["timeout"] = timeout
 
-    def _clean_input(
-        self, config_data: Dict[str, Optional[str]]
-    ) -> Dict[str, Optional[str]]:
-        for setting, value in list(config_data.items()):
+        client_id = os.getenv(f"{env_prefix}_CLIENT_ID")
+        if client_id:
+            overrides["client_id"] = client_id
+
+        client_secret = os.getenv(f"{env_prefix}_CLIENT_SECRET")
+        if client_secret:
+            overrides["client_secret"] = client_secret
+
+        return overrides
+
+    def _clean_input(self, data: Dict[str, str]) -> Dict[str, str]:
+        """Remove surrounding quotes and discard empty strigns.
+        """
+        cleaned = {}
+        for setting, value in data.items():
+            if setting in self.deprecated_settings:
+                warnings.warn(
+                    message=DeprecationWarning(
+                        f"'{setting}' config setting is deprecated"
+                    )
+                )
             # Remove empty setting values
-            if not isinstance(value, str):
-                continue
             if value in ['""', "''", ""]:
-                config_data.pop(setting)
+                continue
             # Strip quotes from setting values
             elif value.startswith(('"', "'")) or value.endswith(('"', "'")):
-                config_data[setting] = value.strip("\"'")
-        return config_data
-
-    def get_client_id(self) -> Optional[str]:
-        return os.getenv(
-            f"{constants.environment_prefix}_CLIENT_ID"
-        ) or self.read_config().get("client_id")
-
-    def get_client_secret(self) -> Optional[str]:
-        return os.getenv(
-            f"{constants.environment_prefix}_CLIENT_SECRET"
-        ) or self.read_config().get("client_secret")
+                cleaned[setting] = value.strip("\"'")
+            else:
+                cleaned[setting] = value
+        return cleaned

--- a/python/looker_sdk/rtl/api_settings.py
+++ b/python/looker_sdk/rtl/api_settings.py
@@ -122,7 +122,7 @@ class ApiSettings(PApiSettings):
         return overrides
 
     def _clean_input(self, data: Dict[str, str]) -> Dict[str, str]:
-        """Remove surrounding quotes and discard empty strigns.
+        """Remove surrounding quotes and discard empty strings.
         """
         cleaned = {}
         for setting, value in data.items():

--- a/python/looker_sdk/rtl/api_settings.py
+++ b/python/looker_sdk/rtl/api_settings.py
@@ -39,21 +39,12 @@ else:
 
 
 class PApiSettings(transport.PTransportSettings, Protocol):
-    looker_url: Optional[str]
-    redirect_uri: Optional[str]
-
-    @property
-    def client_id(self) -> Optional[str]:
-        ...
-
-    @property
-    def client_secret(self) -> Optional[str]:
+    def read_config(self) -> Dict[str, str]:
         ...
 
 
 class ApiSettings(PApiSettings):
     deprecated_settings: Set[str] = {"api_version", "embed_secret", "user_id"}
-    secure_settings: Set[str] = {"client_id", "client_secret"}
 
     def __init__(self, filename: str = "looker.ini", section: Optional[str] = None):
         """Configure using a config file and/or environment variables.
@@ -68,7 +59,7 @@ class ApiSettings(PApiSettings):
         """
         self.filename = filename
         self.section = section
-        data = self._read_config()
+        data = self.read_config()
         verify_ssl = data.get("verify_ssl")
         if verify_ssl is None:
             self.verify_ssl = True
@@ -78,18 +69,8 @@ class ApiSettings(PApiSettings):
         self.timeout = int(data.get("timeout", 120))
         self.headers = {"Content-Type": "application/json"}
         self.agent_tag = f"{transport.AGENT_PREFIX} {constants.sdk_version}"
-        self.looker_url = data.get("looker_url")
-        self.redirect_uri = data.get("redirect_uri")
 
-    @property
-    def client_id(self) -> Optional[str]:
-        return self._read_config().get("client_id")
-
-    @property
-    def client_secret(self) -> Optional[str]:
-        return self._read_config().get("client_secret")
-
-    def _read_config(self) -> Dict[str, str]:
+    def read_config(self) -> Dict[str, str]:
         cfg_parser = cp.ConfigParser()
         try:
             config_file = open(self.filename)

--- a/python/looker_sdk/rtl/auth_session.py
+++ b/python/looker_sdk/rtl/auth_session.py
@@ -175,7 +175,7 @@ class AuthSession:
         self.sudo_token = auth_token.AuthToken(access_token)
 
     def logout(self, full: bool = False) -> None:
-        """Logout cuurent session or all.
+        """Logout of API.
 
         If the session is authenticated as sudo_id, logout() "undoes"
         the sudo and deactivates that sudo_id's current token. By default

--- a/python/looker_sdk/rtl/auth_session.py
+++ b/python/looker_sdk/rtl/auth_session.py
@@ -25,28 +25,17 @@
 from typing import cast, Dict, Optional, Type, Union
 import urllib.parse
 
+
 from looker_sdk import error
 from looker_sdk.rtl import api_settings
 from looker_sdk.rtl import auth_token
-from looker_sdk.rtl import constants
 from looker_sdk.rtl import serialize
 from looker_sdk.rtl import transport
 from looker_sdk.sdk.api31 import models as models31
 from looker_sdk.sdk.api40 import models as models40
 
 
-# I'd expect the following line to be sufficient to tell mypy that `access_token`
-# is a Union[models31.AccessToken, models40.AccessToken] but it isn't.
-#
-# `isinstance(access_token, token_model)`
-#
-# hence the explicit tuple instead
 token_model_isinstances = models31.AccessToken, models40.AccessToken
-token_model: Union[Type[models31.AccessToken], Type[models40.AccessToken]]
-if constants.api_version == "3.1":
-    token_model = models31.AccessToken
-elif constants.api_version == "4.0":
-    token_model = models40.AccessToken
 
 
 class AuthSession:
@@ -58,17 +47,24 @@ class AuthSession:
         settings: api_settings.PApiSettings,
         transport: transport.Transport,
         deserialize: serialize.TDeserialize,
+        version: str,
     ):
         if not settings.is_configured():
             raise error.SDKError(
                 "Missing required configuration values like base_url and api_version."
             )
         self.settings = settings
-        self.user_token: auth_token.AuthToken = auth_token.AuthToken()
-        self.admin_token: auth_token.AuthToken = auth_token.AuthToken()
+        self.sudo_token: auth_token.AuthToken = auth_token.AuthToken()
+        self.token: auth_token.AuthToken = auth_token.AuthToken()
         self._sudo_id: Optional[int] = None
         self.transport = transport
         self.deserialize = deserialize
+        self.version = version
+        self.token_model: Union[Type[models31.AccessToken], Type[models40.AccessToken]]
+        if self.version == "3.1":
+            self.token_model = models31.AccessToken
+        elif self.version == "4.0":
+            self.token_model = models40.AccessToken
 
     def _is_authenticated(self, token: auth_token.AuthToken) -> bool:
         """Determines if current token is active."""
@@ -77,28 +73,24 @@ class AuthSession:
         return token.is_active
 
     @property
-    def is_user_authenticated(self) -> bool:
-        return self._is_authenticated(self.user_token)
+    def is_sudo_authenticated(self) -> bool:
+        return self._is_authenticated(self.sudo_token)
 
     @property
-    def is_admin_authenticated(self) -> bool:
-        return self._is_authenticated(self.admin_token)
+    def is_authenticated(self) -> bool:
+        return self._is_authenticated(self.token)
 
-    @property
-    def is_sudo(self) -> Optional[int]:
-        return self._sudo_id
+    def _get_sudo_token(self) -> auth_token.AuthToken:
+        """Returns an active sudo token."""
+        if not self.is_sudo_authenticated:
+            self._login_sudo()
+        return self.sudo_token
 
-    def _get_user_token(self) -> auth_token.AuthToken:
-        """Returns an active user token."""
-        if not self.is_user_authenticated:
-            self._login_user()
-        return self.user_token
-
-    def _get_admin_token(self) -> auth_token.AuthToken:
-        """Returns an active admin token."""
-        if not self.is_admin_authenticated:
-            self._login_admin()
-        return self.admin_token
+    def _get_token(self) -> auth_token.AuthToken:
+        """Returns an active token."""
+        if not self.is_authenticated:
+            self._login()
+        return self.token
 
     def authenticate(self) -> Dict[str, str]:
         """Return the Authorization header to authenticate each API call.
@@ -106,9 +98,9 @@ class AuthSession:
         Expired token renewal happens automatically.
         """
         if self._sudo_id:
-            token = self._get_user_token()
+            token = self._get_sudo_token()
         else:
-            token = self._get_admin_token()
+            token = self._get_token()
 
         return {"Authorization": f"Bearer {token.access_token}"}
 
@@ -122,7 +114,7 @@ class AuthSession:
         if self._sudo_id is None:
             self._sudo_id = sudo_id
             try:
-                self._login_user()
+                self._login_sudo()
             except error.SDKError:
                 self._sudo_id = None
                 raise
@@ -133,12 +125,12 @@ class AuthSession:
                     f"Another user ({self._sudo_id}) "
                     "is already logged in. Log them out first."
                 )
-            elif not self.is_user_authenticated:
-                self._login_user()
+            elif not self.is_sudo_authenticated:
+                self._login_sudo()
 
-    def _login_admin(self) -> None:
-        client_id = self.settings.get_client_id()
-        client_secret = self.settings.get_client_secret()
+    def _login(self) -> None:
+        client_id = self.settings.client_id
+        client_secret = self.settings.client_secret
         if not (client_id and client_secret):
             raise error.SDKError("Required auth credentials not found.")
 
@@ -152,80 +144,86 @@ class AuthSession:
         response = self._ok(
             self.transport.request(
                 transport.HttpMethod.POST,
-                "/login",
+                f"{self.settings.base_url}/api/login",
                 body=serialized,
                 headers={"Content-Type": "application/x-www-form-urlencoded"},
             )
         )
 
-        access_token = self.deserialize(data=response, structure=token_model)
+        # ignore type: mypy bug doesn't recognized kwarg `structure` to partial func
+        access_token = self.deserialize(
+            data=response, structure=self.token_model
+        )  # type: ignore
         assert isinstance(access_token, token_model_isinstances)
-        self.admin_token = auth_token.AuthToken(access_token)
+        self.token = auth_token.AuthToken(access_token)
 
-    def _login_user(self) -> None:
+    def _login_sudo(self) -> None:
         response = self._ok(
             self.transport.request(
                 transport.HttpMethod.POST,
-                f"/login/{self._sudo_id}",
+                f"{self.settings.base_url}/api/{self.version}/login/{self._sudo_id}",
                 authenticator=lambda: {
-                    "Authorization": f"Bearer {self._get_admin_token().access_token}"
+                    "Authorization": f"Bearer {self._get_token().access_token}"
                 },
             )
         )
-        access_token = self.deserialize(data=response, structure=token_model)
+        # ignore type: mypy bug doesn't recognized kwarg `structure` to partial func
+        access_token = self.deserialize(
+            data=response, structure=self.token_model
+        )  # type: ignore
         assert isinstance(access_token, token_model_isinstances)
-        self.user_token = auth_token.AuthToken(access_token)
+        self.sudo_token = auth_token.AuthToken(access_token)
 
     def logout(self, full: bool = False) -> None:
         """Logout cuurent session or all.
 
-        If the session is authenticated as sudo_id, logoout() "undoes"
+        If the session is authenticated as sudo_id, logout() "undoes"
         the sudo and deactivates that sudo_id's current token. By default
-        the current admin/api3credential session is active at which point
-        you can continue to make API calls as the admin/api3credential user
+        the current api3credential session is active at which point
+        you can continue to make API calls as the api3credential user
         or logout(). If you want to logout completely in one step pass
         full=True
         """
         if self._sudo_id:
             self._sudo_id = None
-            if self.is_user_authenticated:
-                self._logout_user()
+            if self.is_sudo_authenticated:
+                self._logout_sudo()
                 if full:
-                    self._logout_admin()
+                    self._logout()
 
-        elif self.is_admin_authenticated:
-            self._logout_admin()
+        elif self.is_authenticated:
+            self._logout()
 
-    def _logout_user(self) -> None:
+    def _logout_sudo(self) -> None:
         self._ok(
             self.transport.request(
                 transport.HttpMethod.DELETE,
-                "/logout",
+                f"{self.settings.base_url}/api/logout",
                 authenticator=lambda: {
-                    "Authorization": f"Bearer {self.user_token.access_token}"
+                    "Authorization": f"Bearer {self.sudo_token.access_token}"
                 },
             )
         )
-        self._reset_user_token()
+        self._reset_sudo_token()
 
-    def _logout_admin(self) -> None:
+    def _logout(self) -> None:
         self._ok(
             self.transport.request(
                 transport.HttpMethod.DELETE,
-                "/logout",
+                f"{self.settings.base_url}/api/logout",
                 authenticator=lambda: {
-                    "Authorization": f"Bearer {self.admin_token.access_token}"
+                    "Authorization": f"Bearer {self.token.access_token}"
                 },
             )
         )
 
-        self._reset_admin_token()
+        self._reset_token()
 
-    def _reset_admin_token(self) -> None:
-        self.admin_token = auth_token.AuthToken()
+    def _reset_token(self) -> None:
+        self.token = auth_token.AuthToken()
 
-    def _reset_user_token(self) -> None:
-        self.user_token = auth_token.AuthToken()
+    def _reset_sudo_token(self) -> None:
+        self.sudo_token = auth_token.AuthToken()
 
     def _ok(self, response: transport.Response) -> str:
         if not response.ok:

--- a/python/looker_sdk/rtl/requests_transport.py
+++ b/python/looker_sdk/rtl/requests_transport.py
@@ -69,7 +69,7 @@ class RequestsTransport(transport.Transport):
         timeout = self.settings.timeout
         if transport_options:
             timeout = transport_options.timeout
-        logging.info("%s(%s)", method.name, path)
+        self.logger.info("%s(%s)", method.name, path)
         try:
             resp = self.session.request(
                 method.name,

--- a/python/looker_sdk/rtl/requests_transport.py
+++ b/python/looker_sdk/rtl/requests_transport.py
@@ -28,7 +28,6 @@ from typing import cast, Callable, Dict, MutableMapping, Optional
 
 import requests
 
-from looker_sdk.rtl import constants
 from looker_sdk.rtl import transport
 
 
@@ -40,14 +39,12 @@ class RequestsTransport(transport.Transport):
         self, settings: transport.PTransportSettings, session: requests.Session
     ):
         self.settings = settings
-        headers: Dict[str, str] = {"x-looker-appid": f"PY-SDK {constants.sdk_version}"}
+        headers: Dict[str, str] = {transport.LOOKER_API_ID: settings.agent_tag}
         if settings.headers:
             headers.update(settings.headers)
         session.headers.update(headers)
         session.verify = settings.verify_ssl
         self.session = session
-        base_url = settings.base_url.strip("/")
-        self.api_path: str = f"{base_url}/api/{settings.api_version}"
         self.logger = logging.getLogger(__name__)
 
     @classmethod
@@ -65,7 +62,6 @@ class RequestsTransport(transport.Transport):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> transport.Response:
 
-        url = f"{self.api_path}{path}"
         if headers is None:
             headers = {}
         if authenticator:
@@ -73,11 +69,11 @@ class RequestsTransport(transport.Transport):
         timeout = self.settings.timeout
         if transport_options:
             timeout = transport_options.timeout
-        logging.info("%s(%s)", method.name, url)
+        logging.info("%s(%s)", method.name, path)
         try:
             resp = self.session.request(
                 method.name,
-                url,
+                path,
                 auth=NullAuth(),
                 params=query_params,
                 data=body,

--- a/python/looker_sdk/rtl/transport.py
+++ b/python/looker_sdk/rtl/transport.py
@@ -38,6 +38,10 @@ else:
     from typing_extensions import Protocol
 
 
+AGENT_PREFIX = "PY SDK"
+LOOKER_API_ID = "x-looker-appid"
+
+
 class HttpMethod(enum.Enum):
     """Supported HTTP verbs.
     """
@@ -53,28 +57,13 @@ class HttpMethod(enum.Enum):
 
 class PTransportSettings(Protocol):
     base_url: str
-    api_version: str
     verify_ssl: bool
     timeout: int
+    agent_tag: str
     headers: Optional[MutableMapping[str, str]]
 
     def is_configured(self) -> bool:
-        ...
-
-
-@attr.s(auto_attribs=True, kw_only=True)
-class TransportSettings:
-    """Basic transport settings.
-    """
-
-    base_url: str = ""
-    api_version: str = ""
-    verify_ssl: bool = True
-    timeout: int = 120
-    headers: Optional[MutableMapping[str, str]] = None
-
-    def is_configured(self) -> bool:
-        return bool(self.base_url and self.api_version)
+        return bool(self.base_url)
 
 
 TAuthenticator = Optional[Callable[[], Dict[str, str]]]


### PR DESCRIPTION
Make the python ApiSettings conform to the other sdks: instance properties/members will be the properties declared on `PTransportSettings` and `readConfig` will produce a dictionary with keys corresponding to further settings that `AuthSession` needs

I also refactored AuthSession to remove references to "admin" and
substituted "user" with "sudo" and DRY'ed out some logout code there.