### PR TITLE
TS SDK oauth session code-verifier tweak

### DIFF
--- a/packages/sdk-rtl/src/oauthSession.spec.ts
+++ b/packages/sdk-rtl/src/oauthSession.spec.ts
@@ -133,7 +133,7 @@ describe('oauthSession', () => {
     const session = new OAuthSession(services)
     const urlstr = await session.createAuthCodeRequestUrl('api', 'mystate')
     expect(session.code_verifier).toBeDefined()
-    expect((session.code_verifier || '').length).toEqual(64)
+    expect((session.code_verifier || '').length).toEqual(66)
 
     const url = new URL(urlstr)
     expect(url.origin).toEqual(allSettings.looker_url)

--- a/packages/sdk-rtl/src/oauthSession.ts
+++ b/packages/sdk-rtl/src/oauthSession.ts
@@ -205,7 +205,10 @@ export class OAuthSession extends AuthSession {
     scope: string,
     state: string
   ): Promise<string> {
-    this.code_verifier = this.crypto.secureRandom(32)
+    // TODO: remove this comment when we remove hex backwards compatibility
+    // in Looker API. For now it must not be 2^n so that Looker correctly
+    // treats it as base64 encoded
+    this.code_verifier = this.crypto.secureRandom(33)
     const code_challenge = await this.crypto.sha256Hash(this.code_verifier)
     const config = this.readConfig()
     const params: Record<string, string> = {


### PR DESCRIPTION
For now it must not be 2^n so that Looker correctly treats it as base64 encoded