### PR TITLE
Use correct /login endpoint

### DIFF
--- a/python/looker_sdk/rtl/auth_session.py
+++ b/python/looker_sdk/rtl/auth_session.py
@@ -148,7 +148,7 @@ class AuthSession:
         response = self._ok(
             self.transport.request(
                 transport.HttpMethod.POST,
-                f"{self.settings.base_url}/api/login",
+                f"{self.settings.base_url}/api/{self.version}/login",
                 body=serialized,
                 headers={"Content-Type": "application/x-www-form-urlencoded"},
             )


### PR DESCRIPTION
/api/login requires auth prior to 7.4
/api/x.y/login is the correct endpoint to use

fixes #217