### PR TITLE
Change kotlin ApiSettings to be an interface

### DIFF
--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -54,10 +54,14 @@ When the SDK is installed and the server location and API credentials are config
 Verify authentication works and that API calls will succeed with code similar to the following:
 
 ```kotlin
+import com.looker.rtl.ApiSettingsIniFile;
+import com.looker.rtl.AuthSession;
+import com.looker.sdk.LookerSDK;
+
 val localIni = "./looker.ini"
 val settings = ApiSettingsIniFile(localIni, "Looker")
-val session = UserSession(settings, Transport(settings))
-val sdk = Looker40SDK(session)
+val session = AuthSession(settings)
+val sdk = LookerSDK(session)
 // Verify minimal SDK call works
 val me = sdk.ok<User>(sdk.me())
 

--- a/kotlin/src/main/com/looker/rtl/ApiSettings.kt
+++ b/kotlin/src/main/com/looker/rtl/ApiSettings.kt
@@ -41,8 +41,10 @@ fun apiConfig(contents: String): ApiSections {
     return ret
 }
 
+interface ApiSettings : ConfigurationProvider {}
+
 open class ApiSettingsIniFile(var filename: String = "./looker.ini",
-                              section: String = "") : ApiSettings(File(filename).readText(), section) {
+                              section: String = "") : ApiSettingsIniText(File(filename).readText(), section) {
     override fun readConfig(): Map<String, String> {
         val file = File(filename)
         if (!file.exists()) return mapOf()
@@ -55,7 +57,7 @@ open class ApiSettingsIniFile(var filename: String = "./looker.ini",
 
 
 // TODO why no @JvmOverloads here?
-open class ApiSettings(contents: String, var section: String = "") : ConfigurationProvider {
+open class ApiSettingsIniText(contents: String, var section: String = "") : ApiSettings, ConfigurationProvider {
 
     override var baseUrl: String = ""
     override var apiVersion: String = DEFAULT_API_VERSION

--- a/kotlin/src/main/com/looker/rtl/Transport.kt
+++ b/kotlin/src/main/com/looker/rtl/Transport.kt
@@ -111,11 +111,11 @@ typealias Authenticator = (init: RequestSettings) -> RequestSettings
 fun defaultAuthenticator(requestSettings: RequestSettings): RequestSettings = requestSettings
 
 interface TransportOptions {
-    var baseUrl: String
-    var apiVersion: String
-    var verifySSL: Boolean
-    var timeout: Int
-    var headers: Map<String, String>
+    val baseUrl: String
+    val apiVersion: String
+    val verifySSL: Boolean
+    val timeout: Int
+    val headers: Map<String, String>
 }
 
 interface ConfigurationProvider : TransportOptions {

--- a/kotlin/src/test/TestApiSettings.kt
+++ b/kotlin/src/test/TestApiSettings.kt
@@ -1,4 +1,5 @@
 import com.looker.rtl.ApiSettings
+import com.looker.rtl.ApiSettingsIniText
 import com.looker.rtl.DEFAULT_TIMEOUT
 import com.looker.rtl.AuthSession
 import org.junit.Test
@@ -17,7 +18,7 @@ base_url='https://my.looker.com:19999'
 val mockId = "IdOverride"
 val mockSecret = "SecretOverride"
 
-class MockSettings(contents: String) : ApiSettings(contents) {
+class MockSettings(contents: String) : ApiSettingsIniText(contents) {
     override fun readConfig(): Map<String, String> {
         return mapOf(
                 "base_url" to baseUrl,
@@ -33,7 +34,7 @@ class MockSettings(contents: String) : ApiSettings(contents) {
 class TestApiSettings {
     @Test
     fun testApiSettingsDefaults() {
-        val settings = ApiSettings(bareMinimum)
+        val settings = ApiSettingsIniText(bareMinimum)
         val config = settings.readConfig()
         assertEquals(settings.baseUrl, "https://my.looker.com:19999", "Base URL is read")
         assertEquals(settings.verifySSL, true)
@@ -44,7 +45,7 @@ class TestApiSettings {
 
     @Test
     fun testApiSettingsQuotes() {
-        val settings = ApiSettings(quotedMinimum)
+        val settings = ApiSettingsIniText(quotedMinimum)
         assertEquals(settings.baseUrl, "https://my.looker.com:19999", "Base URL has no quotes")
         assertEquals(settings.verifySSL, true)
         assertEquals(settings.timeout, DEFAULT_TIMEOUT)


### PR DESCRIPTION
This allows for completely independent implementations which do not
expect any Ini file data at all.