### PR TITLE
Typescript - reformat calls to be flatter

### DIFF
--- a/packages/sdk-codegen/src/typescript.gen.spec.ts
+++ b/packages/sdk-codegen/src/typescript.gen.spec.ts
@@ -562,8 +562,7 @@ async create_user_credentials_email(
   /**
    * @param {string} fields Requested fields.
    */
-  fields?: string,
-  options?: Partial<ITransportSettings>) {
+  fields?: string, options?: Partial<ITransportSettings>) {
 `
       const actual = gen.methodSignature('', method)
       expect(actual).toEqual(expected)
@@ -576,8 +575,7 @@ async create_user_credentials_email(
  *
  * GET /datagroups -> IDatagroup[]
  */
-async all_datagroups(
-  options?: Partial<ITransportSettings>) {
+async all_datagroups(options?: Partial<ITransportSettings>) {
 `
       const actual = gen.methodSignature('', method)
       expect(actual).toEqual(expected)
@@ -621,8 +619,7 @@ async all_datagroups(
     })
     it('assert response is list active_themes', () => {
       const method = apiTestModel.methods.active_themes
-      const expected = `return this.get<ITheme[], IError>('/themes/active', 
-  {name: request.name, ts: request.ts, fields: request.fields}, null, options)`
+      const expected = `return this.get<ITheme[], IError>('/themes/active', {name: request.name, ts: request.ts, fields: request.fields}, null, options)`
       const actual = gen.httpCall(indent, method)
       expect(actual).toEqual(expected)
     })
@@ -649,12 +646,10 @@ async all_datagroups(
  *
  * POST /render_tasks/dashboards/{dashboard_id}/{result_format} -> IRenderTask
  */
-async create_dashboard_render_task(request: IRequestCreateDashboardRenderTask,
-  options?: Partial<ITransportSettings>) {
-    request.dashboard_id = encodeParam(request.dashboard_id)
-    request.result_format = encodeParam(request.result_format)
-  return this.post<IRenderTask, IError | IValidationError>(\`/render_tasks/dashboards/\${request.dashboard_id}/\${request.result_format}\`, 
-    {width: request.width, height: request.height, fields: request.fields, pdf_paper_size: request.pdf_paper_size, pdf_landscape: request.pdf_landscape, long_tables: request.long_tables}, request.body, options)
+async create_dashboard_render_task(request: IRequestCreateDashboardRenderTask, options?: Partial<ITransportSettings>) {
+  request.dashboard_id = encodeParam(request.dashboard_id)
+  request.result_format = encodeParam(request.result_format)
+  return this.post<IRenderTask, IError | IValidationError>(\`/render_tasks/dashboards/\${request.dashboard_id}/\${request.result_format}\`, {width: request.width, height: request.height, fields: request.fields, pdf_paper_size: request.pdf_paper_size, pdf_landscape: request.pdf_landscape, long_tables: request.long_tables}, request.body, options)
 }`
       const actual = gen.declareMethod(indent, method)
       expect(actual).toEqual(expected)
@@ -780,10 +775,8 @@ async me(
   /**
    * @param {string} hi-test Requested fields.
    */
-  'hi-test'?: string,
-  options?: Partial<ITransportSettings>) {
-  return this.get<IUser, IError>('/user', 
-    {'hi-test'}, null, options)
+  'hi-test'?: string, options?: Partial<ITransportSettings>) {
+  return this.get<IUser, IError>('/user', {'hi-test'}, null, options)
 }`
         expect(actual).toEqual(expected)
       })
@@ -800,10 +793,8 @@ async me(
  *
  * GET /roles/{role_id}/users -> IUser[]
  */
-async role_users(request: IRequestRoleUsers,
-  options?: Partial<ITransportSettings>) {
-  return this.get<IUser[], IError>(\`/roles/\${request.role_id}/users\`, 
-    {fields: request.fields, 'direct-association-only': request['direct-association-only']}, null, options)
+async role_users(request: IRequestRoleUsers, options?: Partial<ITransportSettings>) {
+  return this.get<IUser[], IError>(\`/roles/\${request.role_id}/users\`, {fields: request.fields, 'direct-association-only': request['direct-association-only']}, null, options)
 }`
         expect(actual).toEqual(expected)
       })

--- a/packages/sdk-codegen/src/typescript.gen.ts
+++ b/packages/sdk-codegen/src/typescript.gen.ts
@@ -213,7 +213,7 @@ export interface IDictionary<T> {
       `${method.httpMethod} ${method.endpoint} -> ${mapped.name}`
     let fragment: string
     const requestType = this.requestTypeName(method)
-    const bump = indent + this.indentStr
+    const bump = this.bumper(indent)
 
     if (requestType) {
       // use the request type that will be generated in models.ts
@@ -245,9 +245,8 @@ export interface IDictionary<T> {
     return (
       header +
       fragment +
-      `${
-        fragment ? ',' : ''
-      }\n${bump}options?: Partial<ITransportSettings>) {\n`
+      (fragment ? ', ' : '') +
+      'options?: Partial<ITransportSettings>) {\n'
     )
   }
 
@@ -274,7 +273,7 @@ export interface IDictionary<T> {
     const bump = this.bumper(indent)
     return (
       this.methodSignature(indent, method) +
-      this.encodePathParams(bump, method) +
+      this.encodePathParams(indent, method) +
       this.httpCall(bump, method) +
       `\n${indent}}`
     )
@@ -328,7 +327,7 @@ export interface IDictionary<T> {
     return `'${path}'`
   }
 
-  argGroup(indent: string, args: Arg[], prefix?: string) {
+  argGroup(_indent: string, args: Arg[], prefix?: string) {
     if (!args || args.length === 0) return this.nullStr
     const hash: string[] = []
     for (const arg of args) {
@@ -339,7 +338,7 @@ export interface IDictionary<T> {
         hash.push(reserved)
       }
     }
-    return `\n${indent}{${hash.join(this.argDelimiter)}}`
+    return `{${hash.join(this.argDelimiter)}}`
   }
 
   /**
@@ -410,14 +409,15 @@ export interface IDictionary<T> {
   httpCall(indent: string, method: IMethod) {
     const request = this.useRequest(method) ? 'request.' : ''
     const mapped = this.typeMap(method.type)
-    const bump = indent + this.indentStr
+    const bump = this.bumper(indent)
     const args = this.httpArgs(bump, method)
     const errors = this.errorResponses(indent, method)
-    return `${indent}return ${this.it(method.httpMethod.toLowerCase())}<${
-      mapped.name
-    }, ${errors}>(${this.httpPath(method.endpoint, request)}${
-      args ? ', ' + args : ''
-    })`
+    return (
+      `${indent}return ${this.it(method.httpMethod.toLowerCase())}` +
+      `<${mapped.name}, ${errors}>(` +
+      this.httpPath(method.endpoint, request) +
+      `${args ? ', ' + args : ''})`
+    )
   }
 
   streamCall(indent: string, method: IMethod) {


### PR DESCRIPTION
make methodSignature and httpCall be flatter. This avoids some
extraneous trailing whitespace in tests. No change in generated code
because prettier runs and fixes it all anyway.