### PR TITLE
Python SDK safe enum deserialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,9 @@
       "@typescript-eslint/no-explicit-any": "off",
       "@typescript-eslint/camelcase": "off",
       "@typescript-eslint/interface-name-prefix": "off",
-      "@typescript-eslint/no-unused-vars": "warn",
+      "@typescript-eslint/no-unused-vars": [
+        "warn", {"args": "all", "argsIgnorePattern": "^_"}
+      ],
       "sort-keys-fix/sort-keys-fix": "off",
       "no-useless-constructor": "off",
       "@typescript-eslint/no-empty-interface": "off",

--- a/packages/sdk-codegen/src/python.gen.spec.ts
+++ b/packages/sdk-codegen/src/python.gen.spec.ts
@@ -672,7 +672,11 @@ class PermissionType(enum.Enum):
 
     """
     view = "view"
-    edit = "edit"`
+    edit = "edit"
+    invalid_api_enum_value = "invalid_api_enum_value"
+
+
+PermissionType.__new__ = model.safe_enum__new__`
       expect(actual).toEqual(expected)
     })
 

--- a/packages/sdk-codegen/src/python.gen.ts
+++ b/packages/sdk-codegen/src/python.gen.ts
@@ -291,6 +291,17 @@ ${this.hooks.join('\n')}
     return `${indent}self.${propName} = ${propName}`
   }
 
+  declareType(indent: string, type: IType) {
+    let decl = super.declareType(indent, type)
+    if (type instanceof EnumType) {
+      const invalid =
+        'invalid_api_enum_value = "invalid_api_enum_value"' +
+        `\n\n\n${type.name}.__new__ = model.safe_enum__new__`
+      decl += `\n${this.bumper(indent)}${invalid}`
+    }
+    return decl
+  }
+
   typeProperties(type: IType) {
     return Object.values(type.requiredProperties).concat(
       Object.values(type.optionalProperties)

--- a/python/looker_sdk/rtl/model.py
+++ b/python/looker_sdk/rtl/model.py
@@ -35,6 +35,20 @@ class Model:
     """
 
 
+def safe_enum__new__(cls, value):
+    """Handle out-of-spec enum values returned by API.
+
+    This is achieved by overriding the __new__ method to return
+    `invalid_api_enum_value` (defined on each subclass) when an
+    unexpected value for the enum is returned by the API.
+    """
+    if not isinstance(value, str):
+        return super().__new__(cls, value)
+    else:
+        vals = {v.value: v for v in cls.__members__.values()}
+        return vals.get(value, cls.invalid_api_enum_value)
+
+
 T = TypeVar("T")
 
 

--- a/python/looker_sdk/sdk/api31/models.py
+++ b/python/looker_sdk/sdk/api31/models.py
@@ -75,6 +75,10 @@ class Align(enum.Enum):
 
     left = "left"
     right = "right"
+    invalid_api_enum_value = "invalid_api_enum_value"
+
+
+Align.__new__ = model.safe_enum__new__
 
 
 @attr.s(auto_attribs=True, init=False)
@@ -207,6 +211,10 @@ class Category(enum.Enum):
     filter = "filter"
     measure = "measure"
     dimension = "dimension"
+    invalid_api_enum_value = "invalid_api_enum_value"
+
+
+Category.__new__ = model.safe_enum__new__
 
 
 @attr.s(auto_attribs=True, init=False)
@@ -2639,6 +2647,10 @@ class DependencyStatus(enum.Enum):
     lock_required = "lock_required"
     lock_error = "lock_error"
     install_none = "install_none"
+    invalid_api_enum_value = "invalid_api_enum_value"
+
+
+DependencyStatus.__new__ = model.safe_enum__new__
 
 
 @attr.s(auto_attribs=True, init=False)
@@ -2967,6 +2979,10 @@ class FillStyle(enum.Enum):
 
     enumeration = "enumeration"
     range = "range"
+    invalid_api_enum_value = "invalid_api_enum_value"
+
+
+FillStyle.__new__ = model.safe_enum__new__
 
 
 @attr.s(auto_attribs=True, init=False)
@@ -3139,6 +3155,10 @@ class Format(enum.Enum):
 
     topojson = "topojson"
     vector_tile_region = "vector_tile_region"
+    invalid_api_enum_value = "invalid_api_enum_value"
+
+
+Format.__new__ = model.safe_enum__new__
 
 
 class GitApplicationServerHttpScheme(enum.Enum):
@@ -3149,6 +3169,10 @@ class GitApplicationServerHttpScheme(enum.Enum):
 
     http = "http"
     https = "https"
+    invalid_api_enum_value = "invalid_api_enum_value"
+
+
+GitApplicationServerHttpScheme.__new__ = model.safe_enum__new__
 
 
 @attr.s(auto_attribs=True, init=False)
@@ -6081,6 +6105,10 @@ class Name(enum.Enum):
     week = "week"
     month = "month"
     year = "year"
+    invalid_api_enum_value = "invalid_api_enum_value"
+
+
+Name.__new__ = model.safe_enum__new__
 
 
 @attr.s(auto_attribs=True, init=False)
@@ -6463,6 +6491,10 @@ class PermissionType(enum.Enum):
 
     view = "view"
     edit = "edit"
+    invalid_api_enum_value = "invalid_api_enum_value"
+
+
+PermissionType.__new__ = model.safe_enum__new__
 
 
 @attr.s(auto_attribs=True, init=False)
@@ -6785,6 +6817,10 @@ class PullRequestMode(enum.Enum):
     links = "links"
     recommended = "recommended"
     required = "required"
+    invalid_api_enum_value = "invalid_api_enum_value"
+
+
+PullRequestMode.__new__ = model.safe_enum__new__
 
 
 @attr.s(auto_attribs=True, init=False)
@@ -7147,6 +7183,10 @@ class ResultFormat(enum.Enum):
     txt = "txt"
     xlsx = "xlsx"
     gsxml = "gsxml"
+    invalid_api_enum_value = "invalid_api_enum_value"
+
+
+ResultFormat.__new__ = model.safe_enum__new__
 
 
 @attr.s(auto_attribs=True, init=False)
@@ -8324,6 +8364,10 @@ class SupportedActionTypes(enum.Enum):
     cell = "cell"
     query = "query"
     dashboard = "dashboard"
+    invalid_api_enum_value = "invalid_api_enum_value"
+
+
+SupportedActionTypes.__new__ = model.safe_enum__new__
 
 
 class SupportedDownloadSettings(enum.Enum):
@@ -8334,6 +8378,10 @@ class SupportedDownloadSettings(enum.Enum):
 
     push = "push"
     url = "url"
+    invalid_api_enum_value = "invalid_api_enum_value"
+
+
+SupportedDownloadSettings.__new__ = model.safe_enum__new__
 
 
 class SupportedFormats(enum.Enum):
@@ -8355,6 +8403,10 @@ class SupportedFormats(enum.Enum):
     assembled_pdf = "assembled_pdf"
     wysiwyg_png = "wysiwyg_png"
     csv_zip = "csv_zip"
+    invalid_api_enum_value = "invalid_api_enum_value"
+
+
+SupportedFormats.__new__ = model.safe_enum__new__
 
 
 class SupportedFormattings(enum.Enum):
@@ -8365,6 +8417,10 @@ class SupportedFormattings(enum.Enum):
 
     formatted = "formatted"
     unformatted = "unformatted"
+    invalid_api_enum_value = "invalid_api_enum_value"
+
+
+SupportedFormattings.__new__ = model.safe_enum__new__
 
 
 class SupportedVisualizationFormattings(enum.Enum):
@@ -8375,6 +8431,10 @@ class SupportedVisualizationFormattings(enum.Enum):
 
     apply = "apply"
     noapply = "noapply"
+    invalid_api_enum_value = "invalid_api_enum_value"
+
+
+SupportedVisualizationFormattings.__new__ = model.safe_enum__new__
 
 
 @attr.s(auto_attribs=True, init=False)
@@ -8789,6 +8849,10 @@ class UserAttributeFilterTypes(enum.Enum):
     relative_url = "relative_url"
     yesno = "yesno"
     zipcode = "zipcode"
+    invalid_api_enum_value = "invalid_api_enum_value"
+
+
+UserAttributeFilterTypes.__new__ = model.safe_enum__new__
 
 
 @attr.s(auto_attribs=True, init=False)
@@ -9063,6 +9127,10 @@ class WeekStartDay(enum.Enum):
     friday = "friday"
     saturday = "saturday"
     sunday = "sunday"
+    invalid_api_enum_value = "invalid_api_enum_value"
+
+
+WeekStartDay.__new__ = model.safe_enum__new__
 
 
 @attr.s(auto_attribs=True, init=False)

--- a/python/looker_sdk/sdk/api40/models.py
+++ b/python/looker_sdk/sdk/api40/models.py
@@ -79,6 +79,10 @@ class Align(enum.Enum):
 
     left = "left"
     right = "right"
+    invalid_api_enum_value = "invalid_api_enum_value"
+
+
+Align.__new__ = model.safe_enum__new__
 
 
 @attr.s(auto_attribs=True, init=False)
@@ -406,6 +410,10 @@ class Category(enum.Enum):
     filter = "filter"
     measure = "measure"
     dimension = "dimension"
+    invalid_api_enum_value = "invalid_api_enum_value"
+
+
+Category.__new__ = model.safe_enum__new__
 
 
 @attr.s(auto_attribs=True, init=False)
@@ -2835,6 +2843,10 @@ class DependencyStatus(enum.Enum):
     lock_required = "lock_required"
     lock_error = "lock_error"
     install_none = "install_none"
+    invalid_api_enum_value = "invalid_api_enum_value"
+
+
+DependencyStatus.__new__ = model.safe_enum__new__
 
 
 @attr.s(auto_attribs=True, init=False)
@@ -3184,6 +3196,10 @@ class FillStyle(enum.Enum):
 
     enumeration = "enumeration"
     range = "range"
+    invalid_api_enum_value = "invalid_api_enum_value"
+
+
+FillStyle.__new__ = model.safe_enum__new__
 
 
 @attr.s(auto_attribs=True, init=False)
@@ -3356,6 +3372,10 @@ class Format(enum.Enum):
 
     topojson = "topojson"
     vector_tile_region = "vector_tile_region"
+    invalid_api_enum_value = "invalid_api_enum_value"
+
+
+Format.__new__ = model.safe_enum__new__
 
 
 class GitApplicationServerHttpScheme(enum.Enum):
@@ -3366,6 +3386,10 @@ class GitApplicationServerHttpScheme(enum.Enum):
 
     http = "http"
     https = "https"
+    invalid_api_enum_value = "invalid_api_enum_value"
+
+
+GitApplicationServerHttpScheme.__new__ = model.safe_enum__new__
 
 
 @attr.s(auto_attribs=True, init=False)
@@ -4482,6 +4506,10 @@ class LinkedContentType(enum.Enum):
 
     dashboard = "dashboard"
     lookml_dashboard = "lookml_dashboard"
+    invalid_api_enum_value = "invalid_api_enum_value"
+
+
+LinkedContentType.__new__ = model.safe_enum__new__
 
 
 @attr.s(auto_attribs=True, init=False)
@@ -6071,6 +6099,10 @@ class Name(enum.Enum):
     week = "week"
     month = "month"
     year = "year"
+    invalid_api_enum_value = "invalid_api_enum_value"
+
+
+Name.__new__ = model.safe_enum__new__
 
 
 @attr.s(auto_attribs=True, init=False)
@@ -6494,6 +6526,10 @@ class PermissionType(enum.Enum):
 
     view = "view"
     edit = "edit"
+    invalid_api_enum_value = "invalid_api_enum_value"
+
+
+PermissionType.__new__ = model.safe_enum__new__
 
 
 @attr.s(auto_attribs=True, init=False)
@@ -6820,6 +6856,10 @@ class PullRequestMode(enum.Enum):
     links = "links"
     recommended = "recommended"
     required = "required"
+    invalid_api_enum_value = "invalid_api_enum_value"
+
+
+PullRequestMode.__new__ = model.safe_enum__new__
 
 
 @attr.s(auto_attribs=True, init=False)
@@ -7178,6 +7218,10 @@ class ResultFormat(enum.Enum):
     txt = "txt"
     xlsx = "xlsx"
     gsxml = "gsxml"
+    invalid_api_enum_value = "invalid_api_enum_value"
+
+
+ResultFormat.__new__ = model.safe_enum__new__
 
 
 @attr.s(auto_attribs=True, init=False)
@@ -8308,6 +8352,10 @@ class SupportedActionTypes(enum.Enum):
     cell = "cell"
     query = "query"
     dashboard = "dashboard"
+    invalid_api_enum_value = "invalid_api_enum_value"
+
+
+SupportedActionTypes.__new__ = model.safe_enum__new__
 
 
 class SupportedDownloadSettings(enum.Enum):
@@ -8318,6 +8366,10 @@ class SupportedDownloadSettings(enum.Enum):
 
     push = "push"
     url = "url"
+    invalid_api_enum_value = "invalid_api_enum_value"
+
+
+SupportedDownloadSettings.__new__ = model.safe_enum__new__
 
 
 class SupportedFormats(enum.Enum):
@@ -8339,6 +8391,10 @@ class SupportedFormats(enum.Enum):
     assembled_pdf = "assembled_pdf"
     wysiwyg_png = "wysiwyg_png"
     csv_zip = "csv_zip"
+    invalid_api_enum_value = "invalid_api_enum_value"
+
+
+SupportedFormats.__new__ = model.safe_enum__new__
 
 
 class SupportedFormattings(enum.Enum):
@@ -8349,6 +8405,10 @@ class SupportedFormattings(enum.Enum):
 
     formatted = "formatted"
     unformatted = "unformatted"
+    invalid_api_enum_value = "invalid_api_enum_value"
+
+
+SupportedFormattings.__new__ = model.safe_enum__new__
 
 
 class SupportedVisualizationFormattings(enum.Enum):
@@ -8359,6 +8419,10 @@ class SupportedVisualizationFormattings(enum.Enum):
 
     apply = "apply"
     noapply = "noapply"
+    invalid_api_enum_value = "invalid_api_enum_value"
+
+
+SupportedVisualizationFormattings.__new__ = model.safe_enum__new__
 
 
 @attr.s(auto_attribs=True, init=False)
@@ -8767,6 +8831,10 @@ class UserAttributeFilterTypes(enum.Enum):
     relative_url = "relative_url"
     yesno = "yesno"
     zipcode = "zipcode"
+    invalid_api_enum_value = "invalid_api_enum_value"
+
+
+UserAttributeFilterTypes.__new__ = model.safe_enum__new__
 
 
 @attr.s(auto_attribs=True, init=False)
@@ -9028,6 +9096,10 @@ class WeekStartDay(enum.Enum):
     friday = "friday"
     saturday = "saturday"
     sunday = "sunday"
+    invalid_api_enum_value = "invalid_api_enum_value"
+
+
+WeekStartDay.__new__ = model.safe_enum__new__
 
 
 @attr.s(auto_attribs=True, init=False)

--- a/python/tests/rtl/test_serialize.py
+++ b/python/tests/rtl/test_serialize.py
@@ -47,6 +47,10 @@ class Enum1(enum.Enum):
     """
 
     entry1 = "entry1"
+    invalid_api_enum_value = "invalid_api_enum_value"
+
+
+Enum1.__new__ = ml.safe_enum__new__
 
 
 @attr.s(auto_attribs=True, init=False)
@@ -175,6 +179,10 @@ class Enum2(enum.Enum):
     """
 
     entry2 = "entry2"
+    invalid_api_enum_value = "invalid_api_enum_value"
+
+
+Enum2.__new__ = ml.safe_enum__new__
 
 
 @attr.s(auto_attribs=True, init=False)
@@ -432,3 +440,27 @@ def test_serialize_explict_null():
         }
     ).encode("utf-8")
     assert sr.serialize(model) == expected
+
+
+def test_safe_enum_deserialization():
+    data = copy.deepcopy(MODEL_DATA)
+    data["enum1"] = "not an Enum1 member!"
+    data["enum2"] = ""
+    model = Model(
+        enum1=Enum1.invalid_api_enum_value,
+        model_no_refs1=ModelNoRefs1(name1="model_no_refs1_name"),
+        enum2=Enum2.invalid_api_enum_value,
+        model_no_refs2=ModelNoRefs2(name2="model_no_refs2_name"),
+        list_enum1=[Enum1.entry1],
+        list_model_no_refs1=[ModelNoRefs1(name1="model_no_refs1_name")],
+        opt_enum1=Enum1.entry1,
+        opt_model_no_refs1=ModelNoRefs1(name1="model_no_refs1_name"),
+        id=1,
+        name="my-name",
+        class_="model-name",
+        finally_=[1, 2, 3],
+    )
+    assert (
+        sr.deserialize(data=json.dumps(data), structure=Model, converter=converter)
+        == model
+    )


### PR DESCRIPTION
Prior to this change python SDK would raise when the API returned an
invalid enum value. Given an enum type of `MyAPIEnum` and an invalid
value of `""` this error would be raised

`ValueError: '' is not a valid MyAPIEnum`

Now it will deserialize to `MyAPIEnum.invalid_api_enum_value`

Side note: I really wanted to but was unable to dynamically modify the
`MyAPIEnum.invalid_api_enum_value` enum member value to be the actual
invalid value returned by the API. So
`MyAPIEnum.invalid_api_enum_value.value` will always be
`"invalid_api_enum_value"`