### PR TITLE
Lerna ES build watcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "test:ts": "yarn jest --reporters=default --reporters=jest-junit",
     "test:iphone": "xcodebuild test -project swift/looker/looker.xcodeproj -scheme looker-Package -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 11,OS=13.4.1' | xcpretty --test --color",
     "test:jest": "DOT_ENV_FILE=.env.test jest",
-    "bootstrap": "lerna clean -y && lerna bootstrap"
+    "bootstrap": "lerna clean -y && lerna bootstrap",
+    "watch": "lerna run --parallel watch"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",

--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "test": "jest",
-    "bundle": "tsc && webpack --config webpack.prod.config.js",
+    "build": "tsc && webpack --config webpack.prod.config.js",
     "develop": "webpack-dev-server --https --disable-host-check --config webpack.dev.config.js",
     "docs": "typedoc --mode file --out docs",
     "register": "ts-node -O '{ \"module\": \"commonjs\", \"target\": \"es2019\" }' scripts/register.ts",

--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "test": "jest",
     "develop": "webpack-dev-server --https --disable-host-check --config webpack.dev.config.js",
+    "watch": "yarn lerna exec --scope @looker/api-explorer --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib --source-maps --extensions .ts,.tsx --no-comments --watch'",
     "package": "tsc && webpack --config webpack.prod.config.js",
     "docs": "typedoc --mode file --out docs",
     "register": "ts-node -O '{ \"module\": \"commonjs\", \"target\": \"es2019\" }' scripts/register.ts"

--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -17,11 +17,11 @@
   },
   "scripts": {
     "test": "jest",
+    "bundle": "tsc && webpack --config webpack.prod.config.js",
     "develop": "webpack-dev-server --https --disable-host-check --config webpack.dev.config.js",
-    "watch": "yarn lerna exec --scope @looker/api-explorer --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib --source-maps --extensions .ts,.tsx --no-comments --watch'",
-    "package": "tsc && webpack --config webpack.prod.config.js",
     "docs": "typedoc --mode file --out docs",
-    "register": "ts-node -O '{ \"module\": \"commonjs\", \"target\": \"es2019\" }' scripts/register.ts"
+    "register": "ts-node -O '{ \"module\": \"commonjs\", \"target\": \"es2019\" }' scripts/register.ts",
+    "watch": "yarn lerna exec --scope @looker/api-explorer --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib --source-maps --extensions .ts,.tsx --no-comments --watch'"
   },
   "devDependencies": {
     "@looker/components-test-utils": "^0.7.36",

--- a/packages/extension-api-explorer/package.json
+++ b/packages/extension-api-explorer/package.json
@@ -5,9 +5,9 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "develop": "webpack-dev-server --hot --disable-host-check --port 8080 --https --config webpack.dev.config.js",
-    "package": "tsc && webpack --config webpack.prod.config.js",
+    "bundle": "tsc && webpack --config webpack.prod.config.js",
     "deploy": "bin/deploy",
+    "develop": "webpack-dev-server --hot --disable-host-check --port 8080 --https --config webpack.dev.config.js",
     "watch": "yarn lerna exec --scope @looker/extension-api-explorer --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib --source-maps --extensions .ts,.tsx --no-comments --watch'"
   },
   "dependencies": {

--- a/packages/extension-api-explorer/package.json
+++ b/packages/extension-api-explorer/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "develop": "webpack-dev-server --hot --disable-host-check --port 8080 --https --config webpack.dev.config.js",
     "package": "tsc && webpack --config webpack.prod.config.js",
-    "deploy": "bin/deploy"
+    "deploy": "bin/deploy",
+    "watch": "yarn lerna exec --scope @looker/extension-api-explorer --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib --source-maps --extensions .ts,.tsx --no-comments --watch'"
   },
   "dependencies": {
     "@looker/api-explorer": "^0.1.0-alpha",

--- a/packages/sdk-codegen-scripts/package.json
+++ b/packages/sdk-codegen-scripts/package.json
@@ -23,7 +23,9 @@
   "homepage": "https://github.com/looker-open-source/sdk-codegen/",
   "private": false,
   "scripts": {
-    "docs": "typedoc --mode file --out docs"
+    "docs": "typedoc --mode file --out docs",
+    "watch": "yarn lerna exec --scope @looker/sdk-codegen-scripts --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib --source-maps --extensions .ts,.tsx --no-comments --watch'"
+
   },
   "dependencies": {
     "@looker/sdk": "^0.3.3-alpha.0",

--- a/packages/sdk-codegen-utils/package.json
+++ b/packages/sdk-codegen-utils/package.json
@@ -26,6 +26,9 @@
     "SDK",
     "codegen"
   ],
+  "scripts": {
+    "watch": "yarn lerna exec --scope @looker/sdk-codegen-utils --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib --source-maps --extensions .ts,.tsx --no-comments --watch'"
+  },
   "resolutions": {
     "typescript": "3.8.2"
   }

--- a/packages/sdk-codegen/package.json
+++ b/packages/sdk-codegen/package.json
@@ -27,7 +27,8 @@
     "codegen"
   ],
   "scripts": {
-    "docs": "typedoc --mode file --out docs"
+    "docs": "typedoc --mode file --out docs",
+    "watch": "yarn lerna exec --scope @looker/sdk-codegen --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib --source-maps --extensions .ts,.tsx --no-comments --watch'"
   },
   "dependencies": {
     "@looker/sdk": "^0.3.3-alpha.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -19,7 +19,8 @@
   "author": "Looker",
   "license": "MIT",
   "scripts": {
-    "docs": "typedoc --mode file --out docs"
+    "docs": "typedoc --mode file --out docs",
+    "watch": "yarn lerna exec --scope @looker/sdk --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib --source-maps --extensions .ts,.tsx --no-comments --watch'"
   },
   "bugs": {
     "url": "https://github.com/looker-open-source/sdk-codegen/issues"

--- a/packages/try-it/package.json
+++ b/packages/try-it/package.json
@@ -19,7 +19,8 @@
     "url": "https://github.com/looker-open-source/sdk-codegen/issues"
   },
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "watch": "yarn lerna exec --scope @looker/try-it --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib --source-maps --extensions .ts,.tsx --no-comments --watch'"
   },
   "devDependencies": {
     "@looker/components-test-utils": "^0.7.36",


### PR DESCRIPTION
Added a "watch" script that runs Babel in watch mode for all packages for a more pleasant development experience. 

Unfortunately I couldn't find a good way to also run `tsc -b tsconfig.build.json` in parallel so type errors presented during development might be false positives. On the other hand this is not very important since types don't matter at runtime, the pre-commit hook will flag and prevent them from being checked in and so does `yarn build`.

Also, naming is hard and I was torn between `watch` and `build:watch` for this script. Let me know if you have a preference.