### PR TITLE
Api Explorer: Support example index searching and rendering

### DIFF
--- a/packages/api-explorer/src/components/DocSDKs/DocSDKs.tsx
+++ b/packages/api-explorer/src/components/DocSDKs/DocSDKs.tsx
@@ -50,7 +50,7 @@ export const DocSDKs: FC<LanguageSDKProps> = ({ api, method, type }) => {
   const [item] = useState(method ? noComment(method) : type!)
 
   return (
-    <CollapserCard heading="Language SDK declarations">
+    <CollapserCard heading="SDK declarations">
       <>
         <TabList {...tabs}>
           {Object.keys(generators).map((language) => (

--- a/packages/api-explorer/src/components/DocSDKs/index.ts
+++ b/packages/api-explorer/src/components/DocSDKs/index.ts
@@ -1,1 +1,27 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2020 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
 export { DocSDKs } from './DocSDKs'
+export { getGenerators } from './utils'

--- a/packages/api-explorer/src/components/DocSdkUsage/DocExamples.tsx
+++ b/packages/api-explorer/src/components/DocSdkUsage/DocExamples.tsx
@@ -28,7 +28,7 @@ import { Link } from '@looker/components'
 import { IFileCall } from '@looker/sdk-codegen-scripts/lib/miner'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const index = require('../../../../../examples/index.json').nuggets
+const index = require('../../../../../examples/motherlode.json').nuggets
 
 interface DocExamplesProps {
   /** Language example should be in */
@@ -67,13 +67,13 @@ interface IExample extends IFileCall {}
 const findExamples = (language: string, operationId: string): IExample[] => {
   const allMethodExamples = index[operationId]
   const ext = getLanguageExtension(language)
-  let matchingExamples
+  let matches
 
   if (allMethodExamples && ext) {
-    matchingExamples = allMethodExamples.calls[ext]
+    matches = allMethodExamples.calls[ext]
   }
 
-  return matchingExamples
+  return matches
 }
 
 // TODO: asynchronously fetch index at first render. Report if not available in this component

--- a/packages/api-explorer/src/components/DocSdkUsage/DocExamples.tsx
+++ b/packages/api-explorer/src/components/DocSdkUsage/DocExamples.tsx
@@ -1,0 +1,102 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2020 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+import React, { FC } from 'react'
+import { Link } from '@looker/components'
+import { IFileCall } from '@looker/sdk-codegen-scripts/lib/miner'
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const index = require('../../../../../examples/index.json').nuggets
+
+interface DocExamplesProps {
+  /** Language example should be in */
+  language: string
+  /** Method operation id */
+  operationId: string
+}
+
+const getLanguageExtension = (language: string) => {
+  switch (language.toLowerCase()) {
+    case 'typescript':
+      return '.ts'
+    case 'csharp':
+    case 'c#':
+      return '.cs'
+    case 'ruby':
+      return '.rb'
+    case 'python':
+      return '.py'
+    case 'swift':
+      return '.swift'
+    case 'kotlin':
+      return '.kt'
+    default:
+      return ''
+  }
+}
+
+interface IExample extends IFileCall {}
+
+/**
+ * Searches for examples containing operationId usages in the given language
+ * @param language Language example should be in
+ * @param operationId Method's operationId to search for
+ */
+const findExamples = (language: string, operationId: string): IExample[] => {
+  const allMethodExamples = index[operationId]
+  const ext = getLanguageExtension(language)
+  let matchingExamples
+
+  if (allMethodExamples && ext) {
+    matchingExamples = allMethodExamples.calls[ext]
+  }
+
+  return matchingExamples
+}
+
+// TODO: asynchronously fetch index at first render. Report if not available in this component
+// TODO: Replace link href with full github link to source file
+// TODO: Replace link text to example summary
+/**
+ * Renders links to source files referencing the operationId in the given language
+ */
+export const DocExamples: FC<DocExamplesProps> = ({
+  language,
+  operationId,
+}) => {
+  const examples = findExamples(language, operationId)
+
+  return (
+    <>
+      {examples &&
+        examples.length > 0 &&
+        examples.map((example, index) => (
+          <li key={index}>
+            <Link href={example.sourceFile}>{example.sourceFile}</Link>
+          </li>
+        ))}
+    </>
+  )
+}

--- a/packages/api-explorer/src/components/DocSdkUsage/DocSdkUsage.tsx
+++ b/packages/api-explorer/src/components/DocSdkUsage/DocSdkUsage.tsx
@@ -1,0 +1,68 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2020 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+import React, { FC } from 'react'
+import { TabList, Tab, TabPanels, TabPanel, useTabs } from '@looker/components'
+import { ApiModel, IMethod } from '@looker/sdk-codegen'
+
+import { CollapserCard } from '../Collapser'
+import { getGenerators } from '../DocSDKs'
+import { DocExamples } from './DocExamples'
+
+interface DocExamplesProps {
+  api: ApiModel
+  method: IMethod
+}
+
+/**
+ *  Given an SDK method, searches the examples index for its usages in various languages and renders
+ *  links to the source files
+ */
+export const DocSdkUsage: FC<DocExamplesProps> = ({ api, method }) => {
+  const tabs = useTabs()
+  const generators = getGenerators(api)
+
+  return (
+    <CollapserCard heading="SDK Language Examples">
+      <>
+        <TabList {...tabs}>
+          {Object.keys(generators).map((language) => (
+            <Tab key={language}>{language}</Tab>
+          ))}
+        </TabList>
+        <TabPanels {...tabs} pt="0">
+          {Object.entries(generators).map(([language, gen]) => (
+            <TabPanel key={language}>
+              <DocExamples
+                language={language}
+                operationId={method.operationId}
+              />
+            </TabPanel>
+          ))}
+        </TabPanels>
+      </>
+    </CollapserCard>
+  )
+}

--- a/packages/api-explorer/src/components/DocSdkUsage/DocSdkUsage.tsx
+++ b/packages/api-explorer/src/components/DocSdkUsage/DocSdkUsage.tsx
@@ -45,7 +45,7 @@ export const DocSdkUsage: FC<DocExamplesProps> = ({ api, method }) => {
   const generators = getGenerators(api)
 
   return (
-    <CollapserCard heading="SDK Language Examples">
+    <CollapserCard heading="SDK Examples">
       <>
         <TabList {...tabs}>
           {Object.keys(generators).map((language) => (

--- a/packages/api-explorer/src/components/DocSdkUsage/index.ts
+++ b/packages/api-explorer/src/components/DocSdkUsage/index.ts
@@ -23,28 +23,4 @@
  SOFTWARE.
 
  */
-export { ApixHeading } from './common'
-export { Collapser } from './Collapser'
-export { DocActivityType } from './DocActivityType'
-export { DocCode } from './DocCode'
-export { DocMethodSummary } from './DocMethodSummary'
-export { DocMarkdown } from './DocMarkdown'
-export { DocPseudo } from './DocPseudo'
-export { DocRateLimited } from './DocRateLimited'
-export { DocReferences } from './DocReferences'
-export { DocResponses } from './DocResponses'
-export { DocSDKs } from './DocSDKs'
 export { DocSdkUsage } from './DocSdkUsage'
-export { DocStatus } from './DocStatus'
-export { DocTitle } from './DocTitle'
-export {
-  HeaderWrapper,
-  Main,
-  PageLayout,
-  SideNavDivider,
-  StatusBeta,
-  SummaryCard,
-} from './ExplorerStyle'
-export { Header } from './Header'
-export { SideNav } from './SideNav'
-export { SideNavToggle } from './SideNavToggle'

--- a/packages/api-explorer/src/scenes/MethodScene/MethodScene.tsx
+++ b/packages/api-explorer/src/scenes/MethodScene/MethodScene.tsx
@@ -38,6 +38,7 @@ import {
   DocReferences,
   DocResponses,
   DocSDKs,
+  DocSdkUsage,
   DocStatus,
   DocTitle,
 } from '../../components'
@@ -81,6 +82,7 @@ export const MethodScene: FC<DocMethodProps> = ({ api }) => {
         <DocOperation method={method} />
         <DocMarkdown source={method.description} specKey={specKey} />
         <DocSDKs api={api} method={method} />
+        <DocSdkUsage api={api} method={method} />
         <DocReferences seeTypes={seeTypes} api={api} specKey={specKey} />
         <DocResponses responses={method.responses} />
       </FlexItem>


### PR DESCRIPTION
TODO:
- Replace hardcoded index with an asynchronous index fetch at first render
- In DocExamples, replace href links with full github links
- In DocExamples, replace link text to example summary