### PR TITLE
Various C# fixes

### DIFF
--- a/csharp/rtl/SdkUtils.cs
+++ b/csharp/rtl/SdkUtils.cs
@@ -134,7 +134,7 @@ namespace Looker.RTL
             var args = values
                 .Where(pair =>
                     pair.Value != null || (pair.Value is string && pair.Value.ToString().IsFull()))
-                .Select(x => $"{x.Key}=encodeParam(x.Value)");
+                .Select(x => $"{x.Key}={EncodeParam(x.Value)}");
 
             return string.Join("&", args);
         }

--- a/csharp/rtl/Transport.cs
+++ b/csharp/rtl/Transport.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using JsonSerializer = System.Text.Json.JsonSerializer;
@@ -236,7 +237,7 @@ namespace Looker.RTL
                 {
                     request.Content =
                         new StringContent(
-                            JsonSerializer.Serialize(body),
+                            JsonSerializer.Serialize(body, new JsonSerializerOptions { IgnoreNullValues = true }),
                             Encoding.UTF8,
                             "application/json");
                 }

--- a/csharp/rtl/Transport.cs
+++ b/csharp/rtl/Transport.cs
@@ -186,7 +186,7 @@ namespace Looker.RTL
         {
             if (path.StartsWith("http:", StringComparison.InvariantCultureIgnoreCase)
                 || path.StartsWith("https:", StringComparison.InvariantCultureIgnoreCase))
-                return path;
+                return SdkUtils.AddQueryParams(path, queryParams);
             // TODO I don't think authenticator is needed here any more?
             return SdkUtils.AddQueryParams($"{BaseUrl}{path}", queryParams);
         }


### PR DESCRIPTION
Howdy!

Just wanted to contribute some fixes back after using the C# SDK for a project at work.

- https://github.com/looker-open-source/sdk-codegen/commit/02bc30021eebbb5b864b670595fd3f42f42cbbb7 ignores null values when serialising JSON requests because some APIs didn't play well with null values being included
- https://github.com/looker-open-source/sdk-codegen/commit/7f1166e1ef2d50678c3b39e8ae8f57a21b330f63 fix string interpolation  when calling `EncodeParam`
- https://github.com/looker-open-source/sdk-codegen/commit/43ab86aab0efc22f10bcb687adb4f6109b4a80cc call `AddQueryParams` when constructing a url