### PR TITLE
[Python] Bump attrs, caters versions for Python 3.7+

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -5,10 +5,10 @@
 from setuptools import setup, find_packages  # noqa: H301
 
 NAME = "looker_sdk"
-VERSION = "0.1.3b19"
+VERSION = "0.1.3b20"
 REQUIRES = [
     "requests >= 2.22",
-    "attrs >= 18.2.0",
+    "attrs >= 20.1.0",
     "cattrs >= 1.0.0",
     "python-dateutil;python_version<'3.7'",
     "typing-extensions;python_version<'3.8'",

--- a/python/setup.py
+++ b/python/setup.py
@@ -8,9 +8,13 @@ NAME = "looker_sdk"
 VERSION = "0.1.3b20"
 REQUIRES = [
     "requests >= 2.22",
-    "attrs >= 20.1.0",
-    "cattrs >= 1.0.0",
+    # Python 3.6
+    "attrs >= 18.2.0;python_version<'3.7'",
+    "cattrs < 1.1.0;python_version<'3.7'",
     "python-dateutil;python_version<'3.7'",
+    # Python 3.7+
+    "attrs >= 20.1.0;python_version>='3.7'",
+    "cattrs >= 1.1.0;python_version>='3.7'",
     "typing-extensions;python_version<'3.8'",
 ]
 


### PR DESCRIPTION
Ran into a weird edge case today where import for `looker_sdk` failed because of a version issue with `attrs`, which was on `19.3.0` but `cattrs` required `attr>=20.1.0` ([this line](https://github.com/Tinche/cattrs/blob/1ab1cb27b0ee76d34ad8310d300329fba97a8f3a/src/cattr/converters.py#L16) requires [attrs > 20.1.0](https://www.attrs.org/en/stable/api.html#attr.resolve_types)). Tracelog below, but running a `pip install -U attrs` fixed the issue. Bumping it up in here, along with the version (feel free to update the version appropriately if that's an error on my end).

Tracelog:
```sh
...
/opt/conda/lib/python3.7/site-packages/looker_sdk/__init__.py in <module>
     25 from looker_sdk.rtl import api_settings
     26 from looker_sdk.rtl import requests_transport
---> 27 from looker_sdk.rtl import serialize
     28 from looker_sdk.rtl import auth_session
     29 

/opt/conda/lib/python3.7/site-packages/looker_sdk/rtl/serialize.py in <module>
     37 )
     38 
---> 39 import cattr
     40 
     41 from looker_sdk.rtl import model

/opt/conda/lib/python3.7/site-packages/cattr/__init__.py in <module>
----> 1 from .converters import Converter, GenConverter, UnstructureStrategy
      2 from .gen import override
      3 
      4 __all__ = (
      5     "global_converter",

/opt/conda/lib/python3.7/site-packages/cattr/converters.py in <module>
     14 )
     15 
---> 16 from attr import fields, resolve_types
     17 
     18 from ._compat import (

ImportError: cannot import name 'resolve_types' from 'attr' (/opt/conda/lib/python3.7/site-packages/attr/__init__.py)
```