### PR TITLE
Don't remove base64 padding going to base64url.

### DIFF
--- a/swift/looker/rtl/oauthSession.swift
+++ b/swift/looker/rtl/oauthSession.swift
@@ -60,7 +60,6 @@ extension Data {
         return base64EncodedString()
             .replacingOccurrences(of: "/", with: "_")
             .replacingOccurrences(of: "+", with: "-")
-            .replacingOccurrences(of: "=", with: "")
     }
 }
 


### PR DESCRIPTION
My bootleg base64url encoding algorithm was slightly incorrect. Turns out the server throws fits without the `=` padding on the string.