### PR TITLE
Fixes to support embedding in other projects

### DIFF
--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -10,6 +10,8 @@ buildscript {
     }
 }
 
+group = "com.looker.sdk"
+
 //plugins {
 //    id "org.jmailen.kotlinter" version "2.4.1"
 //}
@@ -25,14 +27,15 @@ repositories {
     maven { url "https://jitpack.io" }
 }
 
+
 sourceSets {
     main.kotlin.srcDirs += 'src/main/'
     test.kotlin.srcDirs += 'src/test'
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    compile "org.ini4j:ini4j:0.5.4"
+    api "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.ini4j:ini4j:0.5.4"
 
     implementation "io.ktor:ktor-client:$ktor_version"
     implementation "io.ktor:ktor-client-okhttp:$ktor_version"
@@ -42,8 +45,8 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.0-RC'
     implementation 'com.google.code.gson:gson:2.8.5'
 
-    testCompile 'junit:junit:4.11'
-    testCompile "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
+    testImplementation 'junit:junit:4.11'
+    testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
 }
 
 compileKotlin {

--- a/kotlin/settings.gradle
+++ b/kotlin/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'looker-kotlin-sdk'


### PR DESCRIPTION
This defines a project group and name which are necesssary so that the
kotlin sdk may be accessed as a project.  Until we have the project
published to a package distribution system, this allows us to use a
Gradle Source Dependency [1] to embed the project.

Also changes a few `compile` dependencies to their newer versions to
remove deprecation warnings from gradle.

[1] https://blog.gradle.org/introducing-source-dependencies