### PR TITLE
Track parent type for properties that are custom types

### DIFF
--- a/packages/sdk-codegen/src/sdkModels.ts
+++ b/packages/sdk-codegen/src/sdkModels.ts
@@ -389,6 +389,11 @@ export interface IType extends ISymbol {
   customTypes: KeyList
 
   /**
+   * Names of custom types that have a property of this type
+   */
+  parentTypes: KeyList
+
+  /**
    * Hopefully temporary concession to build problems with instance of ArrayType checks etc failing
    */
   className: string
@@ -1343,6 +1348,7 @@ export class Type implements IType {
   readonly methodRefs: KeyList = new Set<string>()
   readonly types: KeyList = new Set<string>()
   readonly customTypes: KeyList = new Set<string>()
+  readonly parentTypes: KeyList = new Set<string>()
   description: string
   customType: string
   jsonName = ''
@@ -1432,9 +1438,12 @@ export class Type implements IType {
     Object.entries(this.schema.properties || {}).forEach(
       ([propName, propSchema]) => {
         const propType = api.resolveType(propSchema, undefined, propName)
-        if (propType.className === 'EnumType') {
+        // Using class name instead of instanceof check because Typescript linting complains about declaration order
+        if (propType.instanceOf('EnumType')) {
           api.registerEnum(propType, propName)
         }
+        // Track the "parent" reference for this type from the property reference
+        propType.parentTypes.add(this.name)
         this.types.add(propType.name)
         const customType = propType.customType
         if (customType) this.customTypes.add(customType)
@@ -1956,8 +1965,7 @@ export class ApiModel implements ISymbolTable, IApiModel {
 
   registerEnum(type: IType, typeName?: string, methodName?: string) {
     if (!(type instanceof EnumType)) return type
-    const num = type as EnumType
-    const hash = md5(num.asHashString())
+    const hash = md5(type.asHashString())
 
     if (hash in this.enumTypes) {
       /**
@@ -1981,6 +1989,11 @@ export class ApiModel implements ISymbolTable, IApiModel {
     }
     if (methodName) {
       type.description = `Type defined in ${methodName}\n${type.description}`
+      const method = this.methods[methodName]
+      if (method) {
+        method.types.add(type.name)
+        method.customTypes.add(type.name)
+      }
     }
     this.enumTypes[hash] = type
     this.types[type.name] = type
@@ -2045,6 +2058,7 @@ export class ApiModel implements ISymbolTable, IApiModel {
     if (!result) result = this.makeWriteableType(hash, type)
     type.types.add(result.name)
     type.customTypes.add(result.name)
+    result.parentTypes.add(type.name)
     return result
   }
 
@@ -2077,10 +2091,11 @@ export class ApiModel implements ISymbolTable, IApiModel {
     // this.requestTypes = this.sortList(this.requestTypes)
     // this.refs = this.sortList(this.refs)
     this.tags = this.sortList(this.tags)
-    const keys = Object.keys(this.tags).sort(localeSort)
-    keys.forEach((key) => {
-      this.tags[key] = this.sortList(this.tags[key])
-    })
+    // commented out to leave methods in natural order within the tag
+    // const keys = Object.keys(this.tags).sort(localeSort)
+    // keys.forEach((key) => {
+    //   this.tags[key] = this.sortList(this.tags[key])
+    // })
   }
 
   private load(): void {

--- a/packages/sdk/src/rtl/browserSession.spec.ts
+++ b/packages/sdk/src/rtl/browserSession.spec.ts
@@ -29,6 +29,8 @@ import { BrowserSession } from './browserSession'
 import { IApiSettings } from './apiSettings'
 import { IRequestProps, ITransport } from './transport'
 import { AuthSession } from './authSession'
+import { AuthToken } from './authToken'
+import { MockOauthSettings } from './oauthSession.spec'
 
 const mockToken: IAccessToken = {
   access_token: 'mocked',
@@ -36,22 +38,24 @@ const mockToken: IAccessToken = {
   token_type: 'Bearer',
 }
 
+const settings = new MockOauthSettings()
+
 /**
- * Mocking class for CorsSession getToken() tests
+ * Mocking class for BrowserSession getToken() tests
  */
-class CorsMock extends BrowserSession {
+class BrowserSessionMock extends BrowserSession {
   constructor(public settings: IApiSettings, transport?: ITransport) {
     super(settings, transport)
   }
 
   async getToken() {
-    return Promise.resolve(mockToken)
+    return Promise.resolve(new AuthToken(mockToken))
   }
 }
 
-describe('CORS session', () => {
+describe('Browser session', () => {
   it('initialization', async () => {
-    const mock = new CorsMock({} as IApiSettings)
+    const mock = new BrowserSessionMock(settings)
     await expect(mock.login()).rejects.toEqual(AuthSession.TBD)
     expect(mock.isAuthenticated()).toEqual(false)
     expect(mock.isSudo()).toEqual(false)
@@ -60,13 +64,13 @@ describe('CORS session', () => {
   })
 
   it('getToken is mocked', async () => {
-    const mock = new CorsMock({} as IApiSettings)
+    const mock = new BrowserSessionMock(settings)
     const token = await mock.getToken()
     expect(token).toEqual(mockToken)
   })
 
   it('authenticate causes authentication', async () => {
-    const mock = new CorsMock({} as IApiSettings)
+    const mock = new BrowserSessionMock(settings)
     expect(mock.isAuthenticated()).toEqual(false)
     const props = await mock.authenticate({} as IRequestProps)
     expect(mock.isAuthenticated()).toEqual(true)


### PR DESCRIPTION
- added `IType.parentTypes: KeyList` for types referenced in an `IType` properties collection
- Also restored preserving methods in "natural order" for spec tags/categories