### PR TITLE
Python OAuth session support

### DIFF
--- a/python/looker_sdk/rtl/auth_token.py
+++ b/python/looker_sdk/rtl/auth_token.py
@@ -44,6 +44,7 @@ class AuthToken:
         self, token: Optional[Union[models31.AccessToken, models40.AccessToken]] = None
     ):
         self.access_token: str = ""
+        self.refresh_token: str = ""
         self.token_type: str = ""
         self.expires_in: int = 0
         self.expires_at = datetime.datetime.now()
@@ -54,6 +55,8 @@ class AuthToken:
     def set_token(self, token: Union[models31.AccessToken, models40.AccessToken]):
         """Assign the token and set its expiration."""
         self.access_token = token.access_token or ""
+        if isinstance(token, models40.AccessToken):
+            self.refresh_token = token.refresh_token or ""
         self.token_type = token.token_type or ""
         self.expires_in = token.expires_in or 0
 


### PR DESCRIPTION
Added OAuth session whose `_login` method calls `/api/token` with a
`refresh_token` grant_type. This assumes that you've set `self.token` with
an access token that has a `refresh_token`. We've provided a convenience
function to do this: `redeem_auth_code` which takes a temporary code
you've been given (see below) and calls `/api/token` with an
`authorization_code` grant_type.

In order to get the temporary code you must ask the authorization server
for it which will usually require a login, a redirect to authorize the
access, and then a final redirect to the location you supplied in the
initial request with a `code` query string parameter. For Looker
authorization we've provided another convenience function:
`create_auth_code_request_url` which will construct a URL with the
appropriate query string parameters to the Looker authorization server.

PS tests/integration/api40/test_methods.py tests are broken because the
spec changed. The failing tests are not related to this change. I'll
open a separate PR to fix them