### PR TITLE
ApiExplorer: Refactored DocResponses according to design spec 

### DIFF
--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -43,7 +43,7 @@
     "webpack-dev-server": "^3.10.3"
   },
   "dependencies": {
-    "@looker/components": "^0.9.6",
+    "@looker/components": "^0.9.7",
     "@looker/sdk": "^0.3.3-alpha.0",
     "@looker/sdk-codegen": "^0.1.2-alpha.18+551e4fe",
     "@looker/sdk-codegen-utils": "^0.1.0-alpha.2",

--- a/packages/api-explorer/src/components/DocCode/DocCode.tsx
+++ b/packages/api-explorer/src/components/DocCode/DocCode.tsx
@@ -51,19 +51,19 @@ const theme = require('ace-builds/src-noconflict/theme-dracula')
 
 interface DocCodeProps {
   code: string
-  language: string
+  language?: string
   fontSize?: number
   width?: string
 }
 
 export const DocCode: FC<DocCodeProps> = ({
   code,
-  language,
+  language = 'json',
   fontSize = 16,
   width = 'auto',
 }) => {
   const gen = findGenerator(language)
-  language = gen ? gen.language.toLocaleLowerCase() : json
+  if (gen) language = gen.language.toLocaleLowerCase()
   const {
     searchSettings: { pattern },
   } = useContext(SearchContext)

--- a/packages/api-explorer/src/components/DocResponses/DocResponseTypes.tsx
+++ b/packages/api-explorer/src/components/DocResponses/DocResponseTypes.tsx
@@ -1,0 +1,67 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2020 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+import React, { FC, useState } from 'react'
+import { ButtonToggle, ButtonItem } from '@looker/components'
+import { KeyedCollection, IMethodResponse } from '@looker/sdk-codegen'
+
+import { DocCode } from '../DocCode'
+import { copyAndCleanResponse } from './utils'
+
+interface DocResponseTypesProps {
+  responses: KeyedCollection<IMethodResponse>
+}
+
+/**
+ * Given a collection of media types (keys) and responses (values) for a response code, generate a group of buttons for
+ * toggling media type and render the response
+ * @param response
+ */
+export const DocResponseTypes: FC<DocResponseTypesProps> = ({ responses }) => {
+  const mediaTypes = Object.keys(responses)
+  const [mediaType, setMediaType] = useState(mediaTypes[0])
+
+  return (
+    <>
+      <ButtonToggle
+        value={mediaType}
+        onChange={setMediaType}
+        mt="large"
+        mb="large"
+      >
+        {mediaTypes.map((mediaType) => (
+          <ButtonItem key={mediaType}>{mediaType}</ButtonItem>
+        ))}
+      </ButtonToggle>
+      <DocCode
+        code={JSON.stringify(
+          copyAndCleanResponse(responses[mediaType]),
+          null,
+          2
+        )}
+      />
+    </>
+  )
+}

--- a/packages/api-explorer/src/components/DocResponses/DocResponses.spec.tsx
+++ b/packages/api-explorer/src/components/DocResponses/DocResponses.spec.tsx
@@ -1,0 +1,60 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2020 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+import React from 'react'
+import { screen, waitFor } from '@testing-library/react'
+import { renderWithTheme } from '@looker/components-test-utils'
+import userEvent from '@testing-library/user-event'
+
+import { api } from '../../test-data'
+import { DocResponses } from './DocResponses'
+import { buildResponseTree } from './utils'
+
+describe('DocResponses', () => {
+  test('it renders all response statuses and their types', async () => {
+    const responses = api.methods.run_look.responses
+    renderWithTheme(<DocResponses responses={responses} />)
+
+    expect(screen.getByText('Response Models')).toBeInTheDocument()
+
+    const responseTree = buildResponseTree(responses)
+    const expectedRespStatuses = Object.keys(responseTree)
+    expect(
+      screen.getAllByRole('button', {
+        name: new RegExp(`${expectedRespStatuses.join('|')}`),
+      })
+    ).toHaveLength(expectedRespStatuses.length)
+
+    userEvent.click(screen.getByRole('button', { name: '200: Look' }))
+    const successRespTypes = Object.keys(responseTree['200: Look'])
+    await waitFor(() => {
+      expect(
+        screen.getAllByRole('button', {
+          name: new RegExp(`${successRespTypes.join('|')}`),
+        })
+      ).toHaveLength(successRespTypes.length)
+    })
+  })
+})

--- a/packages/api-explorer/src/components/DocResponses/DocResponses.tsx
+++ b/packages/api-explorer/src/components/DocResponses/DocResponses.tsx
@@ -27,59 +27,41 @@
 import React, { FC } from 'react'
 import {
   Box,
-  MessageBar,
   SpaceVertical,
   Tab,
   TabList,
   TabPanel,
   TabPanels,
-  Table,
-  TableHead,
-  TableRow,
   useTabs,
 } from '@looker/components'
 import { IMethodResponse } from '@looker/sdk-codegen'
 
-import { ApixHeading, DocCode } from '../../../components'
-import { copyAndCleanResponse } from '../utils'
+import { ApixHeading } from '../common'
+import { DocResponseTypes } from './DocResponseTypes'
+import { buildResponseTree } from './utils'
 
-interface DocResponseProps {
+interface DocResponsesProps {
   responses: IMethodResponse[]
 }
 
-export const DocResponse: FC<DocResponseProps> = ({ responses }) => {
+export const DocResponses: FC<DocResponsesProps> = ({ responses }) => {
   const tabs = useTabs()
+  const responseTree = buildResponseTree(responses)
 
   return (
     <Box pt="large" pb="xxlarge">
       <SpaceVertical mb="medium">
-        <ApixHeading as="h2">Responses</ApixHeading>
+        <ApixHeading as="h2">Response Models</ApixHeading>
       </SpaceVertical>
       <TabList {...tabs}>
-        {responses.map((response, index) => (
-          <Tab
-            key={index}
-          >{`${response.statusCode}:${response.description}`}</Tab>
+        {Object.keys(responseTree).map((statusCode, index) => (
+          <Tab key={index}>{statusCode}</Tab>
         ))}
       </TabList>
       <TabPanels {...tabs} pt="0">
-        {responses.map((response, index) => (
+        {Object.values(responseTree).map((responses, index) => (
           <TabPanel key={index}>
-            <Table>
-              <TableHead>
-                <TableRow>
-                  <SpaceVertical py="small">
-                    <MessageBar intent="inform">
-                      {response.statusCode}: {response.description}{' '}
-                      {response.mediaType}
-                    </MessageBar>
-                  </SpaceVertical>
-                </TableRow>
-              </TableHead>
-            </Table>
-            <DocCode
-              code={JSON.stringify(copyAndCleanResponse(response), null, 2)}
-            />
+            <DocResponseTypes responses={responses} />
           </TabPanel>
         ))}
       </TabPanels>

--- a/packages/api-explorer/src/components/DocResponses/index.ts
+++ b/packages/api-explorer/src/components/DocResponses/index.ts
@@ -23,26 +23,4 @@
  SOFTWARE.
 
  */
-export { ApixHeading } from './common'
-export { DocActivityType } from './DocActivityType'
-export { DocCode } from './DocCode'
-export { DocMethodSummary } from './DocMethodSummary'
-export { DocMarkdown } from './DocMarkdown'
-export { DocPseudo } from './DocPseudo'
-export { DocRateLimited } from './DocRateLimited'
-export { DocReferences } from './DocReferences'
 export { DocResponses } from './DocResponses'
-export { DocSDKs } from './DocSDKs'
-export { DocStatus } from './DocStatus'
-export { DocTitle } from './DocTitle'
-export {
-  HeaderWrapper,
-  Main,
-  PageLayout,
-  SideNavDivider,
-  StatusBeta,
-  SummaryCard,
-} from './ExplorerStyle'
-export { Header } from './Header'
-export { SideNav } from './SideNav'
-export { SideNavToggle } from './SideNavToggle'

--- a/packages/api-explorer/src/components/DocResponses/utils.spec.ts
+++ b/packages/api-explorer/src/components/DocResponses/utils.spec.ts
@@ -1,0 +1,167 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2020 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+import { api } from '../../test-data'
+import { buildResponseTree, copyAndCleanResponse } from './utils'
+
+describe('DocResponses utils', () => {
+  describe('buildResponseTree', () => {
+    test('it builds a response tree', () => {
+      const method = api.methods.run_look
+      const responses = method.responses
+      const actual = buildResponseTree(responses)
+      const responseStatuses = [
+        '200: Look',
+        '400: Bad Request',
+        '404: Not Found',
+        '422: Validation Error',
+        '429: Too Many Requests',
+      ]
+      const mediaTypes = ['text', 'application/json', 'image/png', 'image/jpeg']
+      expect(Object.keys(actual)).toEqual(responseStatuses)
+
+      responseStatuses.forEach((status) => {
+        expect(Object.keys(actual[status])).toEqual(mediaTypes)
+      })
+
+      expect(actual['200: Look']['application/json']).toEqual(
+        method.primaryResponse
+      )
+    })
+  })
+
+  describe('copyAndCleanResponse', () => {
+    test('it cleans ArrayType responses', () => {
+      const resp = api.methods.all_users.primaryResponse
+      expect(resp.type.className).toEqual('ArrayType')
+      const actual = copyAndCleanResponse(resp)
+      expect(actual).toEqual({
+        can: 'Hash[boolean]',
+        avatar_url: 'uri',
+        avatar_url_without_sizing: 'uri',
+        credentials_api3: {},
+        credentials_email: {
+          can: 'Hash[boolean]',
+          created_at: 'string',
+          email: 'string',
+          forced_password_reset_at_next_login: 'boolean',
+          is_disabled: 'boolean',
+          logged_in_at: 'string',
+          password_reset_url: 'string',
+          type: 'string',
+          url: 'uri',
+          user_url: 'uri',
+        },
+        credentials_embed: {},
+        credentials_google: {
+          can: 'Hash[boolean]',
+          created_at: 'string',
+          domain: 'string',
+          email: 'string',
+          google_user_id: 'string',
+          is_disabled: 'boolean',
+          logged_in_at: 'string',
+          type: 'string',
+          url: 'uri',
+        },
+        credentials_ldap: {
+          can: 'Hash[boolean]',
+          created_at: 'string',
+          email: 'string',
+          is_disabled: 'boolean',
+          ldap_dn: 'string',
+          ldap_id: 'string',
+          logged_in_at: 'string',
+          type: 'string',
+          url: 'uri',
+        },
+        credentials_looker_openid: {
+          can: 'Hash[boolean]',
+          created_at: 'string',
+          email: 'string',
+          is_disabled: 'boolean',
+          logged_in_at: 'string',
+          logged_in_ip: 'string',
+          type: 'string',
+          url: 'uri',
+          user_url: 'uri',
+        },
+        credentials_oidc: {
+          can: 'Hash[boolean]',
+          created_at: 'string',
+          email: 'string',
+          is_disabled: 'boolean',
+          logged_in_at: 'string',
+          oidc_user_id: 'string',
+          type: 'string',
+          url: 'uri',
+        },
+        credentials_saml: {
+          can: 'Hash[boolean]',
+          created_at: 'string',
+          email: 'string',
+          is_disabled: 'boolean',
+          logged_in_at: 'string',
+          saml_user_id: 'string',
+          type: 'string',
+          url: 'uri',
+        },
+        credentials_totp: {
+          can: 'Hash[boolean]',
+          created_at: 'string',
+          is_disabled: 'boolean',
+          type: 'string',
+          verified: 'boolean',
+          url: 'uri',
+        },
+        display_name: 'string',
+        email: 'string',
+        embed_group_space_id: 'int64',
+        first_name: 'string',
+        group_ids: 'int64[]',
+        home_space_id: 'string',
+        home_folder_id: 'string',
+        id: 'int64',
+        is_disabled: 'boolean',
+        last_name: 'string',
+        locale: 'string',
+        looker_versions: 'string[]',
+        models_dir_validated: 'boolean',
+        personal_space_id: 'int64',
+        personal_folder_id: 'int64',
+        presumed_looker_employee: 'boolean',
+        role_ids: 'int64[]',
+        sessions: {},
+        ui_state: 'Hash[string]',
+        verified_looker_employee: 'boolean',
+        roles_externally_managed: 'boolean',
+        allow_direct_roles: 'boolean',
+        allow_normal_group_membership: 'boolean',
+        allow_roles_from_normal_groups: 'boolean',
+        url: 'uri',
+      })
+    })
+  })
+})

--- a/packages/api-explorer/src/components/DocResponses/utils.ts
+++ b/packages/api-explorer/src/components/DocResponses/utils.ts
@@ -1,0 +1,101 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2020 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+import { cloneDeep, isEmpty } from 'lodash'
+import {
+  IMethodResponse,
+  IProperty,
+  IType,
+  KeyedCollection,
+} from '@looker/sdk-codegen'
+
+/**
+ * Omit unwanted properties from a given property object
+ * @param val Property object
+ */
+const cleanProperty = (val: IProperty) => {
+  if (val.type.customType) {
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    return cleanType(val.type).properties
+  }
+  return val.type.name
+}
+
+interface CleanType {
+  name: string
+  description: string
+  properties: KeyedCollection<any>
+}
+
+/**
+ * Omit unwanted metadata from a given type object
+ * @param val Type object
+ */
+const cleanType = (val: IType): CleanType => {
+  const result = {
+    name: val.name,
+    description: val.description,
+    properties: {},
+  }
+  if (!isEmpty(val.properties)) {
+    Object.entries(val.properties).forEach(
+      ([name, property]) => (result.properties[name] = cleanProperty(property))
+    )
+  }
+  return result
+}
+
+/**
+ * Given a response object, return a copy stripped of unwanted metadata
+ * @param val A method response object
+ */
+export const copyAndCleanResponse = (val: IMethodResponse) => {
+  switch (val.type.className) {
+    case 'ArrayType':
+    case 'HashType':
+    case 'DelimArrayType':
+    case 'EnumType':
+      return cleanType(cloneDeep(val.type.elementType!)).properties
+    default:
+      return cleanType(cloneDeep(val.type)).properties
+  }
+}
+
+/**
+ * Given an array of method responses, group them by statusCode. The value of each status code is a collection of
+ * media types (keys) and responses (values)
+ * @param responses An array of method responses
+ */
+export const buildResponseTree = (
+  responses: IMethodResponse[]
+): KeyedCollection<KeyedCollection<IMethodResponse>> => {
+  const tree = {}
+  Object.values(responses).forEach((response) => {
+    const node = `${response.statusCode}: ${response.description}`
+    if (!(node in tree)) tree[node] = {}
+    tree[node][response.mediaType] = response
+  })
+  return tree
+}

--- a/packages/api-explorer/src/scenes/MethodScene/MethodScene.tsx
+++ b/packages/api-explorer/src/scenes/MethodScene/MethodScene.tsx
@@ -36,11 +36,12 @@ import {
   DocMarkdown,
   DocRateLimited,
   DocReferences,
+  DocResponses,
   DocSDKs,
   DocStatus,
   DocTitle,
 } from '../../components'
-import { DocResponse, DocOperation } from './components'
+import { DocOperation } from './components'
 import { createInputs } from './utils'
 
 interface DocMethodProps {
@@ -80,7 +81,7 @@ export const MethodScene: FC<DocMethodProps> = ({
           <DocReferences items={seeTypes} api={api} specKey={specKey} />
         </Space>
       )}
-      {method.responses && <DocResponse responses={method.responses} />}
+      {method.responses && <DocResponses responses={method.responses} />}
       <RunIt
         specKey={specKey}
         inputs={createInputs(api, method)}

--- a/packages/api-explorer/src/scenes/MethodScene/components/DocResponse.tsx
+++ b/packages/api-explorer/src/scenes/MethodScene/components/DocResponse.tsx
@@ -43,21 +43,6 @@ import { IMethodResponse } from '@looker/sdk-codegen'
 import { ApixHeading, DocCode } from '../../../components'
 import { copyAndCleanResponse } from '../utils'
 
-/*
-  TODO:
-  > Responses
-    - 200 Look
-        - png
-        - csv
-        - html
-        - ...
-    - 400 Bad Request
-        -
-    - 404 Not found
-        -
-    - 422 Validation Error
- */
-
 interface DocResponseProps {
   responses: IMethodResponse[]
 }
@@ -93,7 +78,6 @@ export const DocResponse: FC<DocResponseProps> = ({ responses }) => {
               </TableHead>
             </Table>
             <DocCode
-              language="json"
               code={JSON.stringify(copyAndCleanResponse(response), null, 2)}
             />
           </TabPanel>

--- a/packages/api-explorer/src/scenes/MethodScene/components/index.ts
+++ b/packages/api-explorer/src/scenes/MethodScene/components/index.ts
@@ -24,4 +24,3 @@
 
  */
 export { DocOperation } from './DocOperation'
-export { DocResponse } from './DocResponse'

--- a/packages/api-explorer/src/scenes/MethodScene/utils.spec.ts
+++ b/packages/api-explorer/src/scenes/MethodScene/utils.spec.ts
@@ -23,18 +23,14 @@
  SOFTWARE.
 
  */
-import { api } from '../../test-data'
-import { copyAndCleanResponse, responsePropsToOmit } from './utils'
 
-describe('cleanResponse', () => {
-  test('it omits the right paths', () => {
-    const obj = api.methods.theme.primaryResponse
-    const actual = copyAndCleanResponse(obj)
-    expect(actual).not.toHaveProperty(responsePropsToOmit)
-    Object.values(actual).forEach((val) => {
-      if (val instanceof Object) {
-        expect(val).not.toHaveProperty(responsePropsToOmit)
-      }
-    })
+import { api } from '../../test-data'
+import { copyAndCleanResponse } from './utils'
+
+describe('Response model utils', () => {
+  test('copyAndCleanResponse works', () => {
+    const orig = api.methods.run_look.primaryResponse
+    const actual = copyAndCleanResponse(orig)
+    expect(actual)
   })
 })

--- a/packages/api-explorer/src/scenes/MethodScene/utils.spec.ts
+++ b/packages/api-explorer/src/scenes/MethodScene/utils.spec.ts
@@ -25,12 +25,79 @@
  */
 
 import { api } from '../../test-data'
-import { copyAndCleanResponse } from './utils'
+import { copyAndCleanResponse, createInputs } from './utils'
 
-describe('Response model utils', () => {
-  test('copyAndCleanResponse works', () => {
-    const orig = api.methods.run_look.primaryResponse
-    const actual = copyAndCleanResponse(orig)
-    expect(actual)
+describe('MethodScene utils', () => {
+  describe('response utils', () => {
+    test('copyAndCleanResponse works', () => {
+      const orig = api.methods.run_look.primaryResponse
+      const actual = copyAndCleanResponse(orig)
+      expect(actual)
+    })
+  })
+
+  describe('run-it utils', () => {
+    test('createInputs works with various param types', () => {
+      const method = api.methods.run_inline_query
+      const actual = createInputs(api, method)
+      expect(actual).toHaveLength(method.allParams.length)
+
+      expect(actual).toEqual(
+        expect.arrayContaining([
+          /** Boolean param */
+          {
+            name: 'cache',
+            location: 'query',
+            type: 'boolean',
+            required: false,
+            description: 'Get results from cache if available.',
+          },
+          /** Number param */
+          {
+            name: 'limit',
+            location: 'query',
+            type: 'int64',
+            required: false,
+            description: expect.any(String),
+          },
+          /** String param */
+          {
+            name: 'result_format',
+            location: 'path',
+            type: 'string',
+            required: true,
+            description: 'Format of result',
+          },
+          /** Body param */
+          {
+            name: 'body',
+            location: 'body',
+            type: expect.objectContaining({
+              model: '',
+              view: '',
+              fields: [],
+              pivots: [],
+              fill_fields: [],
+              filters: {},
+              filter_expression: '',
+              sorts: [],
+              limit: '',
+              column_limit: '',
+              total: false,
+              row_total: '',
+              subtotals: [],
+              vis_config: {},
+              filter_config: {},
+              visible_ui_sections: '',
+              dynamic_fields: '',
+              client_id: '',
+              query_timezone: '',
+            }),
+            required: true,
+            description: '',
+          },
+        ])
+      )
+    })
   })
 })

--- a/packages/api-explorer/src/scenes/MethodScene/utils.ts
+++ b/packages/api-explorer/src/scenes/MethodScene/utils.ts
@@ -38,8 +38,12 @@ import {
 } from '@looker/sdk-codegen'
 import { RunItInput } from '@looker/run-it'
 
-// TODO: use potential equivalent from sdk-codegen, confirm formats
-export const getTypeDefault = (type: string) => {
+/**
+ * Return a default value for a given type name
+ * @param type A type name
+ */
+const getTypeDefault = (type: string) => {
+  // TODO: use potential equivalent from sdk-codegen, confirm formats
   switch (type) {
     case 'boolean':
       return false
@@ -68,6 +72,11 @@ export const getTypeDefault = (type: string) => {
   }
 }
 
+/**
+ * Given a type object reduce it to its writeable intrinsic and/or custom type properties and their default values
+ * @param spec Api spec
+ * @param type A type object
+ */
 const createSampleBody = (spec: IApiModel, type: IType) => {
   /* eslint-disable @typescript-eslint/no-use-before-define */
   const getSampleValue = (type: IType) => {
@@ -77,7 +86,6 @@ const createSampleBody = (spec: IApiModel, type: IType) => {
         ? [recurse(spec.types[type.customType])]
         : getTypeDefault(type.name)
     if (type instanceof HashType)
-      // TODO: populate Hash[] types
       return type.customType ? recurse(spec.types[type.customType]) : {}
     if (type instanceof DelimArrayType) return ''
 
@@ -98,6 +106,11 @@ const createSampleBody = (spec: IApiModel, type: IType) => {
   return recurse(type)
 }
 
+/**
+ * Given an SDK method create and return an array of inputs for the run-it form
+ * @param spec Api spec
+ * @param method A method object
+ */
 export const createInputs = (spec: IApiModel, method: IMethod): RunItInput[] =>
   method.allParams.map((param) => ({
     name: param.name,

--- a/packages/api-explorer/src/scenes/MethodScene/utils.ts
+++ b/packages/api-explorer/src/scenes/MethodScene/utils.ts
@@ -24,7 +24,6 @@
 
  */
 
-import { cloneDeep, isEmpty } from 'lodash'
 import {
   ArrayType,
   DelimArrayType,
@@ -33,9 +32,6 @@ import {
   IntrinsicType,
   IType,
   IMethod,
-  IProperty,
-  IMethodResponse,
-  KeyedCollection,
 } from '@looker/sdk-codegen'
 import { RunItInput } from '@looker/run-it'
 
@@ -123,55 +119,3 @@ export const createInputs = (spec: IApiModel, method: IMethod): RunItInput[] =>
     required: param.required,
     description: param.description,
   }))
-
-/**
- * Omit unwanted properties from a given property object
- * @param val Property object
- */
-const cleanProperty = (val: IProperty) => {
-  if (val.type.customType) {
-    // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    return cleanType(val.type).properties
-  }
-  return val.type.name
-}
-
-interface CleanType {
-  name: string
-  description: string
-  properties: KeyedCollection<any>
-}
-
-/**
- * Omit unwanted metadata from a given type object
- * @param val Type object
- */
-const cleanType = (val: IType): CleanType => {
-  const result = {
-    name: val.name,
-    description: val.description,
-    properties: {},
-  }
-  if (!isEmpty(val.properties)) {
-    Object.entries(val.properties).forEach(
-      ([name, property]) => (result.properties[name] = cleanProperty(property))
-    )
-  }
-  return result
-}
-
-/**
- * Given a response object, return a copy stripped of unwanted metadata
- * @param val A method response object
- */
-export const copyAndCleanResponse = (val: IMethodResponse) => {
-  switch (val.type.className) {
-    case 'ArrayType':
-    case 'HashType':
-    case 'DelimArrayType':
-    case 'EnumType':
-      return cleanType(cloneDeep(val.type.elementType!)).properties
-    default:
-      return cleanType(cloneDeep(val.type)).properties
-  }
-}

--- a/packages/run-it/package.json
+++ b/packages/run-it/package.json
@@ -44,7 +44,7 @@
     "webpack-dev-server": "^3.10.3"
   },
   "dependencies": {
-    "@looker/components": "^0.9.6",
+    "@looker/components": "^0.9.7",
     "@looker/design-tokens": "0.9.1",
     "@looker/sdk": "^0.3.3-alpha.0",
     "@looker/sdk-codegen": "^0.1.2-alpha.18+551e4fe",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2110,30 +2110,30 @@
     debug "^2.2.0"
     es6-promise "^4.2.5"
 
-"@looker/components-providers@^0.9.6":
-  version "0.9.6"
-  resolved "https://registry.yarnpkg.com/@looker/components-providers/-/components-providers-0.9.6.tgz#dc0617129be70412f6db32065e24a2c75427e923"
-  integrity sha512-2S1+zMVALUvTUmmfxjvLgpz+QeIzICt0rEJifUd+HIcX1F0n5zECOoVnUN1Hl2Xs6R20kYG7mURR/QgcOOCakA==
+"@looker/components-providers@^0.9.7":
+  version "0.9.7"
+  resolved "https://registry.yarnpkg.com/@looker/components-providers/-/components-providers-0.9.7.tgz#e694e0dd2c112ef6b6d7400688581dc4fe76cf03"
+  integrity sha512-InHmMUUnXIvlSGPwK1ruIl/MH4S0lFyCFAgORV6LHOyHm4ukSxQFQlUiW8dM8yntogValZDsBqZXlj8wT0tXXA==
   dependencies:
-    "@looker/design-tokens" "^0.9.6"
+    "@looker/design-tokens" "^0.9.7"
 
 "@looker/components-test-utils@^0.7.36":
   version "0.7.36"
   resolved "https://registry.yarnpkg.com/@looker/components-test-utils/-/components-test-utils-0.7.36.tgz#2de68473d728b61f11fd744cfe8dbe2dae190e2f"
   integrity sha512-eT6EGgNnCwlBeZ3QYuKq/Mq+n1JataHVD9by3ONv7LrS1bpPg3Rhmdzg8MWoSPrXNj96fMsmvCjkKk6+mfT3yA==
 
-"@looker/components@^0.9.6":
-  version "0.9.6"
-  resolved "https://registry.yarnpkg.com/@looker/components/-/components-0.9.6.tgz#cc04df8a9a1e18b372a3eea02a26a601912c18ae"
-  integrity sha512-mHYlz3cuy0lTkIKW4SFzrYkWFX2fiBjb/Bn6a39WAhyOoItaL8hMlxf2E6bWf60puVaZS4toSISb1iPl5r6KcQ==
+"@looker/components@^0.9.7":
+  version "0.9.7"
+  resolved "https://registry.yarnpkg.com/@looker/components/-/components-0.9.7.tgz#c1b304bb34fbbcfbb60169c12e284cba26645a59"
+  integrity sha512-aY7L9e9vX1MuHvLiD3mIBW+uIi978/qaMJmFHAS3aD7IRWGMECGhINGSCO2ziTU35CQTZzNOwxZm/bFoqcn4Jw==
   dependencies:
-    "@looker/components-providers" "^0.9.6"
-    "@looker/design-tokens" "^0.9.6"
-    "@looker/icons" "^0.9.6"
+    "@looker/components-providers" "^0.9.7"
+    "@looker/design-tokens" "^0.9.7"
+    "@looker/icons" "^0.9.7"
     "@popperjs/core" "^2.4.4"
     d3-color "^1.4.1"
     d3-hsv "^0.1.0"
-    date-fns "^2.14.0"
+    date-fns "^2.15.0"
     date-fns-tz "^1.0.10"
     focus-trap "^5.1.0"
     lodash "^4.17.19"
@@ -2157,10 +2157,10 @@
     polished "^3.6.5"
     styled-system "^5.1.5"
 
-"@looker/design-tokens@^0.9.6":
-  version "0.9.6"
-  resolved "https://registry.yarnpkg.com/@looker/design-tokens/-/design-tokens-0.9.6.tgz#f53fc2b9d83c6fef362d78fe0d392050618679fe"
-  integrity sha512-cgXS8xFtncSkoAXrEAiHUGYWTsPO8L22woDPuSfDvajyFfuZztq+EINRyyXB1ZUOAXRtFc2b1SoCT96h7Uqg/g==
+"@looker/design-tokens@^0.9.7":
+  version "0.9.7"
+  resolved "https://registry.yarnpkg.com/@looker/design-tokens/-/design-tokens-0.9.7.tgz#ad07adb59072064b965c3c6430fce9fe8eefb2e1"
+  integrity sha512-7k+09fYVAEDnjeNdmndIlu24gZo9qYihYCtmhzY1W3Ob84VKh/EWESNVNG334yCZ0N8IQu6phUwrQHEVCFW/Qg==
   dependencies:
     "@styled-system/props" "^5.1.5"
     "@types/styled-system" "^5.1.9"
@@ -2210,10 +2210,10 @@
     deepmerge "^4.2.2"
     semver "^6.3.0"
 
-"@looker/icons@^0.9.6":
-  version "0.9.6"
-  resolved "https://registry.yarnpkg.com/@looker/icons/-/icons-0.9.6.tgz#0558612980e3236d6f34284789ba8c30c5ee5a98"
-  integrity sha512-KmP1wGvFtqTdgM4YeKz4ybZ1cygkOKmAvKaYmmwabW5XlHvjEjc7aGd05QZa00z6HpxelnkjXjYc4O58VLqxPw==
+"@looker/icons@^0.9.7":
+  version "0.9.7"
+  resolved "https://registry.yarnpkg.com/@looker/icons/-/icons-0.9.7.tgz#9531d7430e11a8ac64fca803b36112dba4d633ef"
+  integrity sha512-gKoZIGBuHgt/bwWseoYSKCI/R2PrjHTePMGBnBm/qQA4d9pKYZSr5Mx8hAH7qXobRmSjWHWo+EruXY1EosBuFw==
 
 "@looker/prettier-config@^1.0.15":
   version "1.0.15"
@@ -5332,7 +5332,7 @@ date-fns-tz@^1.0.10:
   resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-1.0.10.tgz#30fef0038f80534fddd8e133a6b8ca55ba313748"
   integrity sha512-cHQAz0/9uDABaUNDM80Mj1FL4ODlxs1xEY4b0DQuAooO2UdNKvDkNbV8ogLnxLbv02Ru1HXFcot0pVvDRBgptg==
 
-date-fns@^2.14.0:
+date-fns@^2.15.0:
   version "2.15.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.15.0.tgz#424de6b3778e4e69d3ff27046ec136af58ae5d5f"
   integrity sha512-ZCPzAMJZn3rNUvvQIMlXhDr4A+Ar07eLeGsGREoWU19a3Pqf5oYa+ccd+B3F6XVtQY6HANMFdOQ8A+ipFnvJdQ==


### PR DESCRIPTION
- Renamed `DocResponse` to `DocResponses` and moved it into global components folder
- Split `DocResponses` into `DocResponses` and `DocResponseTypes`
- Utility functions and tests for cleaning responses from unwanted metadata
- Made `json` the default language in `DocCode`, fixing a previous bug

PS: Updating @looker/components has broken the font