### PR TITLE
API Explorer: Fix stale state render bug

### DIFF
--- a/packages/api-explorer/src/components/DocMarkdown/utils.ts
+++ b/packages/api-explorer/src/components/DocMarkdown/utils.ts
@@ -74,4 +74,4 @@ export const remapHashURL = (specKey: string, url: string) =>
  * Returns transformed url
  */
 export const transformURL = (specKey: string, url: string) =>
-  remapHashURL(specKey, cleanURL(url))
+  url ? remapHashURL(specKey, cleanURL(url)) : url

--- a/packages/api-explorer/src/components/DocResponses/DocResponseTypes.tsx
+++ b/packages/api-explorer/src/components/DocResponses/DocResponseTypes.tsx
@@ -41,11 +41,12 @@ interface DocResponseTypesProps {
  */
 export const DocResponseTypes: FC<DocResponseTypesProps> = ({ responses }) => {
   const mediaTypes = Object.keys(responses)
-  const [mediaType, setMediaType] = useState(mediaTypes[0])
+  const [selectedMediaType, setSelectedMediaType] = useState(mediaTypes[0])
   const [resps, setResps] = useState(responses)
 
   useEffect(() => {
-    setMediaType(mediaTypes[0])
+    /** When new responses are passed, update the default selected media type */
+    setSelectedMediaType(mediaTypes[0])
     setResps(responses)
   }, [responses])
 
@@ -53,8 +54,8 @@ export const DocResponseTypes: FC<DocResponseTypesProps> = ({ responses }) => {
   return (
     <>
       <ButtonToggle
-        value={mediaType}
-        onChange={setMediaType}
+        value={selectedMediaType}
+        onChange={setSelectedMediaType}
         mt="large"
         mb="large"
       >
@@ -63,7 +64,11 @@ export const DocResponseTypes: FC<DocResponseTypesProps> = ({ responses }) => {
         ))}
       </ButtonToggle>
       <DocCode
-        code={JSON.stringify(copyAndCleanResponse(resps[mediaType]), null, 2)}
+        code={JSON.stringify(
+          copyAndCleanResponse(resps[selectedMediaType]),
+          null,
+          2
+        )}
       />
     </>
   )

--- a/packages/api-explorer/src/components/DocResponses/DocResponseTypes.tsx
+++ b/packages/api-explorer/src/components/DocResponses/DocResponseTypes.tsx
@@ -23,7 +23,7 @@
  SOFTWARE.
 
  */
-import React, { FC, useState } from 'react'
+import React, { FC, useState, useEffect } from 'react'
 import { ButtonToggle, ButtonItem } from '@looker/components'
 import { KeyedCollection, IMethodResponse } from '@looker/sdk-codegen'
 
@@ -42,7 +42,14 @@ interface DocResponseTypesProps {
 export const DocResponseTypes: FC<DocResponseTypesProps> = ({ responses }) => {
   const mediaTypes = Object.keys(responses)
   const [mediaType, setMediaType] = useState(mediaTypes[0])
+  const [resps, setResps] = useState(responses)
 
+  useEffect(() => {
+    setMediaType(mediaTypes[0])
+    setResps(responses)
+  }, [responses])
+
+  // TODO: Account for endpoints with no responses (e.g. delete a custom cmd)
   return (
     <>
       <ButtonToggle
@@ -56,11 +63,7 @@ export const DocResponseTypes: FC<DocResponseTypesProps> = ({ responses }) => {
         ))}
       </ButtonToggle>
       <DocCode
-        code={JSON.stringify(
-          copyAndCleanResponse(responses[mediaType]),
-          null,
-          2
-        )}
+        code={JSON.stringify(copyAndCleanResponse(resps[mediaType]), null, 2)}
       />
     </>
   )

--- a/packages/api-explorer/src/components/DocSDKs/DocSDKs.tsx
+++ b/packages/api-explorer/src/components/DocSDKs/DocSDKs.tsx
@@ -24,7 +24,7 @@
 
  */
 
-import React, { FC, useState } from 'react'
+import React, { FC, useState, useEffect } from 'react'
 import { Tab, TabList, TabPanel, TabPanels, useTabs } from '@looker/components'
 import { IMethod, IType, ApiModel } from '@looker/sdk-codegen'
 
@@ -48,7 +48,11 @@ interface LanguageSDKProps {
 export const DocSDKs: FC<LanguageSDKProps> = ({ api, method, type }) => {
   const tabs = useTabs()
   const generators = getGenerators(api)
-  const [item] = useState(method ? noComment(method) : type!)
+  const [item, setItem] = useState(method ? noComment(method) : type!)
+
+  useEffect(() => {
+    setItem(method ? noComment(method) : type!)
+  }, [method, type])
 
   return (
     <CollapserCard heading="Language SDK declarations">

--- a/packages/api-explorer/src/scenes/MethodScene/MethodScene.tsx
+++ b/packages/api-explorer/src/scenes/MethodScene/MethodScene.tsx
@@ -24,7 +24,7 @@
 
  */
 
-import React, { FC, useContext } from 'react'
+import React, { FC, useContext, useState, useEffect } from 'react'
 import { Space, useToggle, FlexItem, Flex } from '@looker/components'
 import { useParams } from 'react-router-dom'
 import { RunIt, RunItContext } from '@looker/run-it'
@@ -56,9 +56,13 @@ interface DocMethodParams {
 export const MethodScene: FC<DocMethodProps> = ({ api }) => {
   const { sdk } = useContext(RunItContext)
   const { methodName, specKey } = useParams<DocMethodParams>()
-  const method = api.methods[methodName]
-  const seeTypes = typeRefs(api, method.customTypes)
   const { value, toggle } = useToggle()
+  const [method, setMethod] = useState(api.methods[methodName])
+  const seeTypes = typeRefs(api, method.customTypes)
+
+  useEffect(() => {
+    setMethod(api.methods[methodName])
+  }, [methodName])
 
   return (
     <Flex>


### PR DESCRIPTION
**The problem**: The default selected media type in `DocResponseTypes` was previously being set once, as a default state value. On navigation to another method, the component received a `responses` object but the default `mediaType` state did not change. As a result, there were cases where the new `responses` object did not have a key matching the default media type previously set on first render causing the app to fail to render the whole scene.

A bug of this nature is also manifesting itself in other components, most notably in `DocSDKs` where the content rendered stays the same as one switches from one method (or type) to another.

**Solution**: In components where there's a link between props and state, there should be a `useEffect` which listens to props changes and updates state accordingly.