### PR TITLE
Lower-bound python attrs requirement to 18.2.0

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -8,7 +8,7 @@ NAME = "looker_sdk"
 VERSION = "0.1.3b14"
 REQUIRES = [
     "requests >= 2.22",
-    "attrs",
+    "attrs >= 18.2.0",
     "cattrs >= 1.0.0",
     "python-dateutil;python_version<'3.7'",
     "typing-extensions;python_version<'3.8'",


### PR DESCRIPTION
looker_sdk [uses](https://github.com/looker-open-source/sdk-codegen/blob/a1c4acb61d727cc7a22368761b0bff2244747c61/python/looker_sdk/rtl/auth_session.py#L276) the `kw_only` feature of attrs, which was [introduced](https://www.attrs.org/en/stable/api.html#core) in 18.2.0.

I'm not _100% sure_ that this really is the minimum bound for `attrs` for looker_sdk (it could be higher), but the minimum bound is at least as low as this.

This became an issue for me while working with another library which specified `attrs==18.1.0`, causing runtime errors. If `looker_sdk` had included this pin, the pip install would have (correctly) failed. Of course, the other library shouldn't be pinning with `==` - I opened a PR there too.