### PR TITLE
Python: better config file handling

### DIFF
--- a/python/looker_sdk/rtl/api_settings.py
+++ b/python/looker_sdk/rtl/api_settings.py
@@ -43,10 +43,13 @@ class PApiSettings(transport.PTransportSettings, Protocol):
         ...
 
 
+_DEFAULT_INI = "looker.ini"
+
+
 class ApiSettings(PApiSettings):
     deprecated_settings: Set[str] = {"api_version", "embed_secret", "user_id"}
 
-    def __init__(self, filename: str = "looker.ini", section: Optional[str] = None):
+    def __init__(self, filename: str = _DEFAULT_INI, section: Optional[str] = None):
         """Configure using a config file and/or environment variables.
 
         Environment variables will override config file settings. Neither
@@ -56,6 +59,13 @@ class ApiSettings(PApiSettings):
         ENV variables map like this:
             <package-prefix>_BASE_URL -> base_url
             <package-prefix>_VERIFY_SSL -> verify_ssl
+
+        Args:
+            filename (str): config file. If specified, the file must exist.
+                If not specified and the default value of "looker.ini" does not
+                exist then no error is raised.
+            section (str): section in config file. If not supplied default to
+                reading first section.
         """
         self.filename = filename
         self.section = section
@@ -74,12 +84,21 @@ class ApiSettings(PApiSettings):
         cfg_parser = cp.ConfigParser()
         try:
             config_file = open(self.filename)
-        except FileNotFoundError:
-            data: Dict[str, str] = {}
+        except FileNotFoundError as ex:
+            # handle undocumented case of caller specifying empty string
+            # to "explicitly" negate config file. best practice is to
+            # simply not specify a filename argument to the constructor
+            if self.filename == _DEFAULT_INI or not self.filename:
+                data: Dict[str, str] = {}
+            else:
+                raise ex
         else:
             cfg_parser.read_file(config_file)
+            config_file.close()
             # If section is not specified, use first section in file
             section = self.section or cfg_parser.sections()[0]
+            if not cfg_parser.has_section(section):
+                raise cp.NoSectionError(section)
             data = dict(cfg_parser[section])
 
         data.update(self._override_from_env())

--- a/python/tests/rtl/test_auth_session.py
+++ b/python/tests/rtl/test_auth_session.py
@@ -31,15 +31,16 @@ from looker_sdk.rtl import serialize
 from looker_sdk.rtl import transport
 
 
-@pytest.fixture(scope="module")
-def config_file(tmpdir_factory):
+@pytest.fixture(scope="function")
+def config_file(tmpdir_factory, monkeypatch):
     """Creates a sample looker.ini file and returns it"""
+    # make sure test is only using these settings
+    for setting in ["BASE_URL", "CLIENT_ID", "CLIENT_SECRET"]:
+        monkeypatch.delenv(f"LOOKERSDK_{setting}", raising=False)
     filename = tmpdir_factory.mktemp("settings").join("looker.ini")
     filename.write(
         """
 [Looker]
-# API version is required
-api_version=3.1
 # Base URL for API. Do not include /api/* in the url
 base_url=https://host1.looker.com:19999
 # API 3 client id


### PR DESCRIPTION
raise NotFoundFileError when specifying a config file that does not
exist (defaulting to "looker.ini" will not raise).

raise configparser.NoSectionError error for bad section

better docstring describing usage

fixes #218