### PR TITLE
Implementing 10 second lag time expiration check

### DIFF
--- a/csharp/rtl.Tests/AuthTokenTests.cs
+++ b/csharp/rtl.Tests/AuthTokenTests.cs
@@ -39,5 +39,35 @@ namespace sdkrtl.Tests
             Assert.Equal(token.token_type, actual.token_type);
             Assert.True(actual.IsActive());
         }
+        
+        /// <summary>
+        /// Verify 10 second lag time is in effect
+        /// </summary>
+        [Fact]
+        public void LagTimeTest()
+        {
+            var token = new AccessToken
+            {
+                access_token = "all-access",
+                expires_in = 9,
+                token_type = "backstage"
+            };
+            var actual = new AuthToken(token);
+            Assert.Equal(token.access_token, actual.access_token);
+            Assert.Equal(token.expires_in, actual.expires_in);
+            Assert.Equal(token.token_type, actual.token_type);
+            Assert.False(actual.IsActive());
+            token = new AccessToken
+            {
+                access_token = "all-access",
+                expires_in = 11,
+                token_type = "backstage"
+            };
+            actual = new AuthToken(token);
+            Assert.Equal(token.access_token, actual.access_token);
+            Assert.Equal(token.expires_in, actual.expires_in);
+            Assert.Equal(token.token_type, actual.token_type);
+            Assert.True(actual.IsActive());
+        }
     }
 }

--- a/csharp/rtl/ApiSettings.cs
+++ b/csharp/rtl/ApiSettings.cs
@@ -69,16 +69,26 @@ namespace Looker.RTL
         public IValues ReadConfig(string sectionName = null)
         {
             var parser = new FileIniDataParser();
-            var data = parser.ReadFile(FileName);
-            sectionName ??= SectionName;
-            var section = data[sectionName];
             IValues result = new Values();
-            foreach (var pair in section)
+            if (File.Exists(FileName))
             {
-                result[pair.KeyName] = pair.Value;
+                var data = parser.ReadFile(FileName);
+                sectionName ??= SectionName;
+                var section = data[sectionName];
+                // TODO: figure out how to make section.toDictionary() work
+                foreach (var pair in section)
+                {
+                    result[pair.KeyName] = pair.Value;
+                }
+            }
+            else
+            {
+                result["agentTag"] = AgentTag;
+                result["base_url"] = BaseUrl;
+                result["timeout"] = Timeout;
+                result["verify_ssl"] = VerifySsl;
             }
 
-            // TODO: figure out how to make section.toDictionary() work
             return result;
         }
 

--- a/csharp/rtl/AuthToken.cs
+++ b/csharp/rtl/AuthToken.cs
@@ -33,6 +33,7 @@ namespace Looker.RTL
     /// </summary>
     public class AuthToken: IAccessToken
     {
+        private static long lagTime = 10;
         public string? access_token { get; set; }
         public string? token_type { get; set; }
 
@@ -40,7 +41,7 @@ namespace Looker.RTL
 
         public string? refresh_token { get; set; }
         // Give a 10 second expiration window to account for latency
-        public DateTime ExpiresAt { get; set; } = DateTime.Now.AddSeconds(-10);
+        public DateTime ExpiresAt { get; set; } = DateTime.Now.AddSeconds(-lagTime);
 
         public AuthToken() { }
 
@@ -66,9 +67,8 @@ namespace Looker.RTL
             }
 
             expires_in = token.expires_in;
-            if (token.access_token.IsNullOrEmpty()) return;
             access_token = token.access_token;
-            ExpiresAt = ExpiresAt.AddSeconds(expires_in);
+            ExpiresAt = DateTime.Now.AddSeconds(expires_in > 0 ? expires_in - lagTime : -lagTime);
         }
 
         /// <summary>
@@ -88,7 +88,7 @@ namespace Looker.RTL
         {
             access_token = null;
             expires_in = 0;
-            ExpiresAt = DateTime.Now.AddSeconds(-10);
+            ExpiresAt = DateTime.Now.AddSeconds(-lagTime);
             return this;
         }
     }

--- a/kotlin/src/main/com/looker/rtl/AuthToken.kt
+++ b/kotlin/src/main/com/looker/rtl/AuthToken.kt
@@ -39,14 +39,14 @@ data class AuthToken(
         var refreshToken: String? = null) {
 
     var expiresAt: LocalDateTime = LocalDateTime.now()
+    /** Lag time of 10 seconds */
+    val lagTime: Long = 10
 
 //    constructor(token: AuthToken) : this(token.accessToken, token.tokenType, token.expiresIn, token.expiresAt, token.refreshToken)
     constructor(token: AccessToken) : this(token.access_token!!, token.token_type!!, token.expires_in!!.toLong(), token.refresh_token)
 
     init {
-        if (expiresIn > 0) {
-            expiresAt = LocalDateTime.now().plusSeconds(expiresIn)
-        }
+        expiresAt = LocalDateTime.now().plusSeconds(if (expiresIn > 0) expiresIn - lagTime else -lagTime)
     }
 
     fun isActive(): Boolean {

--- a/kotlin/src/test/TestAuthToken.kt
+++ b/kotlin/src/test/TestAuthToken.kt
@@ -55,6 +55,28 @@ class TestAuthToken {
     }
 
     @test
+    fun has10SecondLag() {
+        var actual = AuthToken(
+                accessToken = "all-access",
+                tokenType = "backstage",
+                expiresIn = 9
+        )
+
+        assertEquals(actual.accessToken, "all-access")
+        assertEquals(actual.tokenType, "backstage")
+        assertEquals(actual.expiresIn, 9)
+        assertEquals(actual.isActive(), false)
+        actual = AuthToken(
+                accessToken = "all-access",
+                tokenType = "backstage",
+                expiresIn = 11
+        )
+
+        assertEquals(actual.expiresIn, 11)
+        assertEquals(actual.isActive(), true)
+    }
+
+    @test
     fun setTokenWithFullAccessToken() {
         val testToken = AuthToken("accessToken", "type", 3600, "refreshToken")
         val updatedAccessToken = AccessToken("newAccess", "newType", 7200, "newRefresh")

--- a/packages/sdk/src/rtl/authToken.spec.ts
+++ b/packages/sdk/src/rtl/authToken.spec.ts
@@ -46,4 +46,23 @@ describe('AccessToken', () => {
     expect(actual.expires_in).toEqual(3600)
     expect(actual.isActive()).toEqual(true)
   })
+
+  it('has a 10 second lag time for expiration', () => {
+    let actual = new AuthToken({
+      access_token: 'all-access',
+      expires_in: 9,
+      token_type: 'backstage',
+    })
+    expect(actual.access_token).toEqual('all-access')
+    expect(actual.token_type).toEqual('backstage')
+    expect(actual.expires_in).toEqual(9)
+    expect(actual.isActive()).toEqual(false)
+    actual = new AuthToken({
+      access_token: 'all-access',
+      expires_in: 11,
+      token_type: 'backstage',
+    })
+    expect(actual.expires_in).toEqual(11)
+    expect(actual.isActive()).toEqual(true)
+  })
 })

--- a/packages/sdk/src/rtl/authToken.ts
+++ b/packages/sdk/src/rtl/authToken.ts
@@ -27,6 +27,8 @@
 import { IAccessToken } from '../sdk/4.0/models'
 
 export class AuthToken implements IAccessToken {
+  /** set the server response lag time to 10 seconds */
+  lagTime = 10
   access_token = ''
   token_type = ''
   refresh_token?: string
@@ -58,9 +60,9 @@ export class AuthToken implements IAccessToken {
     }
     const exp = new Date()
     if (this.access_token && this.expires_in) {
-      exp.setSeconds(exp.getSeconds() + this.expires_in)
+      exp.setSeconds(exp.getSeconds() + this.expires_in - this.lagTime)
     } else {
-      exp.setSeconds(exp.getSeconds() - 10) // set to expire 10 seconds ago
+      exp.setSeconds(exp.getSeconds() - this.lagTime) // set to expire 'lagTime' ago
     }
     this.expiresAt = exp
     return this

--- a/python/looker_sdk/rtl/auth_token.py
+++ b/python/looker_sdk/rtl/auth_token.py
@@ -43,11 +43,12 @@ class AuthToken:
     def __init__(
         self, token: Optional[Union[models31.AccessToken, models40.AccessToken]] = None
     ):
+        self.lag_time = 10
         self.access_token: str = ""
         self.refresh_token: str = ""
         self.token_type: str = ""
         self.expires_in: int = 0
-        self.expires_at = datetime.datetime.now()
+        self.expires_at = datetime.datetime.now() + datetime.timedelta(seconds=-self.lag_time)
         if token is None:
             token = token_model()
         self.set_token(token)
@@ -60,14 +61,10 @@ class AuthToken:
         self.token_type = token.token_type or ""
         self.expires_in = token.expires_in or 0
 
-        exp = datetime.datetime.now()
-
+        lag = datetime.timedelta(seconds=-self.lag_time)
         if token.access_token and token.expires_in:
-            exp = exp + datetime.timedelta(seconds=token.expires_in)
-        else:
-            # set to expire 10 seconds ago
-            exp = exp + datetime.timedelta(seconds=-10)
-        self.expires_at = exp
+            lag = datetime.timedelta(seconds=token.expires_in - self.lag_time)
+        self.expires_at = datetime.datetime.now() + lag
 
     @property
     def is_active(self) -> bool:

--- a/python/tests/rtl/test_auth_token.py
+++ b/python/tests/rtl/test_auth_token.py
@@ -46,3 +46,26 @@ def test_is_active_with_full_token():
     assert actual.token_type == "backstage"
     assert actual.expires_in == 3600
     assert actual.is_active is True
+
+
+def test_lag_time_is_used():
+    """Confirm active token when expiration is > lag time."""
+    actual = auth_token.AuthToken(
+        models.AccessToken(
+            access_token="all-access", token_type="backstage", expires_in=9
+        )
+    )
+
+    assert actual.access_token == "all-access"
+    assert actual.token_type == "backstage"
+    assert actual.expires_in == 9
+    assert actual.is_active is False
+
+    actual = auth_token.AuthToken(
+        models.AccessToken(
+            access_token="all-access", token_type="backstage", expires_in=11
+        )
+    )
+
+    assert actual.expires_in == 11
+    assert actual.is_active is True

--- a/swift/looker/Tests/lookerTests/authTokenTests.swift
+++ b/swift/looker/Tests/lookerTests/authTokenTests.swift
@@ -40,4 +40,11 @@ class authTokenTests: XCTestCase {
         }
     }
     
+    func testLagTime() {
+        var actual = AuthToken(AccessToken(access_token: "thisismytoken", token_type: "Bearer", expires_in: 9))
+        XCTAssertEqual(actual.isActive(), false, "9 seconds should be inactive")
+        actual = AuthToken(AccessToken(access_token: "thisismytoken", token_type: "Bearer", expires_in: 11))
+        XCTAssertEqual(actual.isActive(), true, "11 seconds should be inactive")
+
+    }
 }

--- a/swift/looker/rtl/authToken.swift
+++ b/swift/looker/rtl/authToken.swift
@@ -38,6 +38,8 @@ protocol AccessTokenProtocol {
 //}
 
 struct AuthToken: AccessTokenProtocol, Codable {
+    /// Lag time is 10 seconds
+    static let lagTime = 10
     var access_token: String = ""
     var token_type: String = ""
     var expires_in: Int64 = 0
@@ -59,7 +61,7 @@ struct AuthToken: AccessTokenProtocol, Codable {
     }
     
     static func expiryDate(_ inSeconds: Int) -> Date {
-        let interval = inSeconds > 0 ? inSeconds : -10
+        let interval = inSeconds > 0 ? inSeconds - lagTime : -lagTime
         return Date.init(timeIntervalSinceNow: TimeInterval(interval))
     }
     


### PR DESCRIPTION
Applied 10 second lag time to all existing `AuthToken` implementations

- also fixed missing `looker.ini` crash bug for Look#'s `ApiSettings.ReadConfig()`

Closes #223 