### PR TITLE
Python SDK: enable models as dictionaries

### DIFF
--- a/packages/sdk-codegen/src/python.gen.spec.ts
+++ b/packages/sdk-codegen/src/python.gen.spec.ts
@@ -331,13 +331,6 @@ def run_url_encoded_query(
   })
 
   describe('method body', () => {
-    it('asserts type of required input body params', () => {
-      const method = apiTestModel.methods.run_inline_query
-      const expected = `assert isinstance(body, models.WriteQuery)\n`
-      const actual = gen.bodyParamsTypeAssertions('', method)
-      expect(actual).toEqual(expected)
-    })
-
     it('encodes string path params', () => {
       const method = apiTestModel.methods.run_url_encoded_query
       const expected = `model_name = self.encode_path_param(model_name)
@@ -353,35 +346,6 @@ result_format = self.encode_path_param(result_format)
       // should NOT escape look_id (int)
       const expected = 'result_format = self.encode_path_param(result_format)\n'
       const actual = gen.encodePathParams('', method)
-      expect(actual).toEqual(expected)
-    })
-
-    it('asserts type of optional body params', () => {
-      const method = apiTestModel.methods.import_lookml_dashboard
-      const expected = `if body:
-    assert isinstance(body, models.WriteDashboard)
-`
-      const actual = gen.bodyParamsTypeAssertions('', method)
-      expect(actual).toEqual(expected)
-    })
-
-    it('body type assertions have generic subscripts stripped away', () => {
-      const sequenceBodyMethod = apiTestModel.methods.set_role_groups
-      let expected = `assert isinstance(body, Sequence)\n`
-      let actual = gen.bodyParamsTypeAssertions('', sequenceBodyMethod)
-      expect(actual).toEqual(expected)
-
-      const mutableMappingBodyMethod =
-        apiTestModel.methods.fetch_remote_data_action_form
-      expected = `assert isinstance(body, MutableMapping)\n`
-      actual = gen.bodyParamsTypeAssertions('', mutableMappingBodyMethod)
-      expect(actual).toEqual(expected)
-    })
-
-    it('does not assert type of query/path params', () => {
-      const method = apiTestModel.methods.lookml_model_explore
-      const expected = ''
-      const actual = gen.bodyParamsTypeAssertions('', method)
       expect(actual).toEqual(expected)
     })
 

--- a/packages/sdk-codegen/src/python.gen.ts
+++ b/packages/sdk-codegen/src/python.gen.ts
@@ -454,32 +454,6 @@ ${this.hooks.join('\n')}
     return encodings
   }
 
-  bodyParamsTypeAssertions(indent: string, method: IMethod): string {
-    const bodyParams = method.bodyParams
-    const bump = indent + this.indentStr
-    let assertions = ''
-    if (bodyParams.length > 0) {
-      for (const param of bodyParams) {
-        if (param.location === strBody) {
-          const conditionStr = param.required
-            ? ''
-            : `${indent}if ${param.name}:\n${bump}`
-          const type = this.writeableType(param.type, method) || param.type
-          let bodyType = this.typeMapMethods(type).name
-          if (bodyType.startsWith('Sequence')) {
-            bodyType = 'Sequence'
-          } else if (bodyType.startsWith('MutableMapping')) {
-            bodyType = 'MutableMapping'
-          } else if (bodyType.startsWith('models.DelimSequence')) {
-            bodyType = 'models.DelimSequence'
-          }
-          assertions += `${conditionStr}${indent}assert isinstance(${param.name}, ${bodyType})\n`
-        }
-      }
-    }
-    return assertions
-  }
-
   declareMethod(indent: string, method: IMethod) {
     const bump = this.bumper(indent)
 
@@ -496,7 +470,6 @@ ${this.hooks.join('\n')}
       this.methodSignature(indent, method) +
       this.summary(bump, method.summary) +
       this.encodePathParams(bump, method) +
-      this.bodyParamsTypeAssertions(bump, method) +
       this.httpCall(bump, method)
     )
   }

--- a/python/looker_sdk/rtl/serialize.py
+++ b/python/looker_sdk/rtl/serialize.py
@@ -33,7 +33,6 @@ from typing import (
     MutableMapping,
     Sequence,
     Type,
-    TypeVar,
     Union,
 )
 

--- a/python/looker_sdk/sdk/api31/methods.py
+++ b/python/looker_sdk/sdk/api31/methods.py
@@ -90,7 +90,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.EmbedUrlResponse:
         """Create SSO Embed Url"""
-        assert isinstance(body, models.EmbedSsoParams)
         response = self.post(
             f"/embed/sso_url",
             models.EmbedUrlResponse,
@@ -147,7 +146,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.LDAPConfig:
         """Update LDAP Configuration"""
-        assert isinstance(body, models.WriteLDAPConfig)
         response = self.patch(
             f"/ldap_config",
             models.LDAPConfig,
@@ -183,7 +181,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.LDAPConfigTestResult:
         """Test LDAP Connection"""
-        assert isinstance(body, models.WriteLDAPConfig)
         response = self.put(
             f"/ldap_config/test_connection",
             models.LDAPConfigTestResult,
@@ -221,7 +218,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.LDAPConfigTestResult:
         """Test LDAP Auth"""
-        assert isinstance(body, models.WriteLDAPConfig)
         response = self.put(
             f"/ldap_config/test_auth",
             models.LDAPConfigTestResult,
@@ -248,7 +244,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.LDAPConfigTestResult:
         """Test LDAP User Info"""
-        assert isinstance(body, models.WriteLDAPConfig)
         response = self.put(
             f"/ldap_config/test_user_info",
             models.LDAPConfigTestResult,
@@ -275,7 +270,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.LDAPConfigTestResult:
         """Test LDAP User Auth"""
-        assert isinstance(body, models.WriteLDAPConfig)
         response = self.put(
             f"/ldap_config/test_user_auth",
             models.LDAPConfigTestResult,
@@ -326,7 +320,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.OIDCConfig:
         """Update OIDC Configuration"""
-        assert isinstance(body, models.WriteOIDCConfig)
         response = self.patch(
             f"/oidc_config",
             models.OIDCConfig,
@@ -381,7 +374,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.OIDCConfig:
         """Create OIDC Test Configuration"""
-        assert isinstance(body, models.WriteOIDCConfig)
         response = self.post(
             f"/oidc_test_configs",
             models.OIDCConfig,
@@ -415,7 +407,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.PasswordConfig:
         """Update Password Config"""
-        assert isinstance(body, models.WritePasswordConfig)
         response = self.patch(
             f"/password_config",
             models.PasswordConfig,
@@ -481,7 +472,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.SamlConfig:
         """Update SAML Configuration"""
-        assert isinstance(body, models.WriteSamlConfig)
         response = self.patch(
             f"/saml_config",
             models.SamlConfig,
@@ -536,7 +526,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.SamlConfig:
         """Create SAML Test Configuration"""
-        assert isinstance(body, models.WriteSamlConfig)
         response = self.post(
             f"/saml_test_configs",
             models.SamlConfig,
@@ -555,7 +544,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.SamlMetadataParseResult:
         """Parse SAML IdP XML"""
-        assert isinstance(body, str)
         response = self.post(
             f"/parse_saml_idp_metadata",
             models.SamlMetadataParseResult,
@@ -576,7 +564,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.SamlMetadataParseResult:
         """Parse SAML IdP Url"""
-        assert isinstance(body, str)
         response = self.post(
             f"/fetch_and_parse_saml_idp_metadata",
             models.SamlMetadataParseResult,
@@ -610,7 +597,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.SessionConfig:
         """Update Session Config"""
-        assert isinstance(body, models.WriteSessionConfig)
         response = self.patch(
             f"/session_config",
             models.SessionConfig,
@@ -748,7 +734,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.ColorCollection:
         """Create ColorCollection"""
-        assert isinstance(body, models.WriteColorCollection)
         response = self.post(
             f"/color_collections",
             models.ColorCollection,
@@ -891,7 +876,6 @@ class Looker31SDK(api_methods.APIMethods):
     ) -> models.ColorCollection:
         """Update Custom Color collection"""
         collection_id = self.encode_path_param(collection_id)
-        assert isinstance(body, models.WriteColorCollection)
         response = self.patch(
             f"/color_collections/{collection_id}",
             models.ColorCollection,
@@ -955,7 +939,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.BackupConfiguration:
         """Update Backup Configuration"""
-        assert isinstance(body, models.WriteBackupConfiguration)
         response = self.patch(
             f"/backup_configuration",
             models.BackupConfiguration,
@@ -989,7 +972,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.BackupConfiguration:
         """Update Cloud Storage"""
-        assert isinstance(body, models.WriteBackupConfiguration)
         response = self.patch(
             f"/cloud_storage",
             models.BackupConfiguration,
@@ -1025,7 +1007,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.CustomWelcomeEmail:
         """Update Custom Welcome Email Content"""
-        assert isinstance(body, models.WriteCustomWelcomeEmail)
         response = self.patch(
             f"/custom_welcome_email",
             models.CustomWelcomeEmail,
@@ -1045,7 +1026,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.WelcomeEmailTest:
         """Send a test welcome email to the currently logged in user with the supplied content """
-        assert isinstance(body, models.WelcomeEmailTest)
         response = self.put(
             f"/custom_welcome_email_test",
             models.WelcomeEmailTest,
@@ -1079,7 +1059,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.DigestEmails:
         """Update Digest_emails"""
-        assert isinstance(body, models.DigestEmails)
         response = self.patch(
             f"/digest_emails_enabled",
             models.DigestEmails,
@@ -1130,7 +1109,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.InternalHelpResourcesContent:
         """Update internal help resources content"""
-        assert isinstance(body, models.WriteInternalHelpResourcesContent)
         response = self.patch(
             f"/internal_help_resources_content",
             models.InternalHelpResourcesContent,
@@ -1164,7 +1142,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.InternalHelpResources:
         """Update internal help resources configuration"""
-        assert isinstance(body, models.WriteInternalHelpResources)
         response = self.patch(
             f"/internal_help_resources",
             models.InternalHelpResources,
@@ -1218,7 +1195,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.LegacyFeature:
         """Update Legacy Feature"""
-        assert isinstance(body, models.WriteLegacyFeature)
         response = self.patch(
             f"/legacy_features/{legacy_feature_id}",
             models.LegacyFeature,
@@ -1304,7 +1280,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.WhitelabelConfiguration:
         """Update Whitelabel configuration"""
-        assert isinstance(body, models.WriteWhitelabelConfiguration)
         response = self.put(
             f"/whitelabel_configuration",
             models.WhitelabelConfiguration,
@@ -1346,7 +1321,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.DBConnection:
         """Create Connection"""
-        assert isinstance(body, models.WriteDBConnection)
         response = self.post(
             f"/connections",
             models.DBConnection,
@@ -1390,7 +1364,6 @@ class Looker31SDK(api_methods.APIMethods):
     ) -> models.DBConnection:
         """Update Connection"""
         connection_name = self.encode_path_param(connection_name)
-        assert isinstance(body, models.WriteDBConnection)
         response = self.patch(
             f"/connections/{connection_name}",
             models.DBConnection,
@@ -1486,7 +1459,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> Sequence[models.DBConnectionTestResult]:
         """Test Connection Configuration"""
-        assert isinstance(body, models.WriteDBConnection)
         response = self.put(
             f"/connections/test",
             Sequence[models.DBConnectionTestResult],
@@ -1637,7 +1609,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.ContentFavorite:
         """Create Favorite Content"""
-        assert isinstance(body, models.WriteContentFavorite)
         response = self.post(
             f"/content_favorite",
             models.ContentFavorite,
@@ -1700,7 +1671,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.ContentMeta:
         """Update Content Metadata"""
-        assert isinstance(body, models.WriteContentMeta)
         response = self.patch(
             f"/content_metadata/{content_metadata_id}",
             models.ContentMeta,
@@ -1742,7 +1712,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.ContentMetaGroupUser:
         """Create Content Metadata Access"""
-        assert isinstance(body, models.ContentMetaGroupUser)
         response = self.post(
             f"/content_metadata_access",
             models.ContentMetaGroupUser,
@@ -1766,7 +1735,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.ContentMetaGroupUser:
         """Update Content Metadata Access"""
-        assert isinstance(body, models.ContentMetaGroupUser)
         response = self.put(
             f"/content_metadata_access/{content_metadata_access_id}",
             models.ContentMetaGroupUser,
@@ -1973,7 +1941,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.Dashboard:
         """Create Dashboard"""
-        assert isinstance(body, models.WriteDashboard)
         response = self.post(
             f"/dashboards",
             models.Dashboard,
@@ -2114,8 +2081,6 @@ class Looker31SDK(api_methods.APIMethods):
         """Import LookML Dashboard"""
         lookml_dashboard_id = self.encode_path_param(lookml_dashboard_id)
         space_id = self.encode_path_param(space_id)
-        if body:
-            assert isinstance(body, models.WriteDashboard)
         response = self.post(
             f"/dashboards/{lookml_dashboard_id}/import/{space_id}",
             models.Dashboard,
@@ -2148,7 +2113,6 @@ class Looker31SDK(api_methods.APIMethods):
     ) -> Sequence[int]:
         """Sync LookML Dashboard"""
         lookml_dashboard_id = self.encode_path_param(lookml_dashboard_id)
-        assert isinstance(body, models.WriteDashboard)
         response = self.patch(
             f"/dashboards/{lookml_dashboard_id}/sync",
             Sequence[int],
@@ -2208,7 +2172,6 @@ class Looker31SDK(api_methods.APIMethods):
     ) -> models.Dashboard:
         """Update Dashboard"""
         dashboard_id = self.encode_path_param(dashboard_id)
-        assert isinstance(body, models.WriteDashboard)
         response = self.patch(
             f"/dashboards/{dashboard_id}",
             models.Dashboard,
@@ -2381,7 +2344,6 @@ class Looker31SDK(api_methods.APIMethods):
     ) -> models.DashboardElement:
         """Update DashboardElement"""
         dashboard_element_id = self.encode_path_param(dashboard_element_id)
-        assert isinstance(body, models.WriteDashboardElement)
         response = self.patch(
             f"/dashboard_elements/{dashboard_element_id}",
             models.DashboardElement,
@@ -2444,7 +2406,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.DashboardElement:
         """Create DashboardElement"""
-        assert isinstance(body, models.WriteDashboardElement)
         response = self.post(
             f"/dashboard_elements",
             models.DashboardElement,
@@ -2491,7 +2452,6 @@ class Looker31SDK(api_methods.APIMethods):
     ) -> models.DashboardFilter:
         """Update Dashboard Filter"""
         dashboard_filter_id = self.encode_path_param(dashboard_filter_id)
-        assert isinstance(body, models.WriteDashboardFilter)
         response = self.patch(
             f"/dashboard_filters/{dashboard_filter_id}",
             models.DashboardFilter,
@@ -2554,7 +2514,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.DashboardFilter:
         """Create Dashboard Filter"""
-        assert isinstance(body, models.WriteCreateDashboardFilter)
         response = self.post(
             f"/dashboard_filters",
             models.DashboardFilter,
@@ -2605,7 +2564,6 @@ class Looker31SDK(api_methods.APIMethods):
         dashboard_layout_component_id = self.encode_path_param(
             dashboard_layout_component_id
         )
-        assert isinstance(body, models.WriteDashboardLayoutComponent)
         response = self.patch(
             f"/dashboard_layout_components/{dashboard_layout_component_id}",
             models.DashboardLayoutComponent,
@@ -2674,7 +2632,6 @@ class Looker31SDK(api_methods.APIMethods):
     ) -> models.DashboardLayout:
         """Update DashboardLayout"""
         dashboard_layout_id = self.encode_path_param(dashboard_layout_id)
-        assert isinstance(body, models.WriteDashboardLayout)
         response = self.patch(
             f"/dashboard_layouts/{dashboard_layout_id}",
             models.DashboardLayout,
@@ -2737,7 +2694,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.DashboardLayout:
         """Create DashboardLayout"""
-        assert isinstance(body, models.WriteDashboardLayout)
         response = self.post(
             f"/dashboard_layouts",
             models.DashboardLayout,
@@ -2761,7 +2717,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.DataActionResponse:
         """Send a Data Action"""
-        assert isinstance(body, models.DataActionRequest)
         response = self.post(
             f"/data_actions",
             models.DataActionResponse,
@@ -2780,7 +2735,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.DataActionForm:
         """Fetch Remote Data Action Form"""
-        assert isinstance(body, MutableMapping)
         response = self.post(
             f"/data_actions/form",
             models.DataActionForm,
@@ -2840,7 +2794,6 @@ class Looker31SDK(api_methods.APIMethods):
     ) -> models.Datagroup:
         """Update Datagroup"""
         datagroup_id = self.encode_path_param(datagroup_id)
-        assert isinstance(body, models.WriteDatagroup)
         response = self.patch(
             f"/datagroups/{datagroup_id}",
             models.Datagroup,
@@ -2939,7 +2892,6 @@ class Looker31SDK(api_methods.APIMethods):
     ) -> models.Folder:
         """Update Folder"""
         folder_id = self.encode_path_param(folder_id)
-        assert isinstance(body, models.UpdateFolder)
         response = self.patch(
             f"/folders/{folder_id}",
             models.Folder,
@@ -2998,7 +2950,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.Folder:
         """Create Folder"""
-        assert isinstance(body, models.CreateFolder)
         response = self.post(
             f"/folders", models.Folder, body=body, transport_options=transport_options
         )
@@ -3206,7 +3157,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.Group:
         """Create Group"""
-        assert isinstance(body, models.WriteGroup)
         response = self.post(
             f"/groups",
             models.Group,
@@ -3322,7 +3272,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.Group:
         """Update Group"""
-        assert isinstance(body, models.WriteGroup)
         response = self.patch(
             f"/groups/{group_id}",
             models.Group,
@@ -3381,7 +3330,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.Group:
         """Add a Group to Group"""
-        assert isinstance(body, models.GroupIdForGroupInclusion)
         response = self.post(
             f"/groups/{group_id}/groups",
             models.Group,
@@ -3434,7 +3382,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.User:
         """Add a User to Group"""
-        assert isinstance(body, models.GroupIdForGroupUserInclusion)
         response = self.post(
             f"/groups/{group_id}/users",
             models.User,
@@ -3499,7 +3446,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.UserAttributeGroupValue:
         """Set User Attribute Group Value"""
-        assert isinstance(body, models.UserAttributeGroupValue)
         response = self.patch(
             f"/groups/{group_id}/attribute_values/{user_attribute_id}",
             models.UserAttributeGroupValue,
@@ -3563,7 +3509,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.Homepage:
         """Create Homepage"""
-        assert isinstance(body, models.WriteHomepage)
         response = self.post(
             f"/homepages",
             models.Homepage,
@@ -3686,7 +3631,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.Homepage:
         """Update Homepage"""
-        assert isinstance(body, models.WriteHomepage)
         response = self.patch(
             f"/homepages/{homepage_id}",
             models.Homepage,
@@ -3751,7 +3695,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.HomepageItem:
         """Create Homepage Item"""
-        assert isinstance(body, models.WriteHomepageItem)
         response = self.post(
             f"/homepage_items",
             models.HomepageItem,
@@ -3796,7 +3739,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.HomepageItem:
         """Update Homepage Item"""
-        assert isinstance(body, models.WriteHomepageItem)
         response = self.patch(
             f"/homepage_items/{homepage_item_id}",
             models.HomepageItem,
@@ -3857,7 +3799,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.HomepageSection:
         """Create Homepage section"""
-        assert isinstance(body, models.WriteHomepageSection)
         response = self.post(
             f"/homepage_sections",
             models.HomepageSection,
@@ -3902,7 +3843,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.HomepageSection:
         """Update Homepage section"""
-        assert isinstance(body, models.WriteHomepageSection)
         response = self.patch(
             f"/homepage_sections/{homepage_section_id}",
             models.HomepageSection,
@@ -3967,7 +3907,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.IntegrationHub:
         """Create Integration Hub"""
-        assert isinstance(body, models.WriteIntegrationHub)
         response = self.post(
             f"/integration_hubs",
             models.IntegrationHub,
@@ -4014,7 +3953,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.IntegrationHub:
         """Update Integration Hub"""
-        assert isinstance(body, models.WriteIntegrationHub)
         response = self.patch(
             f"/integration_hubs/{integration_hub_id}",
             models.IntegrationHub,
@@ -4118,7 +4056,6 @@ class Looker31SDK(api_methods.APIMethods):
     ) -> models.Integration:
         """Update Integration"""
         integration_id = self.encode_path_param(integration_id)
-        assert isinstance(body, models.WriteIntegration)
         response = self.patch(
             f"/integrations/{integration_id}",
             models.Integration,
@@ -4213,7 +4150,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.LookWithQuery:
         """Create Look"""
-        assert isinstance(body, models.WriteLookWithQuery)
         response = self.post(
             f"/looks",
             models.LookWithQuery,
@@ -4374,7 +4310,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.LookWithQuery:
         """Update Look"""
-        assert isinstance(body, models.WriteLookWithQuery)
         response = self.patch(
             f"/looks/{look_id}",
             models.LookWithQuery,
@@ -4515,7 +4450,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.LookmlModel:
         """Create LookML Model"""
-        assert isinstance(body, models.WriteLookmlModel)
         response = self.post(
             f"/lookml_models",
             models.LookmlModel,
@@ -4559,7 +4493,6 @@ class Looker31SDK(api_methods.APIMethods):
     ) -> models.LookmlModel:
         """Update LookML Model"""
         lookml_model_name = self.encode_path_param(lookml_model_name)
-        assert isinstance(body, models.WriteLookmlModel)
         response = self.patch(
             f"/lookml_models/{lookml_model_name}",
             models.LookmlModel,
@@ -4679,7 +4612,6 @@ class Looker31SDK(api_methods.APIMethods):
     ) -> models.GitBranch:
         """Update Project Git Branch"""
         project_id = self.encode_path_param(project_id)
-        assert isinstance(body, models.WriteGitBranch)
         response = self.put(
             f"/projects/{project_id}/git_branch",
             models.GitBranch,
@@ -4708,7 +4640,6 @@ class Looker31SDK(api_methods.APIMethods):
     ) -> models.GitBranch:
         """Checkout New Git Branch"""
         project_id = self.encode_path_param(project_id)
-        assert isinstance(body, models.WriteGitBranch)
         response = self.post(
             f"/projects/{project_id}/git_branch",
             models.GitBranch,
@@ -4906,7 +4837,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.Project:
         """Create Project"""
-        assert isinstance(body, models.WriteProject)
         response = self.post(
             f"/projects", models.Project, body=body, transport_options=transport_options
         )
@@ -4972,7 +4902,6 @@ class Looker31SDK(api_methods.APIMethods):
     ) -> models.Project:
         """Update Project"""
         project_id = self.encode_path_param(project_id)
-        assert isinstance(body, models.WriteProject)
         response = self.patch(
             f"/projects/{project_id}",
             models.Project,
@@ -5325,7 +5254,6 @@ class Looker31SDK(api_methods.APIMethods):
         """Create Repository Credential"""
         root_project_id = self.encode_path_param(root_project_id)
         credential_id = self.encode_path_param(credential_id)
-        assert isinstance(body, models.WriteRepositoryCredential)
         response = self.put(
             f"/projects/{root_project_id}/credential/{credential_id}",
             models.RepositoryCredential,
@@ -5427,7 +5355,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.QueryTask:
         """Run Query Async"""
-        assert isinstance(body, models.WriteCreateQueryTask)
         response = self.post(
             f"/query_tasks",
             models.QueryTask,
@@ -5639,7 +5566,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.Query:
         """Create Query"""
-        assert isinstance(body, models.WriteQuery)
         response = self.post(
             f"/queries",
             models.Query,
@@ -5814,7 +5740,6 @@ class Looker31SDK(api_methods.APIMethods):
     ) -> Union[str, bytes]:
         """Run Inline Query"""
         result_format = self.encode_path_param(result_format)
-        assert isinstance(body, models.WriteQuery)
         response = self.post(
             f"/queries/run/{result_format}",
             Union[str, bytes],  # type: ignore
@@ -5965,8 +5890,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.MergeQuery:
         """Create Merge Query"""
-        if body:
-            assert isinstance(body, models.WriteMergeQuery)
         response = self.post(
             f"/merge_queries",
             models.MergeQuery,
@@ -6039,7 +5962,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.SqlQuery:
         """Create SQL Runner Query"""
-        assert isinstance(body, models.SqlQueryCreate)
         response = self.post(
             f"/sql_queries",
             models.SqlQuery,
@@ -6109,7 +6031,6 @@ class Looker31SDK(api_methods.APIMethods):
         """Create Lookml Dashboard Render Task"""
         dashboard_id = self.encode_path_param(dashboard_id)
         result_format = self.encode_path_param(result_format)
-        assert isinstance(body, models.CreateDashboardRenderTask)
         response = self.post(
             f"/render_tasks/lookml_dashboards/{dashboard_id}/{result_format}",
             models.RenderTask,
@@ -6218,7 +6139,6 @@ class Looker31SDK(api_methods.APIMethods):
     ) -> models.RenderTask:
         """Create Dashboard Render Task"""
         result_format = self.encode_path_param(result_format)
-        assert isinstance(body, models.CreateDashboardRenderTask)
         response = self.post(
             f"/render_tasks/dashboards/{dashboard_id}/{result_format}",
             models.RenderTask,
@@ -6398,7 +6318,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.ModelSet:
         """Update Model Set"""
-        assert isinstance(body, models.WriteModelSet)
         response = self.patch(
             f"/model_sets/{model_set_id}",
             models.ModelSet,
@@ -6452,7 +6371,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.ModelSet:
         """Create Model Set"""
-        assert isinstance(body, models.WriteModelSet)
         response = self.post(
             f"/model_sets",
             models.ModelSet,
@@ -6575,7 +6493,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.PermissionSet:
         """Update Permission Set"""
-        assert isinstance(body, models.WritePermissionSet)
         response = self.patch(
             f"/permission_sets/{permission_set_id}",
             models.PermissionSet,
@@ -6631,7 +6548,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.PermissionSet:
         """Create Permission Set"""
-        assert isinstance(body, models.WritePermissionSet)
         response = self.post(
             f"/permission_sets",
             models.PermissionSet,
@@ -6671,7 +6587,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.Role:
         """Create Role"""
-        assert isinstance(body, models.WriteRole)
         response = self.post(
             f"/roles", models.Role, body=body, transport_options=transport_options
         )
@@ -6770,7 +6685,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.Role:
         """Update Role"""
-        assert isinstance(body, models.WriteRole)
         response = self.patch(
             f"/roles/{role_id}",
             models.Role,
@@ -6828,7 +6742,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> Sequence[models.Group]:
         """Update Role Groups"""
-        assert isinstance(body, Sequence)
         response = self.put(
             f"/roles/{role_id}/groups",
             Sequence[models.Group],
@@ -6875,7 +6788,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> Sequence[models.User]:
         """Update Role Users"""
-        assert isinstance(body, Sequence)
         response = self.put(
             f"/roles/{role_id}/users",
             Sequence[models.User],
@@ -6987,7 +6899,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.ScheduledPlan:
         """Update Scheduled Plan"""
-        assert isinstance(body, models.WriteScheduledPlan)
         response = self.patch(
             f"/scheduled_plans/{scheduled_plan_id}",
             models.ScheduledPlan,
@@ -7118,7 +7029,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.ScheduledPlan:
         """Create Scheduled Plan"""
-        assert isinstance(body, models.WriteScheduledPlan)
         response = self.post(
             f"/scheduled_plans",
             models.ScheduledPlan,
@@ -7173,7 +7083,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.ScheduledPlan:
         """Run Scheduled Plan Once"""
-        assert isinstance(body, models.WriteScheduledPlan)
         response = self.post(
             f"/scheduled_plans/run_once",
             models.ScheduledPlan,
@@ -7345,8 +7254,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.ScheduledPlan:
         """Run Scheduled Plan Once by Id"""
-        if body:
-            assert isinstance(body, models.WriteScheduledPlan)
         response = self.post(
             f"/scheduled_plans/{scheduled_plan_id}/run_once",
             models.ScheduledPlan,
@@ -7403,7 +7310,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.ApiSession:
         """Update Session"""
-        assert isinstance(body, models.WriteApiSession)
         response = self.patch(
             f"/session",
             models.ApiSession,
@@ -7530,7 +7436,6 @@ class Looker31SDK(api_methods.APIMethods):
     ) -> models.Space:
         """Update Space"""
         space_id = self.encode_path_param(space_id)
-        assert isinstance(body, models.UpdateSpace)
         response = self.patch(
             f"/spaces/{space_id}",
             models.Space,
@@ -7589,7 +7494,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.Space:
         """Create Space"""
-        assert isinstance(body, models.CreateSpace)
         response = self.post(
             f"/spaces", models.Space, body=body, transport_options=transport_options
         )
@@ -7795,7 +7699,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.Theme:
         """Create Theme"""
-        assert isinstance(body, models.WriteTheme)
         response = self.post(
             f"/themes", models.Theme, body=body, transport_options=transport_options
         )
@@ -8010,7 +7913,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.ValidationError:
         """Validate Theme"""
-        assert isinstance(body, models.WriteTheme)
         response = self.post(
             f"/themes/validate",
             models.ValidationError,
@@ -8060,7 +7962,6 @@ class Looker31SDK(api_methods.APIMethods):
     ) -> models.Theme:
         """Update Theme"""
         theme_id = self.encode_path_param(theme_id)
-        assert isinstance(body, models.WriteTheme)
         response = self.patch(
             f"/themes/{theme_id}",
             models.Theme,
@@ -8162,8 +8063,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.User:
         """Create User"""
-        if body:
-            assert isinstance(body, models.WriteUser)
         response = self.post(
             f"/users",
             models.User,
@@ -8354,7 +8253,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.User:
         """Update User"""
-        assert isinstance(body, models.WriteUser)
         response = self.patch(
             f"/users/{user_id}",
             models.User,
@@ -8469,7 +8367,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.CredentialsEmail:
         """Create Email/Password Credential"""
-        assert isinstance(body, models.WriteCredentialsEmail)
         response = self.post(
             f"/users/{user_id}/credentials_email",
             models.CredentialsEmail,
@@ -8493,7 +8390,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.CredentialsEmail:
         """Update Email/Password Credential"""
-        assert isinstance(body, models.WriteCredentialsEmail)
         response = self.patch(
             f"/users/{user_id}/credentials_email",
             models.CredentialsEmail,
@@ -8556,8 +8452,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.CredentialsTotp:
         """Create Two-Factor Credential"""
-        if body:
-            assert isinstance(body, models.CredentialsTotp)
         response = self.post(
             f"/users/{user_id}/credentials_totp",
             models.CredentialsTotp,
@@ -8819,8 +8713,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.CredentialsApi3:
         """Create API 3 Credential"""
-        if body:
-            assert isinstance(body, models.CredentialsApi3)
         response = self.post(
             f"/users/{user_id}/credentials_api3",
             models.CredentialsApi3,
@@ -9068,7 +8960,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> Sequence[models.Role]:
         """Set User Roles"""
-        assert isinstance(body, Sequence)
         response = self.put(
             f"/users/{user_id}/roles",
             Sequence[models.Role],
@@ -9141,7 +9032,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.UserAttributeWithValue:
         """Set User Attribute User Value"""
-        assert isinstance(body, models.WriteUserAttributeWithValue)
         response = self.patch(
             f"/users/{user_id}/attribute_values/{user_attribute_id}",
             models.UserAttributeWithValue,
@@ -9221,7 +9111,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.UserAttribute:
         """Create User Attribute"""
-        assert isinstance(body, models.WriteUserAttribute)
         response = self.post(
             f"/user_attributes",
             models.UserAttribute,
@@ -9266,7 +9155,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.UserAttribute:
         """Update User Attribute"""
-        assert isinstance(body, models.WriteUserAttribute)
         response = self.patch(
             f"/user_attributes/{user_attribute_id}",
             models.UserAttribute,
@@ -9352,7 +9240,6 @@ class Looker31SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> Sequence[models.UserAttributeGroupValue]:
         """Set User Attribute Group Values"""
-        assert isinstance(body, Sequence)
         response = self.post(
             f"/user_attributes/{user_attribute_id}/group_values",
             Sequence[models.UserAttributeGroupValue],

--- a/python/looker_sdk/sdk/api40/methods.py
+++ b/python/looker_sdk/sdk/api40/methods.py
@@ -90,7 +90,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.EmbedUrlResponse:
         """Create SSO Embed Url"""
-        assert isinstance(body, models.EmbedSsoParams)
         response = self.post(
             f"/embed/sso_url",
             models.EmbedUrlResponse,
@@ -127,7 +126,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.EmbedUrlResponse:
         """Create Embed Url"""
-        assert isinstance(body, models.EmbedParams)
         response = self.post(
             f"/embed/token_url/me",
             models.EmbedUrlResponse,
@@ -184,7 +182,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.LDAPConfig:
         """Update LDAP Configuration"""
-        assert isinstance(body, models.WriteLDAPConfig)
         response = self.patch(
             f"/ldap_config",
             models.LDAPConfig,
@@ -220,7 +217,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.LDAPConfigTestResult:
         """Test LDAP Connection"""
-        assert isinstance(body, models.WriteLDAPConfig)
         response = self.put(
             f"/ldap_config/test_connection",
             models.LDAPConfigTestResult,
@@ -258,7 +254,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.LDAPConfigTestResult:
         """Test LDAP Auth"""
-        assert isinstance(body, models.WriteLDAPConfig)
         response = self.put(
             f"/ldap_config/test_auth",
             models.LDAPConfigTestResult,
@@ -285,7 +280,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.LDAPConfigTestResult:
         """Test LDAP User Info"""
-        assert isinstance(body, models.WriteLDAPConfig)
         response = self.put(
             f"/ldap_config/test_user_info",
             models.LDAPConfigTestResult,
@@ -312,7 +306,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.LDAPConfigTestResult:
         """Test LDAP User Auth"""
-        assert isinstance(body, models.WriteLDAPConfig)
         response = self.put(
             f"/ldap_config/test_user_auth",
             models.LDAPConfigTestResult,
@@ -390,7 +383,6 @@ class Looker40SDK(api_methods.APIMethods):
     ) -> models.OauthClientApp:
         """Register OAuth App"""
         client_guid = self.encode_path_param(client_guid)
-        assert isinstance(body, models.WriteOauthClientApp)
         response = self.post(
             f"/oauth_client_apps/{client_guid}",
             models.OauthClientApp,
@@ -417,7 +409,6 @@ class Looker40SDK(api_methods.APIMethods):
     ) -> models.OauthClientApp:
         """Update OAuth App"""
         client_guid = self.encode_path_param(client_guid)
-        assert isinstance(body, models.WriteOauthClientApp)
         response = self.patch(
             f"/oauth_client_apps/{client_guid}",
             models.OauthClientApp,
@@ -578,7 +569,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.OIDCConfig:
         """Update OIDC Configuration"""
-        assert isinstance(body, models.WriteOIDCConfig)
         response = self.patch(
             f"/oidc_config",
             models.OIDCConfig,
@@ -633,7 +623,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.OIDCConfig:
         """Create OIDC Test Configuration"""
-        assert isinstance(body, models.WriteOIDCConfig)
         response = self.post(
             f"/oidc_test_configs",
             models.OIDCConfig,
@@ -667,7 +656,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.PasswordConfig:
         """Update Password Config"""
-        assert isinstance(body, models.WritePasswordConfig)
         response = self.patch(
             f"/password_config",
             models.PasswordConfig,
@@ -733,7 +721,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.SamlConfig:
         """Update SAML Configuration"""
-        assert isinstance(body, models.WriteSamlConfig)
         response = self.patch(
             f"/saml_config",
             models.SamlConfig,
@@ -788,7 +775,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.SamlConfig:
         """Create SAML Test Configuration"""
-        assert isinstance(body, models.WriteSamlConfig)
         response = self.post(
             f"/saml_test_configs",
             models.SamlConfig,
@@ -807,7 +793,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.SamlMetadataParseResult:
         """Parse SAML IdP XML"""
-        assert isinstance(body, str)
         response = self.post(
             f"/parse_saml_idp_metadata",
             models.SamlMetadataParseResult,
@@ -828,7 +813,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.SamlMetadataParseResult:
         """Parse SAML IdP Url"""
-        assert isinstance(body, str)
         response = self.post(
             f"/fetch_and_parse_saml_idp_metadata",
             models.SamlMetadataParseResult,
@@ -862,7 +846,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.SessionConfig:
         """Update Session Config"""
-        assert isinstance(body, models.WriteSessionConfig)
         response = self.patch(
             f"/session_config",
             models.SessionConfig,
@@ -987,7 +970,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.Board:
         """Create Board"""
-        assert isinstance(body, models.WriteBoard)
         response = self.post(
             f"/boards",
             models.Board,
@@ -1110,7 +1092,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.Board:
         """Update Board"""
-        assert isinstance(body, models.WriteBoard)
         response = self.patch(
             f"/boards/{board_id}",
             models.Board,
@@ -1175,7 +1156,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.BoardItem:
         """Create Board Item"""
-        assert isinstance(body, models.WriteBoardItem)
         response = self.post(
             f"/board_items",
             models.BoardItem,
@@ -1220,7 +1200,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.BoardItem:
         """Update Board Item"""
-        assert isinstance(body, models.WriteBoardItem)
         response = self.patch(
             f"/board_items/{board_item_id}",
             models.BoardItem,
@@ -1279,7 +1258,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.BoardSection:
         """Create Board section"""
-        assert isinstance(body, models.WriteBoardSection)
         response = self.post(
             f"/board_sections",
             models.BoardSection,
@@ -1324,7 +1302,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.BoardSection:
         """Update Board section"""
-        assert isinstance(body, models.WriteBoardSection)
         response = self.patch(
             f"/board_sections/{board_section_id}",
             models.BoardSection,
@@ -1400,7 +1377,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.ColorCollection:
         """Create ColorCollection"""
-        assert isinstance(body, models.WriteColorCollection)
         response = self.post(
             f"/color_collections",
             models.ColorCollection,
@@ -1543,7 +1519,6 @@ class Looker40SDK(api_methods.APIMethods):
     ) -> models.ColorCollection:
         """Update Custom Color collection"""
         collection_id = self.encode_path_param(collection_id)
-        assert isinstance(body, models.WriteColorCollection)
         response = self.patch(
             f"/color_collections/{collection_id}",
             models.ColorCollection,
@@ -1622,7 +1597,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.Command:
         """Create a custom command"""
-        assert isinstance(body, models.WriteCommand)
         response = self.post(
             f"/commands", models.Command, body=body, transport_options=transport_options
         )
@@ -1642,7 +1616,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.Command:
         """Update a custom command"""
-        assert isinstance(body, models.UpdateCommand)
         response = self.patch(
             f"/commands/{command_id}",
             models.Command,
@@ -1696,7 +1669,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.BackupConfiguration:
         """Update Cloud Storage"""
-        assert isinstance(body, models.WriteBackupConfiguration)
         response = self.patch(
             f"/cloud_storage",
             models.BackupConfiguration,
@@ -1732,7 +1704,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.CustomWelcomeEmail:
         """Update Custom Welcome Email Content"""
-        assert isinstance(body, models.WriteCustomWelcomeEmail)
         response = self.patch(
             f"/custom_welcome_email",
             models.CustomWelcomeEmail,
@@ -1752,7 +1723,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.WelcomeEmailTest:
         """Send a test welcome email to the currently logged in user with the supplied content """
-        assert isinstance(body, models.WelcomeEmailTest)
         response = self.put(
             f"/custom_welcome_email_test",
             models.WelcomeEmailTest,
@@ -1786,7 +1756,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.DigestEmails:
         """Update Digest_emails"""
-        assert isinstance(body, models.DigestEmails)
         response = self.patch(
             f"/digest_emails_enabled",
             models.DigestEmails,
@@ -1837,7 +1806,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.InternalHelpResourcesContent:
         """Update internal help resources content"""
-        assert isinstance(body, models.WriteInternalHelpResourcesContent)
         response = self.patch(
             f"/internal_help_resources_content",
             models.InternalHelpResourcesContent,
@@ -1871,7 +1839,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.InternalHelpResources:
         """Update internal help resources configuration"""
-        assert isinstance(body, models.WriteInternalHelpResources)
         response = self.patch(
             f"/internal_help_resources",
             models.InternalHelpResources,
@@ -1927,7 +1894,6 @@ class Looker40SDK(api_methods.APIMethods):
     ) -> models.LegacyFeature:
         """Update Legacy Feature"""
         legacy_feature_id = self.encode_path_param(legacy_feature_id)
-        assert isinstance(body, models.WriteLegacyFeature)
         response = self.patch(
             f"/legacy_features/{legacy_feature_id}",
             models.LegacyFeature,
@@ -2013,7 +1979,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.WhitelabelConfiguration:
         """Update Whitelabel configuration"""
-        assert isinstance(body, models.WriteWhitelabelConfiguration)
         response = self.put(
             f"/whitelabel_configuration",
             models.WhitelabelConfiguration,
@@ -2055,7 +2020,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.DBConnection:
         """Create Connection"""
-        assert isinstance(body, models.WriteDBConnection)
         response = self.post(
             f"/connections",
             models.DBConnection,
@@ -2099,7 +2063,6 @@ class Looker40SDK(api_methods.APIMethods):
     ) -> models.DBConnection:
         """Update Connection"""
         connection_name = self.encode_path_param(connection_name)
-        assert isinstance(body, models.WriteDBConnection)
         response = self.patch(
             f"/connections/{connection_name}",
             models.DBConnection,
@@ -2195,7 +2158,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> Sequence[models.DBConnectionTestResult]:
         """Test Connection Configuration"""
-        assert isinstance(body, models.WriteDBConnection)
         response = self.put(
             f"/connections/test",
             Sequence[models.DBConnectionTestResult],
@@ -2253,7 +2215,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.SshServer:
         """Create SSH Server"""
-        assert isinstance(body, models.WriteSshServer)
         response = self.post(
             f"/ssh_servers",
             models.SshServer,
@@ -2294,7 +2255,6 @@ class Looker40SDK(api_methods.APIMethods):
     ) -> models.SshServer:
         """Update SSH Server"""
         ssh_server_id = self.encode_path_param(ssh_server_id)
-        assert isinstance(body, models.WriteSshServer)
         response = self.patch(
             f"/ssh_server/{ssh_server_id}",
             models.SshServer,
@@ -2368,7 +2328,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.SshTunnel:
         """Create SSH Tunnel"""
-        assert isinstance(body, models.WriteSshTunnel)
         response = self.post(
             f"/ssh_tunnels",
             models.SshTunnel,
@@ -2409,7 +2368,6 @@ class Looker40SDK(api_methods.APIMethods):
     ) -> models.SshTunnel:
         """Update SSH Tunnel"""
         ssh_tunnel_id = self.encode_path_param(ssh_tunnel_id)
-        assert isinstance(body, models.WriteSshTunnel)
         response = self.patch(
             f"/ssh_tunnel/{ssh_tunnel_id}",
             models.SshTunnel,
@@ -2594,7 +2552,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.ContentFavorite:
         """Create Favorite Content"""
-        assert isinstance(body, models.WriteContentFavorite)
         response = self.post(
             f"/content_favorite",
             models.ContentFavorite,
@@ -2657,7 +2614,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.ContentMeta:
         """Update Content Metadata"""
-        assert isinstance(body, models.WriteContentMeta)
         response = self.patch(
             f"/content_metadata/{content_metadata_id}",
             models.ContentMeta,
@@ -2699,7 +2655,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.ContentMetaGroupUser:
         """Create Content Metadata Access"""
-        assert isinstance(body, models.ContentMetaGroupUser)
         response = self.post(
             f"/content_metadata_access",
             models.ContentMetaGroupUser,
@@ -2724,7 +2679,6 @@ class Looker40SDK(api_methods.APIMethods):
     ) -> models.ContentMetaGroupUser:
         """Update Content Metadata Access"""
         content_metadata_access_id = self.encode_path_param(content_metadata_access_id)
-        assert isinstance(body, models.ContentMetaGroupUser)
         response = self.put(
             f"/content_metadata_access/{content_metadata_access_id}",
             models.ContentMetaGroupUser,
@@ -2931,7 +2885,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.Dashboard:
         """Create Dashboard"""
-        assert isinstance(body, models.WriteDashboard)
         response = self.post(
             f"/dashboards",
             models.Dashboard,
@@ -3072,8 +3025,6 @@ class Looker40SDK(api_methods.APIMethods):
         """Import LookML Dashboard"""
         lookml_dashboard_id = self.encode_path_param(lookml_dashboard_id)
         space_id = self.encode_path_param(space_id)
-        if body:
-            assert isinstance(body, models.WriteDashboard)
         response = self.post(
             f"/dashboards/{lookml_dashboard_id}/import/{space_id}",
             models.Dashboard,
@@ -3106,7 +3057,6 @@ class Looker40SDK(api_methods.APIMethods):
     ) -> Sequence[int]:
         """Sync LookML Dashboard"""
         lookml_dashboard_id = self.encode_path_param(lookml_dashboard_id)
-        assert isinstance(body, models.WriteDashboard)
         response = self.patch(
             f"/dashboards/{lookml_dashboard_id}/sync",
             Sequence[int],
@@ -3166,7 +3116,6 @@ class Looker40SDK(api_methods.APIMethods):
     ) -> models.Dashboard:
         """Update Dashboard"""
         dashboard_id = self.encode_path_param(dashboard_id)
-        assert isinstance(body, models.WriteDashboard)
         response = self.patch(
             f"/dashboards/{dashboard_id}",
             models.Dashboard,
@@ -3339,7 +3288,6 @@ class Looker40SDK(api_methods.APIMethods):
     ) -> models.DashboardElement:
         """Update DashboardElement"""
         dashboard_element_id = self.encode_path_param(dashboard_element_id)
-        assert isinstance(body, models.WriteDashboardElement)
         response = self.patch(
             f"/dashboard_elements/{dashboard_element_id}",
             models.DashboardElement,
@@ -3402,7 +3350,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.DashboardElement:
         """Create DashboardElement"""
-        assert isinstance(body, models.WriteDashboardElement)
         response = self.post(
             f"/dashboard_elements",
             models.DashboardElement,
@@ -3449,7 +3396,6 @@ class Looker40SDK(api_methods.APIMethods):
     ) -> models.DashboardFilter:
         """Update Dashboard Filter"""
         dashboard_filter_id = self.encode_path_param(dashboard_filter_id)
-        assert isinstance(body, models.WriteDashboardFilter)
         response = self.patch(
             f"/dashboard_filters/{dashboard_filter_id}",
             models.DashboardFilter,
@@ -3512,7 +3458,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.DashboardFilter:
         """Create Dashboard Filter"""
-        assert isinstance(body, models.WriteCreateDashboardFilter)
         response = self.post(
             f"/dashboard_filters",
             models.DashboardFilter,
@@ -3563,7 +3508,6 @@ class Looker40SDK(api_methods.APIMethods):
         dashboard_layout_component_id = self.encode_path_param(
             dashboard_layout_component_id
         )
-        assert isinstance(body, models.WriteDashboardLayoutComponent)
         response = self.patch(
             f"/dashboard_layout_components/{dashboard_layout_component_id}",
             models.DashboardLayoutComponent,
@@ -3632,7 +3576,6 @@ class Looker40SDK(api_methods.APIMethods):
     ) -> models.DashboardLayout:
         """Update DashboardLayout"""
         dashboard_layout_id = self.encode_path_param(dashboard_layout_id)
-        assert isinstance(body, models.WriteDashboardLayout)
         response = self.patch(
             f"/dashboard_layouts/{dashboard_layout_id}",
             models.DashboardLayout,
@@ -3695,7 +3638,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.DashboardLayout:
         """Create DashboardLayout"""
-        assert isinstance(body, models.WriteDashboardLayout)
         response = self.post(
             f"/dashboard_layouts",
             models.DashboardLayout,
@@ -3719,7 +3661,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.DataActionResponse:
         """Send a Data Action"""
-        assert isinstance(body, models.DataActionRequest)
         response = self.post(
             f"/data_actions",
             models.DataActionResponse,
@@ -3738,7 +3679,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.DataActionForm:
         """Fetch Remote Data Action Form"""
-        assert isinstance(body, MutableMapping)
         response = self.post(
             f"/data_actions/form",
             models.DataActionForm,
@@ -3796,7 +3736,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.Datagroup:
         """Update Datagroup"""
-        assert isinstance(body, models.WriteDatagroup)
         response = self.patch(
             f"/datagroups/{datagroup_id}",
             models.Datagroup,
@@ -3895,7 +3834,6 @@ class Looker40SDK(api_methods.APIMethods):
     ) -> models.Folder:
         """Update Folder"""
         folder_id = self.encode_path_param(folder_id)
-        assert isinstance(body, models.UpdateFolder)
         response = self.patch(
             f"/folders/{folder_id}",
             models.Folder,
@@ -3954,7 +3892,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.Folder:
         """Create Folder"""
-        assert isinstance(body, models.CreateFolder)
         response = self.post(
             f"/folders", models.Folder, body=body, transport_options=transport_options
         )
@@ -4162,7 +4099,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.Group:
         """Create Group"""
-        assert isinstance(body, models.WriteGroup)
         response = self.post(
             f"/groups",
             models.Group,
@@ -4349,7 +4285,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.Group:
         """Update Group"""
-        assert isinstance(body, models.WriteGroup)
         response = self.patch(
             f"/groups/{group_id}",
             models.Group,
@@ -4408,7 +4343,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.Group:
         """Add a Group to Group"""
-        assert isinstance(body, models.GroupIdForGroupInclusion)
         response = self.post(
             f"/groups/{group_id}/groups",
             models.Group,
@@ -4461,7 +4395,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.User:
         """Add a User to Group"""
-        assert isinstance(body, models.GroupIdForGroupUserInclusion)
         response = self.post(
             f"/groups/{group_id}/users",
             models.User,
@@ -4526,7 +4459,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.UserAttributeGroupValue:
         """Set User Attribute Group Value"""
-        assert isinstance(body, models.UserAttributeGroupValue)
         response = self.patch(
             f"/groups/{group_id}/attribute_values/{user_attribute_id}",
             models.UserAttributeGroupValue,
@@ -4592,7 +4524,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.IntegrationHub:
         """Create Integration Hub"""
-        assert isinstance(body, models.WriteIntegrationHub)
         response = self.post(
             f"/integration_hubs",
             models.IntegrationHub,
@@ -4639,7 +4570,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.IntegrationHub:
         """Update Integration Hub"""
-        assert isinstance(body, models.WriteIntegrationHub)
         response = self.patch(
             f"/integration_hubs/{integration_hub_id}",
             models.IntegrationHub,
@@ -4743,7 +4673,6 @@ class Looker40SDK(api_methods.APIMethods):
     ) -> models.Integration:
         """Update Integration"""
         integration_id = self.encode_path_param(integration_id)
-        assert isinstance(body, models.WriteIntegration)
         response = self.patch(
             f"/integrations/{integration_id}",
             models.Integration,
@@ -4838,7 +4767,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.LookWithQuery:
         """Create Look"""
-        assert isinstance(body, models.WriteLookWithQuery)
         response = self.post(
             f"/looks",
             models.LookWithQuery,
@@ -5002,7 +4930,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.LookWithQuery:
         """Update Look"""
-        assert isinstance(body, models.WriteLookWithQuery)
         response = self.patch(
             f"/looks/{look_id}",
             models.LookWithQuery,
@@ -5143,7 +5070,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.LookmlModel:
         """Create LookML Model"""
-        assert isinstance(body, models.WriteLookmlModel)
         response = self.post(
             f"/lookml_models",
             models.LookmlModel,
@@ -5187,7 +5113,6 @@ class Looker40SDK(api_methods.APIMethods):
     ) -> models.LookmlModel:
         """Update LookML Model"""
         lookml_model_name = self.encode_path_param(lookml_model_name)
-        assert isinstance(body, models.WriteLookmlModel)
         response = self.patch(
             f"/lookml_models/{lookml_model_name}",
             models.LookmlModel,
@@ -5335,7 +5260,6 @@ class Looker40SDK(api_methods.APIMethods):
     ) -> models.GitBranch:
         """Update Project Git Branch"""
         project_id = self.encode_path_param(project_id)
-        assert isinstance(body, models.WriteGitBranch)
         response = self.put(
             f"/projects/{project_id}/git_branch",
             models.GitBranch,
@@ -5364,7 +5288,6 @@ class Looker40SDK(api_methods.APIMethods):
     ) -> models.GitBranch:
         """Checkout New Git Branch"""
         project_id = self.encode_path_param(project_id)
-        assert isinstance(body, models.WriteGitBranch)
         response = self.post(
             f"/projects/{project_id}/git_branch",
             models.GitBranch,
@@ -5562,7 +5485,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.Project:
         """Create Project"""
-        assert isinstance(body, models.WriteProject)
         response = self.post(
             f"/projects", models.Project, body=body, transport_options=transport_options
         )
@@ -5628,7 +5550,6 @@ class Looker40SDK(api_methods.APIMethods):
     ) -> models.Project:
         """Update Project"""
         project_id = self.encode_path_param(project_id)
-        assert isinstance(body, models.WriteProject)
         response = self.patch(
             f"/projects/{project_id}",
             models.Project,
@@ -5981,7 +5902,6 @@ class Looker40SDK(api_methods.APIMethods):
         """Create Repository Credential"""
         root_project_id = self.encode_path_param(root_project_id)
         credential_id = self.encode_path_param(credential_id)
-        assert isinstance(body, models.WriteRepositoryCredential)
         response = self.put(
             f"/projects/{root_project_id}/credential/{credential_id}",
             models.RepositoryCredential,
@@ -6083,7 +6003,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.QueryTask:
         """Run Query Async"""
-        assert isinstance(body, models.WriteCreateQueryTask)
         response = self.post(
             f"/query_tasks",
             models.QueryTask,
@@ -6295,7 +6214,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.Query:
         """Create Query"""
-        assert isinstance(body, models.WriteQuery)
         response = self.post(
             f"/queries",
             models.Query,
@@ -6470,7 +6388,6 @@ class Looker40SDK(api_methods.APIMethods):
     ) -> Union[str, bytes]:
         """Run Inline Query"""
         result_format = self.encode_path_param(result_format)
-        assert isinstance(body, models.WriteQuery)
         response = self.post(
             f"/queries/run/{result_format}",
             Union[str, bytes],  # type: ignore
@@ -6621,8 +6538,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.MergeQuery:
         """Create Merge Query"""
-        if body:
-            assert isinstance(body, models.WriteMergeQuery)
         response = self.post(
             f"/merge_queries",
             models.MergeQuery,
@@ -6695,7 +6610,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.SqlQuery:
         """Create SQL Runner Query"""
-        assert isinstance(body, models.SqlQueryCreate)
         response = self.post(
             f"/sql_queries",
             models.SqlQuery,
@@ -6829,7 +6743,6 @@ class Looker40SDK(api_methods.APIMethods):
         """Create Dashboard Render Task"""
         dashboard_id = self.encode_path_param(dashboard_id)
         result_format = self.encode_path_param(result_format)
-        assert isinstance(body, models.CreateDashboardRenderTask)
         response = self.post(
             f"/render_tasks/dashboards/{dashboard_id}/{result_format}",
             models.RenderTask,
@@ -7010,7 +6923,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.ModelSet:
         """Update Model Set"""
-        assert isinstance(body, models.WriteModelSet)
         response = self.patch(
             f"/model_sets/{model_set_id}",
             models.ModelSet,
@@ -7064,7 +6976,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.ModelSet:
         """Create Model Set"""
-        assert isinstance(body, models.WriteModelSet)
         response = self.post(
             f"/model_sets",
             models.ModelSet,
@@ -7187,7 +7098,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.PermissionSet:
         """Update Permission Set"""
-        assert isinstance(body, models.WritePermissionSet)
         response = self.patch(
             f"/permission_sets/{permission_set_id}",
             models.PermissionSet,
@@ -7243,7 +7153,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.PermissionSet:
         """Create Permission Set"""
-        assert isinstance(body, models.WritePermissionSet)
         response = self.post(
             f"/permission_sets",
             models.PermissionSet,
@@ -7283,7 +7192,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.Role:
         """Create Role"""
-        assert isinstance(body, models.WriteRole)
         response = self.post(
             f"/roles", models.Role, body=body, transport_options=transport_options
         )
@@ -7382,7 +7290,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.Role:
         """Update Role"""
-        assert isinstance(body, models.WriteRole)
         response = self.patch(
             f"/roles/{role_id}",
             models.Role,
@@ -7440,7 +7347,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> Sequence[models.Group]:
         """Update Role Groups"""
-        assert isinstance(body, Sequence)
         response = self.put(
             f"/roles/{role_id}/groups",
             Sequence[models.Group],
@@ -7487,7 +7393,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> Sequence[models.User]:
         """Update Role Users"""
-        assert isinstance(body, Sequence)
         response = self.put(
             f"/roles/{role_id}/users",
             Sequence[models.User],
@@ -7599,7 +7504,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.ScheduledPlan:
         """Update Scheduled Plan"""
-        assert isinstance(body, models.WriteScheduledPlan)
         response = self.patch(
             f"/scheduled_plans/{scheduled_plan_id}",
             models.ScheduledPlan,
@@ -7730,7 +7634,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.ScheduledPlan:
         """Create Scheduled Plan"""
-        assert isinstance(body, models.WriteScheduledPlan)
         response = self.post(
             f"/scheduled_plans",
             models.ScheduledPlan,
@@ -7785,7 +7688,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.ScheduledPlan:
         """Run Scheduled Plan Once"""
-        assert isinstance(body, models.WriteScheduledPlan)
         response = self.post(
             f"/scheduled_plans/run_once",
             models.ScheduledPlan,
@@ -7957,8 +7859,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.ScheduledPlan:
         """Run Scheduled Plan Once by Id"""
-        if body:
-            assert isinstance(body, models.WriteScheduledPlan)
         response = self.post(
             f"/scheduled_plans/{scheduled_plan_id}/run_once",
             models.ScheduledPlan,
@@ -8015,7 +7915,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.ApiSession:
         """Update Session"""
-        assert isinstance(body, models.WriteApiSession)
         response = self.patch(
             f"/session",
             models.ApiSession,
@@ -8077,7 +7976,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.Theme:
         """Create Theme"""
-        assert isinstance(body, models.WriteTheme)
         response = self.post(
             f"/themes", models.Theme, body=body, transport_options=transport_options
         )
@@ -8292,7 +8190,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.ValidationError:
         """Validate Theme"""
-        assert isinstance(body, models.WriteTheme)
         response = self.post(
             f"/themes/validate",
             models.ValidationError,
@@ -8340,7 +8237,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.Theme:
         """Update Theme"""
-        assert isinstance(body, models.WriteTheme)
         response = self.patch(
             f"/themes/{theme_id}",
             models.Theme,
@@ -8746,7 +8642,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.CredentialsEmail:
         """Create Email/Password Credential"""
-        assert isinstance(body, models.WriteCredentialsEmail)
         response = self.post(
             f"/users/{user_id}/credentials_email",
             models.CredentialsEmail,
@@ -8770,7 +8665,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.CredentialsEmail:
         """Update Email/Password Credential"""
-        assert isinstance(body, models.WriteCredentialsEmail)
         response = self.patch(
             f"/users/{user_id}/credentials_email",
             models.CredentialsEmail,
@@ -8833,8 +8727,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.CredentialsTotp:
         """Create Two-Factor Credential"""
-        if body:
-            assert isinstance(body, models.CredentialsTotp)
         response = self.post(
             f"/users/{user_id}/credentials_totp",
             models.CredentialsTotp,
@@ -9096,8 +8988,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.CredentialsApi3:
         """Create API 3 Credential"""
-        if body:
-            assert isinstance(body, models.CredentialsApi3)
         response = self.post(
             f"/users/{user_id}/credentials_api3",
             models.CredentialsApi3,
@@ -9345,7 +9235,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> Sequence[models.Role]:
         """Set User Roles"""
-        assert isinstance(body, Sequence)
         response = self.put(
             f"/users/{user_id}/roles",
             Sequence[models.Role],
@@ -9418,7 +9307,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.UserAttributeWithValue:
         """Set User Attribute User Value"""
-        assert isinstance(body, models.WriteUserAttributeWithValue)
         response = self.patch(
             f"/users/{user_id}/attribute_values/{user_attribute_id}",
             models.UserAttributeWithValue,
@@ -9498,7 +9386,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.UserAttribute:
         """Create User Attribute"""
-        assert isinstance(body, models.WriteUserAttribute)
         response = self.post(
             f"/user_attributes",
             models.UserAttribute,
@@ -9543,7 +9430,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.UserAttribute:
         """Update User Attribute"""
-        assert isinstance(body, models.WriteUserAttribute)
         response = self.patch(
             f"/user_attributes/{user_attribute_id}",
             models.UserAttribute,
@@ -9629,7 +9515,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> Sequence[models.UserAttributeGroupValue]:
         """Set User Attribute Group Values"""
-        assert isinstance(body, Sequence)
         response = self.post(
             f"/user_attributes/{user_attribute_id}/group_values",
             Sequence[models.UserAttributeGroupValue],

--- a/python/looker_sdk/sdk/api40/methods.py
+++ b/python/looker_sdk/sdk/api40/methods.py
@@ -8442,8 +8442,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.User:
         """Create User"""
-        if body:
-            assert isinstance(body, models.WriteUser)
         response = self.post(
             f"/users",
             models.User,
@@ -8634,7 +8632,6 @@ class Looker40SDK(api_methods.APIMethods):
         transport_options: Optional[transport.PTransportSettings] = None,
     ) -> models.User:
         """Update User"""
-        assert isinstance(body, models.WriteUser)
         response = self.patch(
             f"/users/{user_id}",
             models.User,

--- a/python/tests/integration/api31/test_methods.py
+++ b/python/tests/integration/api31/test_methods.py
@@ -16,17 +16,26 @@ def sdk(sdk31) -> mtds.Looker31SDK:
     return sdk31
 
 
+TEST_FIRST_NAME = "Rudolphontronix"
+TEST_LAST_NAME = "Doe"
+
+
 def test_crud_user(sdk: mtds.Looker31SDK):
     """Test creating, retrieving, updating and deleting a user."""
 
     # Create user
     user = sdk.create_user(
-        ml.WriteUser(first_name="John", last_name="Doe", is_disabled=False, locale="fr")
+        ml.WriteUser(
+            first_name=TEST_FIRST_NAME,
+            last_name=TEST_LAST_NAME,
+            is_disabled=False,
+            locale="fr",
+        )
     )
     assert isinstance(user, ml.User)
     assert isinstance(user.id, int)
-    assert user.first_name == "John"
-    assert user.last_name == "Doe"
+    assert user.first_name == TEST_FIRST_NAME
+    assert user.last_name == TEST_LAST_NAME
     assert not user.is_disabled
     assert user.locale == "fr"
 
@@ -34,19 +43,19 @@ def test_crud_user(sdk: mtds.Looker31SDK):
     user_id = user.id
     sdk.login_user(user_id)
     user = sdk.me()
-    assert user.first_name == "John"
-    assert user.last_name == "Doe"
+    assert user.first_name == TEST_FIRST_NAME
+    assert user.last_name == TEST_LAST_NAME
     sdk.logout()
     user = sdk.me()
-    assert user.first_name != "John"
-    assert user.last_name != "Doe"
+    assert user.first_name != TEST_FIRST_NAME
+    assert user.last_name != TEST_LAST_NAME
 
     # Update user and check fields we didn't intend to change didn't change
     update_user = ml.WriteUser(is_disabled=True, locale="uk")
     sdk.update_user(user_id, update_user)
     user = sdk.user(user_id)
-    assert user.first_name == "John"
-    assert user.last_name == "Doe"
+    assert user.first_name == TEST_FIRST_NAME
+    assert user.last_name == TEST_LAST_NAME
     assert user.locale == "uk"
     assert user.is_disabled
 

--- a/python/tests/integration/api40/test_methods.py
+++ b/python/tests/integration/api40/test_methods.py
@@ -21,11 +21,16 @@ def test_crud_user(sdk: mtds.Looker40SDK):
 
     # Create user
     user = sdk.create_user(
-        ml.WriteUser(first_name="John", last_name="Doe", is_disabled=False, locale="fr")
+        ml.WriteUser(
+            first_name="Rudolphontronix",
+            last_name="Doe",
+            is_disabled=False,
+            locale="fr",
+        )
     )
     assert isinstance(user, ml.User)
     assert isinstance(user.id, int)
-    assert user.first_name == "John"
+    assert user.first_name == "Rudolphontronix"
     assert user.last_name == "Doe"
     assert not user.is_disabled
     assert user.locale == "fr"
@@ -34,18 +39,18 @@ def test_crud_user(sdk: mtds.Looker40SDK):
     user_id = user.id
     sdk.login_user(user_id)
     user = sdk.me()
-    assert user.first_name == "John"
+    assert user.first_name == "Rudolphontronix"
     assert user.last_name == "Doe"
     sdk.logout()
     user = sdk.me()
-    assert user.first_name != "John"
+    assert user.first_name != "Rudolphontronix"
     assert user.last_name != "Doe"
 
     # Update user and check fields we didn't intend to change didn't change
     update_user = ml.WriteUser(is_disabled=True, locale="uk")
     sdk.update_user(user_id, update_user)
     user = sdk.user(user_id)
-    assert user.first_name == "John"
+    assert user.first_name == "Rudolphontronix"
     assert user.last_name == "Doe"
     assert user.locale == "uk"
     assert user.is_disabled
@@ -67,6 +72,62 @@ def test_crud_user(sdk: mtds.Looker40SDK):
     user = sdk.user(user_id)
     assert isinstance(user.credentials_email, ml.CredentialsEmail)
     assert user.credentials_email.email == "john.doe@looker.com"
+
+    # Delete user
+    resp = sdk.delete_user(user_id)
+    assert resp == ""
+
+
+def test_crud_user_dict(sdk):  # no typing
+    """Test creating, retrieving, updating and deleting a user."""
+
+    # Create user
+    new_user = sdk.create_user(
+        dict(
+            first_name="Rudolphontronix",
+            last_name="Doe",
+            is_disabled=False,
+            locale="fr",
+        )
+    )
+    assert new_user["first_name"] == "Rudolphontronix"
+    assert new_user["last_name"] == "Doe"
+    assert not new_user["is_disabled"]
+    assert new_user["locale"] == "fr"
+
+    # sudo checks
+    user_id = new_user["id"]
+    sdk.login_user(user_id)
+    sudo_user = sdk.me()
+    assert sudo_user["first_name"] == "Rudolphontronix"
+    assert sudo_user["last_name"] == "Doe"
+    sdk.logout()
+    me_user = sdk.me()
+    assert me_user["first_name"] != "Rudolphontronix"
+    assert me_user["last_name"] != "Doe"
+
+    # Update user and check fields we didn't intend to change didn't change
+    new_user["is_disabled"] = True
+    new_user["locale"] = "uk"
+    # sdk.update_user(user_id, update_user)
+    sdk.update_user(user_id, new_user)
+    updated_user = sdk.user(user_id)
+    assert updated_user["first_name"] == "Rudolphontronix"
+    assert updated_user["last_name"] == "Doe"
+    assert updated_user["locale"] == "uk"
+    assert updated_user["is_disabled"]
+
+    update_user = dict(first_name=None)
+    update_user["last_name"] = None
+    sdk.update_user(user_id, update_user)
+    user = sdk.user(user_id)
+    assert user["first_name"] == ""
+    assert user["last_name"] == ""
+
+    # Try adding email creds
+    sdk.create_user_credentials_email(user_id, dict(email="john.doe@looker.com"))
+    user = sdk.user(user_id)
+    assert user["credentials_email"]["email"] == "john.doe@looker.com"
 
     # Delete user
     resp = sdk.delete_user(user_id)

--- a/python/tests/integration/api40/test_methods.py
+++ b/python/tests/integration/api40/test_methods.py
@@ -16,22 +16,26 @@ def sdk(sdk40) -> mtds.Looker40SDK:
     return sdk40
 
 
+TEST_FIRST_NAME = "Rudolphontronix"
+TEST_LAST_NAME = "Doe"
+
+
 def test_crud_user(sdk: mtds.Looker40SDK):
     """Test creating, retrieving, updating and deleting a user."""
 
     # Create user
     user = sdk.create_user(
         ml.WriteUser(
-            first_name="Rudolphontronix",
-            last_name="Doe",
+            first_name=TEST_FIRST_NAME,
+            last_name=TEST_LAST_NAME,
             is_disabled=False,
             locale="fr",
         )
     )
     assert isinstance(user, ml.User)
     assert isinstance(user.id, int)
-    assert user.first_name == "Rudolphontronix"
-    assert user.last_name == "Doe"
+    assert user.first_name == TEST_FIRST_NAME
+    assert user.last_name == TEST_LAST_NAME
     assert not user.is_disabled
     assert user.locale == "fr"
 
@@ -39,19 +43,19 @@ def test_crud_user(sdk: mtds.Looker40SDK):
     user_id = user.id
     sdk.login_user(user_id)
     user = sdk.me()
-    assert user.first_name == "Rudolphontronix"
-    assert user.last_name == "Doe"
+    assert user.first_name == TEST_FIRST_NAME
+    assert user.last_name == TEST_LAST_NAME
     sdk.logout()
     user = sdk.me()
-    assert user.first_name != "Rudolphontronix"
-    assert user.last_name != "Doe"
+    assert user.first_name != TEST_FIRST_NAME
+    assert user.last_name != TEST_LAST_NAME
 
     # Update user and check fields we didn't intend to change didn't change
     update_user = ml.WriteUser(is_disabled=True, locale="uk")
     sdk.update_user(user_id, update_user)
     user = sdk.user(user_id)
-    assert user.first_name == "Rudolphontronix"
-    assert user.last_name == "Doe"
+    assert user.first_name == TEST_FIRST_NAME
+    assert user.last_name == TEST_LAST_NAME
     assert user.locale == "uk"
     assert user.is_disabled
 
@@ -84,14 +88,14 @@ def test_crud_user_dict(sdk):  # no typing
     # Create user
     new_user = sdk.create_user(
         dict(
-            first_name="Rudolphontronix",
-            last_name="Doe",
+            first_name=TEST_FIRST_NAME,
+            last_name=TEST_LAST_NAME,
             is_disabled=False,
             locale="fr",
         )
     )
-    assert new_user["first_name"] == "Rudolphontronix"
-    assert new_user["last_name"] == "Doe"
+    assert new_user["first_name"] == TEST_FIRST_NAME
+    assert new_user["last_name"] == TEST_LAST_NAME
     assert not new_user["is_disabled"]
     assert new_user["locale"] == "fr"
 
@@ -99,12 +103,12 @@ def test_crud_user_dict(sdk):  # no typing
     user_id = new_user["id"]
     sdk.login_user(user_id)
     sudo_user = sdk.me()
-    assert sudo_user["first_name"] == "Rudolphontronix"
-    assert sudo_user["last_name"] == "Doe"
+    assert sudo_user["first_name"] == TEST_FIRST_NAME
+    assert sudo_user["last_name"] == TEST_LAST_NAME
     sdk.logout()
     me_user = sdk.me()
-    assert me_user["first_name"] != "Rudolphontronix"
-    assert me_user["last_name"] != "Doe"
+    assert me_user["first_name"] != TEST_FIRST_NAME
+    assert me_user["last_name"] != TEST_LAST_NAME
 
     # Update user and check fields we didn't intend to change didn't change
     new_user["is_disabled"] = True
@@ -112,8 +116,8 @@ def test_crud_user_dict(sdk):  # no typing
     # sdk.update_user(user_id, update_user)
     sdk.update_user(user_id, new_user)
     updated_user = sdk.user(user_id)
-    assert updated_user["first_name"] == "Rudolphontronix"
-    assert updated_user["last_name"] == "Doe"
+    assert updated_user["first_name"] == TEST_FIRST_NAME
+    assert updated_user["last_name"] == TEST_LAST_NAME
     assert updated_user["locale"] == "uk"
     assert updated_user["is_disabled"]
 


### PR DESCRIPTION
The python SDK now accepts dictionaries as method bodies in addition to
the original model class instances. E.g. these are equivalent:

```
sdk.create_user({"first_name": "Jane", "last_name": "Smith"})
sdk.create_user(models.Writeuser(first_name="Jane", last_name="Smith"))
```

Note: static type checking fails on the first example but the assumption
is that users who opt for that form are not interested in type safety

Additionally, model class instances returned by the API act like
dictionaries. So you can do this:

```
me = sdk.me()
me["locale"] = "uk"
sdk.update_user(me["id"], me)
```

Note: the SDK will not do anything to prevent sending read-only
properties - the caller is responsible for the API's behavior in such
cases.

The dictionary-like behavior of model class instances is nearly
complete. `popitem()`, `clear()`, and `copy()` are the only methods not
supported. Another difference is setting a nested child property
to a dictionary: under the hood that gets converted to
the appropriate model instance and no reference to the original
dictionary is kept. The following demonstrates this:

```
my_email = {"email": "jane.smith@example.com"}
me = sdk.me()
me["credentials_api3"] = my_email
my_email["email"] = "jane.smith@foo.com"
print(me["credentials_api3"]["email"])  # jane.smith@example.com
me["credentials_api3"]["email"] = "jane.smith@foo.com"
print(me["credentials_api3"]["email"])  # jane.smith@example.com
```
(unrealistic example as the Looker API does not support updating email
 address via update_user)