### PR TITLE
Change ApiSettings to accept a Map instead of Ini text

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.kt]
+indent_style = space
+indent_size = 4

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -54,10 +54,14 @@ When the SDK is installed and the server location and API credentials are config
 Verify authentication works and that API calls will succeed with code similar to the following:
 
 ```kotlin
+import com.looker.rtl.ApiSettings;
+import com.looker.rtl.AuthSession;
+import com.looker.sdk.LookerSDK;
+
 val localIni = "./looker.ini"
-val settings = ApiSettingsIniFile(localIni, "Looker")
-val session = UserSession(settings, Transport(settings))
-val sdk = Looker40SDK(session)
+val settings = ApiSettings.fromIniFile(localIni, "Looker")
+val session = AuthSession(settings)
+val sdk = LookerSDK(session)
 // Verify minimal SDK call works
 val me = sdk.ok<User>(sdk.me())
 

--- a/kotlin/src/main/com/looker/rtl/AuthSession.kt
+++ b/kotlin/src/main/com/looker/rtl/AuthSession.kt
@@ -27,7 +27,7 @@ package com.looker.rtl
 import io.ktor.client.request.forms.FormDataContent
 import io.ktor.http.Parameters
 
-open class AuthSession(open val apiSettings: ApiSettings,
+open class AuthSession(open val apiSettings: ConfigurationProvider,
                        open val transport: Transport = Transport(apiSettings)) {
 
     var authToken: AuthToken = AuthToken()

--- a/kotlin/src/main/com/looker/rtl/OAuthSession.kt
+++ b/kotlin/src/main/com/looker/rtl/OAuthSession.kt
@@ -101,7 +101,7 @@ fun hexStr(bytes: ByteArray): String {
 }
 
 @ExperimentalUnsignedTypes
-class OAuthSession(override val apiSettings: ApiSettings, override val transport: Transport = Transport(apiSettings))
+class OAuthSession(override val apiSettings: ConfigurationProvider, override val transport: Transport = Transport(apiSettings))
     : AuthSession(apiSettings, transport) {
     private var random = SecureRandom()
     private var codeVerifier: String = ""

--- a/kotlin/src/test/TestApiSettings.kt
+++ b/kotlin/src/test/TestApiSettings.kt
@@ -1,4 +1,5 @@
 import com.looker.rtl.ApiSettings
+import com.looker.rtl.ConfigurationProvider
 import com.looker.rtl.DEFAULT_TIMEOUT
 import com.looker.rtl.AuthSession
 import org.junit.Test
@@ -17,7 +18,7 @@ base_url='https://my.looker.com:19999'
 val mockId = "IdOverride"
 val mockSecret = "SecretOverride"
 
-class MockSettings(contents: String) : ApiSettings(contents) {
+class MockSettings(contents: String) : ConfigurationProvider by ApiSettings.fromIniText(contents) {
     override fun readConfig(): Map<String, String> {
         return mapOf(
                 "base_url" to baseUrl,
@@ -33,7 +34,7 @@ class MockSettings(contents: String) : ApiSettings(contents) {
 class TestApiSettings {
     @Test
     fun testApiSettingsDefaults() {
-        val settings = ApiSettings(bareMinimum)
+        val settings = ApiSettings.fromIniText(bareMinimum)
         val config = settings.readConfig()
         assertEquals(settings.baseUrl, "https://my.looker.com:19999", "Base URL is read")
         assertEquals(settings.verifySSL, true)
@@ -44,7 +45,7 @@ class TestApiSettings {
 
     @Test
     fun testApiSettingsQuotes() {
-        val settings = ApiSettings(quotedMinimum)
+        val settings = ApiSettings.fromIniText(quotedMinimum)
         assertEquals(settings.baseUrl, "https://my.looker.com:19999", "Base URL has no quotes")
         assertEquals(settings.verifySSL, true)
         assertEquals(settings.timeout, DEFAULT_TIMEOUT)

--- a/kotlin/src/test/Utils.kt
+++ b/kotlin/src/test/Utils.kt
@@ -34,10 +34,14 @@ typealias jsonDict = Map<String, Any>
 
 val jsonDictType = object : TypeToken<jsonDict>() {}.type
 
-class TestSettingsIniFile(filename: String = "./looker.ini", section: String = "")
-    : ApiSettingsIniFile(filename, section) {
+class TestSettingsIniFile(
+    filename: String = "./looker.ini",
+    section: String = "",
+    private val base: ConfigurationProvider = ApiSettings.fromIniFile(filename, section)
+) : ConfigurationProvider by base {
+
     override fun readConfig(): Map<String, String> {
-        var map = super.readConfig().toMutableMap()
+        var map = base.readConfig().toMutableMap()
         map["client_id"] = "test_client_id"
         map["redirect_uri"] = "looker://"
         return map
@@ -57,7 +61,7 @@ open class TestConfig() {
     val configContents = File(localIni).readText()
     val config = apiConfig(configContents)
     val section = config["Looker"]
-    var settings = ApiSettingsIniFile(localIni, "Looker")
+    var settings = ApiSettings.fromIniFile(localIni, "Looker")
     var oAuthTestSettings = TestSettingsIniFile(localIni, "Looker")
     val baseUrl = section?.get("base_url")
     val timeout = section?.get("timeout")?.toInt(10)


### PR DESCRIPTION
This should allow for simpler overriding of behavior, allowing clients
to provide a custom dict rather than requiring that they use the INI
format.