### PR TITLE
Cleaner use of Kotlin's JsonProperty attribute

### DIFF
--- a/packages/sdk-codegen/src/kotlin.gen.spec.ts
+++ b/packages/sdk-codegen/src/kotlin.gen.spec.ts
@@ -75,12 +75,12 @@ enum class PermissionType : Serializable {
   /**
    * A hyphenated property name (read-only)
    */
-  @param:JsonProperty("project-digest") @get:JsonProperty("project-digest")
+  @JsonProperty("project-digest")
   var project_digest: String? = null,
   /**
    * A spaced out property name (read-only)
    */
-  @param:JsonProperty("computation time") @get:JsonProperty("computation time")
+  @JsonProperty("computation time")
   var computation_time: Float? = null
 ) : Serializable`
       expect(actual).toEqual(expected)

--- a/packages/sdk-codegen/src/kotlin.gen.ts
+++ b/packages/sdk-codegen/src/kotlin.gen.ts
@@ -148,7 +148,7 @@ import java.util.*
     const optional = !property.required ? '? = null' : ''
     const type = this.typeMap(property.type)
     const attr = property.hasSpecialNeeds
-      ? `${indent}@param:JsonProperty("${property.jsonName}") @get:JsonProperty("${property.jsonName}")\n`
+      ? `${indent}@JsonProperty("${property.jsonName}")\n`
       : ''
     return (
       this.commentHeader(indent, this.describeProperty(property)) +


### PR DESCRIPTION
One attribute to rule them all