### PR TITLE
Refactor Kotlin RTL

### DIFF
--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -56,6 +56,8 @@ Verify authentication works and that API calls will succeed with code similar to
 ```kotlin
 import com.looker.rtl.ApiSettings;
 import com.looker.rtl.AuthSession;
+import com.looker.rtl.SdkResult;
+import com.looker.rtl.ok;
 import com.looker.sdk.LookerSDK;
 
 val localIni = "./looker.ini"
@@ -63,10 +65,21 @@ val settings = ApiSettings.fromIniFile(localIni, "Looker")
 val session = AuthSession(settings)
 val sdk = LookerSDK(session)
 // Verify minimal SDK call works
-val me = sdk.ok<User>(sdk.me())
+val me = sdk.me().ok()
 
 /// continue making SDK calls
-val users = sdk.ok<Array<User>>(sdk.all_users())
+val result = sdk.all_users()
+when (result) {
+  is SdkResult.SuccessResponse<List<User>> -> {
+    result.body.forEach { user -> print(user.name) }
+  }
+  is SdkResult.FailureResponse<com.looker.sdk.Error> -> {
+    log(result.body.message)
+  }
+  is SdkResult.Error -> {
+    log(result.error.message)
+  }
+}
 ```
 
 ### More examples

--- a/kotlin/src/main/com/looker/rtl/APIMethods.kt
+++ b/kotlin/src/main/com/looker/rtl/APIMethods.kt
@@ -33,36 +33,64 @@ open class APIMethods(val authSession: AuthSession) {
 
     val authRequest = authSession::authenticate
 
-    fun <T> ok(response: SDKResponse): T {
-        when (response) {
-            is SDKResponse.SDKErrorResponse<*> -> throw Error(response.value.toString())
-            is SDKResponse.SDKSuccessResponse<*> -> return response.value as T
-            else -> throw Error("Fail!!")
-        }
+    inline fun <reified TSuccess, reified TFailure> get(
+        path: String,
+        queryParams: Values = mapOf(),
+        body: Any? = null
+    ): SdkResult<TSuccess, TFailure> {
+        return authSession.transport.request<TSuccess, TFailure>(
+            HttpMethod.GET, path, queryParams, body, authRequest
+        )
     }
 
-    inline fun <reified T> get(path: String, queryParams: Values = mapOf(), body: Any? = null): SDKResponse {
-        return authSession.transport.request<T>(HttpMethod.GET, path, queryParams, body, authRequest)
+    inline fun <reified TSuccess, reified TFailure> head(
+        path: String,
+        queryParams: Values = mapOf(),
+        body: Any? = null
+    ): SdkResult<TSuccess, TFailure> {
+        return authSession.transport.request<TSuccess, TFailure>(
+            HttpMethod.HEAD, path, queryParams, body, authRequest
+        )
     }
 
-    inline fun <reified T> head(path: String, queryParams: Values = mapOf(), body: Any? = null): SDKResponse {
-        return authSession.transport.request<T>(HttpMethod.HEAD, path, queryParams, body, authRequest)
+    inline fun <reified TSuccess, reified TFailure> delete(
+        path: String,
+        queryParams: Values = mapOf(),
+        body: Any? = null
+    ): SdkResult<TSuccess, TFailure> {
+        return authSession.transport.request<TSuccess, TFailure>(
+            HttpMethod.DELETE, path, queryParams, body, authRequest
+        )
     }
 
-    inline fun <reified T> delete(path: String, queryParams: Values = mapOf(), body: Any? = null): SDKResponse {
-        return authSession.transport.request<T>(HttpMethod.DELETE, path, queryParams, body, authRequest)
+    inline fun <reified TSuccess, reified TFailure> post(
+        path: String,
+        queryParams: Values = mapOf(),
+        body: Any? = null
+    ): SdkResult<TSuccess, TFailure> {
+        return authSession.transport.request<TSuccess, TFailure>(
+            HttpMethod.POST, path, queryParams, body, authRequest
+        )
     }
 
-    inline fun <reified T> post(path: String, queryParams: Values = mapOf(), body: Any? = null): SDKResponse {
-        return authSession.transport.request<T>(HttpMethod.POST, path, queryParams, body, authRequest)
+    inline fun <reified TSuccess, reified TFailure> put(
+        path: String,
+        queryParams: Values = mapOf(),
+        body: Any? = null
+    ): SdkResult<TSuccess, TFailure> {
+        return authSession.transport.request<TSuccess, TFailure>(
+            HttpMethod.PUT, path, queryParams, body, authRequest
+        )
     }
 
-    inline fun <reified T> put(path: String, queryParams: Values = mapOf(), body: Any? = null): SDKResponse {
-        return authSession.transport.request<T>(HttpMethod.PUT, path, queryParams, body, authRequest)
-    }
-
-    inline fun <reified T> patch(path: String, queryParams: Values = mapOf(), body: Any? = null): SDKResponse {
-        return authSession.transport.request<T>(HttpMethod.PATCH, path, queryParams, body, authRequest)
+    inline fun <reified TSuccess, reified TFailure> patch(
+        path: String,
+        queryParams: Values = mapOf(),
+        body: Any? = null
+    ): SdkResult<TSuccess, TFailure> {
+        return authSession.transport.request<TSuccess, TFailure>(
+            HttpMethod.PATCH, path, queryParams, body, authRequest
+        )
     }
 
     fun encodeURI(value: String): String {

--- a/kotlin/src/main/com/looker/rtl/OAuthSession.kt
+++ b/kotlin/src/main/com/looker/rtl/OAuthSession.kt
@@ -45,13 +45,13 @@ class OAuthSession(override val apiSettings: ConfigurationProvider, override val
     }
 
     fun requestToken(body: Values): AuthToken {
-        val response = this.transport.request<AccessToken>(
+        val response = this.transport.request<AccessToken, Any?>(
             HttpMethod.POST,
             "/api/token",
             mapOf(),
             body
         )
-        val token = this.ok<AccessToken>(response)
+        val token = response.ok()
         this.authToken.setToken(token)
         return this.authToken
     }

--- a/kotlin/src/main/com/looker/rtl/SdkResult.kt
+++ b/kotlin/src/main/com/looker/rtl/SdkResult.kt
@@ -1,0 +1,104 @@
+package com.looker.rtl
+
+import io.ktor.client.call.receive
+import io.ktor.client.response.HttpResponse
+import io.ktor.http.isSuccess
+import kotlinx.coroutines.runBlocking
+
+class FailureResponseError(val result: SdkResult<*, *>) : Exception()
+
+interface SdkResponse<T> {
+    val success: Boolean
+    val statusCode: Int
+    val method: HttpMethod
+    val path: String
+    fun body(): T
+}
+
+sealed class SdkResult<out TSuccess, out TFailure> {
+    abstract val success: Boolean
+    abstract val method: HttpMethod
+    abstract val path: String
+
+    data class SuccessResponse<TSuccess>(
+        val response: HttpResponse,
+        override val method: HttpMethod,
+        override val path: String,
+        private val body: TSuccess
+    ) : SdkResponse<TSuccess>, SdkResult<TSuccess, Nothing>() {
+        override val success: Boolean = true
+        override val statusCode: Int = response.status.value
+
+        override fun body(): TSuccess = body
+
+        inline fun <reified T> bodyAs(): T {
+            return runBlocking { response.receive<T>() }
+        }
+    }
+
+    data class FailureResponse<TFailure>(
+        val response: HttpResponse,
+        override val method: HttpMethod,
+        override val path: String,
+        private val body: TFailure
+    ) : SdkResponse<TFailure>, SdkResult<Nothing, TFailure>() {
+        override val success: Boolean = false
+        override val statusCode: Int = response.status.value
+
+        override fun body(): TFailure = body
+
+        inline fun <reified T> bodyAs(): T {
+            return runBlocking { response.receive<T>() }
+        }
+    }
+
+    data class Error(
+        val error: Throwable,
+        override val method: HttpMethod,
+        override val path: String
+    ) : SdkResult<Nothing, Nothing>() {
+        override val success: Boolean = false
+    }
+
+    companion object {
+        inline fun <reified TSuccess, reified TFailure> response(
+            response: HttpResponse,
+            method: HttpMethod,
+            path: String
+        ): SdkResult<TSuccess, TFailure> {
+            try {
+                if (response.status.isSuccess()) {
+                    val body = runBlocking { response.receive<TSuccess>() }
+                    return SuccessResponse<TSuccess>(response, method, path, body)
+                } else {
+                    val body = runBlocking { response.receive<TFailure>() }
+                    return FailureResponse<TFailure>(response, method, path, body)
+                }
+            } catch (ex: Exception) {
+                return error(ex, method, path)
+            }
+        }
+
+        fun <TSuccess, TFailure> error(
+            error: Throwable,
+            method: HttpMethod,
+            path: String
+        ): SdkResult<TSuccess, TFailure> {
+            return SdkResult.Error(error, method, path)
+        }
+    }
+}
+
+fun <TSuccess> SdkResult<TSuccess, *>.ok(): TSuccess {
+    return when (this) {
+        is SdkResult.SuccessResponse<TSuccess> -> {
+            this.body()
+        }
+        is SdkResult.FailureResponse<*> -> {
+            throw FailureResponseError(this)
+        }
+        is SdkResult.Error -> {
+            throw this.error
+        }
+    }
+}

--- a/kotlin/src/main/com/looker/sdk/3.1/methods.kt
+++ b/kotlin/src/main/com/looker/sdk/3.1/methods.kt
@@ -78,8 +78,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun login(
         client_id: String? = null,
         client_secret: String? = null
-    ): SDKResponse {
-        return this.post<AccessToken>(
+    ): SdkResult<AccessToken, com.looker.sdk.Error> {
+        return this.post<AccessToken, com.looker.sdk.Error>(
             "/login",
             mapOf(
                 "client_id" to client_id,
@@ -114,9 +114,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun login_user(
         user_id: Long,
         associative: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<AccessToken, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.post<AccessToken>(
+        return this.post<AccessToken, com.looker.sdk.Error>(
             "/login/$path_user_id",
             mapOf("associative" to associative)
         )
@@ -127,8 +127,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * DELETE /logout -> String
      */
-    fun logout(): SDKResponse {
-        return this.delete<String>("/logout", mapOf())
+    fun logout(): SdkResult<String, com.looker.sdk.Error> {
+        return this.delete<String, com.looker.sdk.Error>(
+            "/logout", mapOf()
+        )
     }
 
     //endregion ApiAuth: API Authentication
@@ -177,8 +179,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_sso_embed_url(
         body: EmbedSsoParams
-    ): SDKResponse {
-        return this.post<EmbedUrlResponse>("/embed/sso_url", mapOf(), body)
+    ): SdkResult<EmbedUrlResponse, com.looker.sdk.Error> {
+        return this.post<EmbedUrlResponse, com.looker.sdk.Error>(
+            "/embed/sso_url", mapOf(), body
+        )
     }
 
     /**
@@ -201,8 +205,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /ldap_config -> LDAPConfig
      */
-    fun ldap_config(): SDKResponse {
-        return this.get<LDAPConfig>("/ldap_config", mapOf())
+    fun ldap_config(): SdkResult<LDAPConfig, com.looker.sdk.Error> {
+        return this.get<LDAPConfig, com.looker.sdk.Error>(
+            "/ldap_config", mapOf()
+        )
     }
 
     /**
@@ -224,8 +230,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_ldap_config(
         body: WriteLDAPConfig
-    ): SDKResponse {
-        return this.patch<LDAPConfig>("/ldap_config", mapOf(), body)
+    ): SdkResult<LDAPConfig, com.looker.sdk.Error> {
+        return this.patch<LDAPConfig, com.looker.sdk.Error>(
+            "/ldap_config", mapOf(), body
+        )
     }
 
     /**
@@ -254,8 +262,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun test_ldap_config_connection(
         body: WriteLDAPConfig
-    ): SDKResponse {
-        return this.put<LDAPConfigTestResult>("/ldap_config/test_connection", mapOf(), body)
+    ): SdkResult<LDAPConfigTestResult, com.looker.sdk.Error> {
+        return this.put<LDAPConfigTestResult, com.looker.sdk.Error>(
+            "/ldap_config/test_connection", mapOf(), body
+        )
     }
 
     /**
@@ -286,8 +296,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun test_ldap_config_auth(
         body: WriteLDAPConfig
-    ): SDKResponse {
-        return this.put<LDAPConfigTestResult>("/ldap_config/test_auth", mapOf(), body)
+    ): SdkResult<LDAPConfigTestResult, com.looker.sdk.Error> {
+        return this.put<LDAPConfigTestResult, com.looker.sdk.Error>(
+            "/ldap_config/test_auth", mapOf(), body
+        )
     }
 
     /**
@@ -307,8 +319,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun test_ldap_config_user_info(
         body: WriteLDAPConfig
-    ): SDKResponse {
-        return this.put<LDAPConfigTestResult>("/ldap_config/test_user_info", mapOf(), body)
+    ): SdkResult<LDAPConfigTestResult, com.looker.sdk.Error> {
+        return this.put<LDAPConfigTestResult, com.looker.sdk.Error>(
+            "/ldap_config/test_user_info", mapOf(), body
+        )
     }
 
     /**
@@ -328,8 +342,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun test_ldap_config_user_auth(
         body: WriteLDAPConfig
-    ): SDKResponse {
-        return this.put<LDAPConfigTestResult>("/ldap_config/test_user_auth", mapOf(), body)
+    ): SdkResult<LDAPConfigTestResult, com.looker.sdk.Error> {
+        return this.put<LDAPConfigTestResult, com.looker.sdk.Error>(
+            "/ldap_config/test_user_auth", mapOf(), body
+        )
     }
 
     /**
@@ -348,8 +364,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /oidc_config -> OIDCConfig
      */
-    fun oidc_config(): SDKResponse {
-        return this.get<OIDCConfig>("/oidc_config", mapOf())
+    fun oidc_config(): SdkResult<OIDCConfig, com.looker.sdk.Error> {
+        return this.get<OIDCConfig, com.looker.sdk.Error>(
+            "/oidc_config", mapOf()
+        )
     }
 
     /**
@@ -369,8 +387,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_oidc_config(
         body: WriteOIDCConfig
-    ): SDKResponse {
-        return this.patch<OIDCConfig>("/oidc_config", mapOf(), body)
+    ): SdkResult<OIDCConfig, com.looker.sdk.Error> {
+        return this.patch<OIDCConfig, com.looker.sdk.Error>(
+            "/oidc_config", mapOf(), body
+        )
     }
 
     /**
@@ -382,9 +402,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun oidc_test_config(
         test_slug: String
-    ): SDKResponse {
+    ): SdkResult<OIDCConfig, com.looker.sdk.Error> {
         val path_test_slug = encodeParam(test_slug)
-        return this.get<OIDCConfig>("/oidc_test_configs/$path_test_slug", mapOf())
+        return this.get<OIDCConfig, com.looker.sdk.Error>(
+            "/oidc_test_configs/$path_test_slug", mapOf()
+        )
     }
 
     /**
@@ -396,9 +418,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_oidc_test_config(
         test_slug: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_test_slug = encodeParam(test_slug)
-        return this.delete<String>("/oidc_test_configs/$path_test_slug", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/oidc_test_configs/$path_test_slug", mapOf()
+        )
     }
 
     /**
@@ -410,8 +434,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_oidc_test_config(
         body: WriteOIDCConfig
-    ): SDKResponse {
-        return this.post<OIDCConfig>("/oidc_test_configs", mapOf(), body)
+    ): SdkResult<OIDCConfig, com.looker.sdk.Error> {
+        return this.post<OIDCConfig, com.looker.sdk.Error>(
+            "/oidc_test_configs", mapOf(), body
+        )
     }
 
     /**
@@ -419,8 +445,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /password_config -> PasswordConfig
      */
-    fun password_config(): SDKResponse {
-        return this.get<PasswordConfig>("/password_config", mapOf())
+    fun password_config(): SdkResult<PasswordConfig, com.looker.sdk.Error> {
+        return this.get<PasswordConfig, com.looker.sdk.Error>(
+            "/password_config", mapOf()
+        )
     }
 
     /**
@@ -432,8 +460,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_password_config(
         body: WritePasswordConfig
-    ): SDKResponse {
-        return this.patch<PasswordConfig>("/password_config", mapOf(), body)
+    ): SdkResult<PasswordConfig, com.looker.sdk.Error> {
+        return this.patch<PasswordConfig, com.looker.sdk.Error>(
+            "/password_config", mapOf(), body
+        )
     }
 
     /**
@@ -441,8 +471,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * PUT /password_config/force_password_reset_at_next_login_for_all_users -> String
      */
-    fun force_password_reset_at_next_login_for_all_users(): SDKResponse {
-        return this.put<String>("/password_config/force_password_reset_at_next_login_for_all_users", mapOf())
+    fun force_password_reset_at_next_login_for_all_users(): SdkResult<String, com.looker.sdk.Error> {
+        return this.put<String, com.looker.sdk.Error>(
+            "/password_config/force_password_reset_at_next_login_for_all_users", mapOf()
+        )
     }
 
     /**
@@ -461,8 +493,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /saml_config -> SamlConfig
      */
-    fun saml_config(): SDKResponse {
-        return this.get<SamlConfig>("/saml_config", mapOf())
+    fun saml_config(): SdkResult<SamlConfig, com.looker.sdk.Error> {
+        return this.get<SamlConfig, com.looker.sdk.Error>(
+            "/saml_config", mapOf()
+        )
     }
 
     /**
@@ -482,8 +516,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_saml_config(
         body: WriteSamlConfig
-    ): SDKResponse {
-        return this.patch<SamlConfig>("/saml_config", mapOf(), body)
+    ): SdkResult<SamlConfig, com.looker.sdk.Error> {
+        return this.patch<SamlConfig, com.looker.sdk.Error>(
+            "/saml_config", mapOf(), body
+        )
     }
 
     /**
@@ -495,9 +531,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun saml_test_config(
         test_slug: String
-    ): SDKResponse {
+    ): SdkResult<SamlConfig, com.looker.sdk.Error> {
         val path_test_slug = encodeParam(test_slug)
-        return this.get<SamlConfig>("/saml_test_configs/$path_test_slug", mapOf())
+        return this.get<SamlConfig, com.looker.sdk.Error>(
+            "/saml_test_configs/$path_test_slug", mapOf()
+        )
     }
 
     /**
@@ -509,9 +547,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_saml_test_config(
         test_slug: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_test_slug = encodeParam(test_slug)
-        return this.delete<String>("/saml_test_configs/$path_test_slug", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/saml_test_configs/$path_test_slug", mapOf()
+        )
     }
 
     /**
@@ -523,8 +563,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_saml_test_config(
         body: WriteSamlConfig
-    ): SDKResponse {
-        return this.post<SamlConfig>("/saml_test_configs", mapOf(), body)
+    ): SdkResult<SamlConfig, com.looker.sdk.Error> {
+        return this.post<SamlConfig, com.looker.sdk.Error>(
+            "/saml_test_configs", mapOf(), body
+        )
     }
 
     /**
@@ -536,8 +578,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun parse_saml_idp_metadata(
         body: String
-    ): SDKResponse {
-        return this.post<SamlMetadataParseResult>("/parse_saml_idp_metadata", mapOf(), body)
+    ): SdkResult<SamlMetadataParseResult, com.looker.sdk.Error> {
+        return this.post<SamlMetadataParseResult, com.looker.sdk.Error>(
+            "/parse_saml_idp_metadata", mapOf(), body
+        )
     }
 
     /**
@@ -551,8 +595,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun fetch_and_parse_saml_idp_metadata(
         body: String
-    ): SDKResponse {
-        return this.post<SamlMetadataParseResult>("/fetch_and_parse_saml_idp_metadata", mapOf(), body)
+    ): SdkResult<SamlMetadataParseResult, com.looker.sdk.Error> {
+        return this.post<SamlMetadataParseResult, com.looker.sdk.Error>(
+            "/fetch_and_parse_saml_idp_metadata", mapOf(), body
+        )
     }
 
     /**
@@ -560,8 +606,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /session_config -> SessionConfig
      */
-    fun session_config(): SDKResponse {
-        return this.get<SessionConfig>("/session_config", mapOf())
+    fun session_config(): SdkResult<SessionConfig, com.looker.sdk.Error> {
+        return this.get<SessionConfig, com.looker.sdk.Error>(
+            "/session_config", mapOf()
+        )
     }
 
     /**
@@ -573,8 +621,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_session_config(
         body: WriteSessionConfig
-    ): SDKResponse {
-        return this.patch<SessionConfig>("/session_config", mapOf(), body)
+    ): SdkResult<SessionConfig, com.looker.sdk.Error> {
+        return this.patch<SessionConfig, com.looker.sdk.Error>(
+            "/session_config", mapOf(), body
+        )
     }
 
     /**
@@ -586,8 +636,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_user_login_lockouts(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<UserLoginLockout>>(
+    ): SdkResult<Array<UserLoginLockout>, com.looker.sdk.Error> {
+        return this.get<Array<UserLoginLockout>, com.looker.sdk.Error>(
             "/user_login_lockouts",
             mapOf("fields" to fields)
         )
@@ -618,8 +668,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         email: String? = null,
         remote_id: String? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<Array<UserLoginLockout>>(
+    ): SdkResult<Array<UserLoginLockout>, com.looker.sdk.Error> {
+        return this.get<Array<UserLoginLockout>, com.looker.sdk.Error>(
             "/user_login_lockouts/search",
             mapOf(
                 "fields" to fields,
@@ -644,9 +694,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_user_login_lockout(
         key: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_key = encodeParam(key)
-        return this.delete<String>("/user_login_lockout/$path_key", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/user_login_lockout/$path_key", mapOf()
+        )
     }
 
     //endregion Auth: Manage User Authentication Configuration
@@ -669,8 +721,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_color_collections(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<ColorCollection>>(
+    ): SdkResult<Array<ColorCollection>, com.looker.sdk.Error> {
+        return this.get<Array<ColorCollection>, com.looker.sdk.Error>(
             "/color_collections",
             mapOf("fields" to fields)
         )
@@ -693,8 +745,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_color_collection(
         body: WriteColorCollection
-    ): SDKResponse {
-        return this.post<ColorCollection>("/color_collections", mapOf(), body)
+    ): SdkResult<ColorCollection, com.looker.sdk.Error> {
+        return this.post<ColorCollection, com.looker.sdk.Error>(
+            "/color_collections", mapOf(), body
+        )
     }
 
     /**
@@ -711,8 +765,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun color_collections_custom(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<ColorCollection>>(
+    ): SdkResult<Array<ColorCollection>, com.looker.sdk.Error> {
+        return this.get<Array<ColorCollection>, com.looker.sdk.Error>(
             "/color_collections/custom",
             mapOf("fields" to fields)
         )
@@ -732,8 +786,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun color_collections_standard(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<ColorCollection>>(
+    ): SdkResult<Array<ColorCollection>, com.looker.sdk.Error> {
+        return this.get<Array<ColorCollection>, com.looker.sdk.Error>(
             "/color_collections/standard",
             mapOf("fields" to fields)
         )
@@ -748,8 +802,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /color_collections/default -> ColorCollection
      */
-    fun default_color_collection(): SDKResponse {
-        return this.get<ColorCollection>("/color_collections/default", mapOf())
+    fun default_color_collection(): SdkResult<ColorCollection, com.looker.sdk.Error> {
+        return this.get<ColorCollection, com.looker.sdk.Error>(
+            "/color_collections/default", mapOf()
+        )
     }
 
     /**
@@ -764,8 +820,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun set_default_color_collection(
         collection_id: String
-    ): SDKResponse {
-        return this.put<ColorCollection>(
+    ): SdkResult<ColorCollection, com.looker.sdk.Error> {
+        return this.put<ColorCollection, com.looker.sdk.Error>(
             "/color_collections/default",
             mapOf("collection_id" to collection_id)
         )
@@ -791,9 +847,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun color_collection(
         collection_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ColorCollection, com.looker.sdk.Error> {
         val path_collection_id = encodeParam(collection_id)
-        return this.get<ColorCollection>(
+        return this.get<ColorCollection, com.looker.sdk.Error>(
             "/color_collections/$path_collection_id",
             mapOf("fields" to fields)
         )
@@ -811,9 +867,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     fun update_color_collection(
         collection_id: String,
         body: WriteColorCollection
-    ): SDKResponse {
+    ): SdkResult<ColorCollection, com.looker.sdk.Error> {
         val path_collection_id = encodeParam(collection_id)
-        return this.patch<ColorCollection>("/color_collections/$path_collection_id", mapOf(), body)
+        return this.patch<ColorCollection, com.looker.sdk.Error>(
+            "/color_collections/$path_collection_id", mapOf(), body
+        )
     }
 
     /**
@@ -832,9 +890,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_color_collection(
         collection_id: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_collection_id = encodeParam(collection_id)
-        return this.delete<String>("/color_collections/$path_collection_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/color_collections/$path_collection_id", mapOf()
+        )
     }
 
     //endregion ColorCollection: Manage Color Collections
@@ -846,8 +906,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /backup_configuration -> BackupConfiguration
      */
-    fun backup_configuration(): SDKResponse {
-        return this.get<BackupConfiguration>("/backup_configuration", mapOf())
+    fun backup_configuration(): SdkResult<BackupConfiguration, com.looker.sdk.Error> {
+        return this.get<BackupConfiguration, com.looker.sdk.Error>(
+            "/backup_configuration", mapOf()
+        )
     }
 
     /**
@@ -859,8 +921,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_backup_configuration(
         body: WriteBackupConfiguration
-    ): SDKResponse {
-        return this.patch<BackupConfiguration>("/backup_configuration", mapOf(), body)
+    ): SdkResult<BackupConfiguration, com.looker.sdk.Error> {
+        return this.patch<BackupConfiguration, com.looker.sdk.Error>(
+            "/backup_configuration", mapOf(), body
+        )
     }
 
     /**
@@ -868,8 +932,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /cloud_storage -> BackupConfiguration
      */
-    fun cloud_storage_configuration(): SDKResponse {
-        return this.get<BackupConfiguration>("/cloud_storage", mapOf())
+    fun cloud_storage_configuration(): SdkResult<BackupConfiguration, com.looker.sdk.Error> {
+        return this.get<BackupConfiguration, com.looker.sdk.Error>(
+            "/cloud_storage", mapOf()
+        )
     }
 
     /**
@@ -881,8 +947,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_cloud_storage_configuration(
         body: WriteBackupConfiguration
-    ): SDKResponse {
-        return this.patch<BackupConfiguration>("/cloud_storage", mapOf(), body)
+    ): SdkResult<BackupConfiguration, com.looker.sdk.Error> {
+        return this.patch<BackupConfiguration, com.looker.sdk.Error>(
+            "/cloud_storage", mapOf(), body
+        )
     }
 
     /**
@@ -890,8 +958,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /custom_welcome_email -> CustomWelcomeEmail
      */
-    fun custom_welcome_email(): SDKResponse {
-        return this.get<CustomWelcomeEmail>("/custom_welcome_email", mapOf())
+    fun custom_welcome_email(): SdkResult<CustomWelcomeEmail, com.looker.sdk.Error> {
+        return this.get<CustomWelcomeEmail, com.looker.sdk.Error>(
+            "/custom_welcome_email", mapOf()
+        )
     }
 
     /**
@@ -905,8 +975,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun update_custom_welcome_email(
         body: WriteCustomWelcomeEmail,
         send_test_welcome_email: Boolean? = null
-    ): SDKResponse {
-        return this.patch<CustomWelcomeEmail>(
+    ): SdkResult<CustomWelcomeEmail, com.looker.sdk.Error> {
+        return this.patch<CustomWelcomeEmail, com.looker.sdk.Error>(
             "/custom_welcome_email",
             mapOf("send_test_welcome_email" to send_test_welcome_email), body
         )
@@ -921,8 +991,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_custom_welcome_email_test(
         body: WelcomeEmailTest
-    ): SDKResponse {
-        return this.put<WelcomeEmailTest>("/custom_welcome_email_test", mapOf(), body)
+    ): SdkResult<WelcomeEmailTest, com.looker.sdk.Error> {
+        return this.put<WelcomeEmailTest, com.looker.sdk.Error>(
+            "/custom_welcome_email_test", mapOf(), body
+        )
     }
 
     /**
@@ -930,8 +1002,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /digest_emails_enabled -> DigestEmails
      */
-    fun digest_emails_enabled(): SDKResponse {
-        return this.get<DigestEmails>("/digest_emails_enabled", mapOf())
+    fun digest_emails_enabled(): SdkResult<DigestEmails, com.looker.sdk.Error> {
+        return this.get<DigestEmails, com.looker.sdk.Error>(
+            "/digest_emails_enabled", mapOf()
+        )
     }
 
     /**
@@ -943,8 +1017,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_digest_emails_enabled(
         body: DigestEmails
-    ): SDKResponse {
-        return this.patch<DigestEmails>("/digest_emails_enabled", mapOf(), body)
+    ): SdkResult<DigestEmails, com.looker.sdk.Error> {
+        return this.patch<DigestEmails, com.looker.sdk.Error>(
+            "/digest_emails_enabled", mapOf(), body
+        )
     }
 
     /**
@@ -954,8 +1030,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * POST /digest_email_send -> DigestEmailSend
      */
-    fun create_digest_email_send(): SDKResponse {
-        return this.post<DigestEmailSend>("/digest_email_send", mapOf())
+    fun create_digest_email_send(): SdkResult<DigestEmailSend, com.looker.sdk.Error> {
+        return this.post<DigestEmailSend, com.looker.sdk.Error>(
+            "/digest_email_send", mapOf()
+        )
     }
 
     /**
@@ -963,8 +1041,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /internal_help_resources_content -> InternalHelpResourcesContent
      */
-    fun internal_help_resources_content(): SDKResponse {
-        return this.get<InternalHelpResourcesContent>("/internal_help_resources_content", mapOf())
+    fun internal_help_resources_content(): SdkResult<InternalHelpResourcesContent, com.looker.sdk.Error> {
+        return this.get<InternalHelpResourcesContent, com.looker.sdk.Error>(
+            "/internal_help_resources_content", mapOf()
+        )
     }
 
     /**
@@ -976,8 +1056,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_internal_help_resources_content(
         body: WriteInternalHelpResourcesContent
-    ): SDKResponse {
-        return this.patch<InternalHelpResourcesContent>("/internal_help_resources_content", mapOf(), body)
+    ): SdkResult<InternalHelpResourcesContent, com.looker.sdk.Error> {
+        return this.patch<InternalHelpResourcesContent, com.looker.sdk.Error>(
+            "/internal_help_resources_content", mapOf(), body
+        )
     }
 
     /**
@@ -985,8 +1067,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /internal_help_resources_enabled -> InternalHelpResources
      */
-    fun internal_help_resources(): SDKResponse {
-        return this.get<InternalHelpResources>("/internal_help_resources_enabled", mapOf())
+    fun internal_help_resources(): SdkResult<InternalHelpResources, com.looker.sdk.Error> {
+        return this.get<InternalHelpResources, com.looker.sdk.Error>(
+            "/internal_help_resources_enabled", mapOf()
+        )
     }
 
     /**
@@ -998,8 +1082,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_internal_help_resources(
         body: WriteInternalHelpResources
-    ): SDKResponse {
-        return this.patch<InternalHelpResources>("/internal_help_resources", mapOf(), body)
+    ): SdkResult<InternalHelpResources, com.looker.sdk.Error> {
+        return this.patch<InternalHelpResources, com.looker.sdk.Error>(
+            "/internal_help_resources", mapOf(), body
+        )
     }
 
     /**
@@ -1007,8 +1093,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /legacy_features -> Array<LegacyFeature>
      */
-    fun all_legacy_features(): SDKResponse {
-        return this.get<Array<LegacyFeature>>("/legacy_features", mapOf())
+    fun all_legacy_features(): SdkResult<Array<LegacyFeature>, com.looker.sdk.Error> {
+        return this.get<Array<LegacyFeature>, com.looker.sdk.Error>(
+            "/legacy_features", mapOf()
+        )
     }
 
     /**
@@ -1020,9 +1108,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun legacy_feature(
         legacy_feature_id: Long
-    ): SDKResponse {
+    ): SdkResult<LegacyFeature, com.looker.sdk.Error> {
         val path_legacy_feature_id = encodeParam(legacy_feature_id)
-        return this.get<LegacyFeature>("/legacy_features/$path_legacy_feature_id", mapOf())
+        return this.get<LegacyFeature, com.looker.sdk.Error>(
+            "/legacy_features/$path_legacy_feature_id", mapOf()
+        )
     }
 
     /**
@@ -1036,9 +1126,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     fun update_legacy_feature(
         legacy_feature_id: Long,
         body: WriteLegacyFeature
-    ): SDKResponse {
+    ): SdkResult<LegacyFeature, com.looker.sdk.Error> {
         val path_legacy_feature_id = encodeParam(legacy_feature_id)
-        return this.patch<LegacyFeature>("/legacy_features/$path_legacy_feature_id", mapOf(), body)
+        return this.patch<LegacyFeature, com.looker.sdk.Error>(
+            "/legacy_features/$path_legacy_feature_id", mapOf(), body
+        )
     }
 
     /**
@@ -1046,8 +1138,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /locales -> Array<Locale>
      */
-    fun all_locales(): SDKResponse {
-        return this.get<Array<Locale>>("/locales", mapOf())
+    fun all_locales(): SdkResult<Array<Locale>, com.looker.sdk.Error> {
+        return this.get<Array<Locale>, com.looker.sdk.Error>(
+            "/locales", mapOf()
+        )
     }
 
     /**
@@ -1055,8 +1149,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /timezones -> Array<Timezone>
      */
-    fun all_timezones(): SDKResponse {
-        return this.get<Array<Timezone>>("/timezones", mapOf())
+    fun all_timezones(): SdkResult<Array<Timezone>, com.looker.sdk.Error> {
+        return this.get<Array<Timezone>, com.looker.sdk.Error>(
+            "/timezones", mapOf()
+        )
     }
 
     /**
@@ -1068,8 +1164,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun versions(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ApiVersion>(
+    ): SdkResult<ApiVersion, com.looker.sdk.Error> {
+        return this.get<ApiVersion, com.looker.sdk.Error>(
             "/versions",
             mapOf("fields" to fields)
         )
@@ -1085,8 +1181,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun whitelabel_configuration(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<WhitelabelConfiguration>(
+    ): SdkResult<WhitelabelConfiguration, com.looker.sdk.Error> {
+        return this.get<WhitelabelConfiguration, com.looker.sdk.Error>(
             "/whitelabel_configuration",
             mapOf("fields" to fields)
         )
@@ -1101,8 +1197,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_whitelabel_configuration(
         body: WriteWhitelabelConfiguration
-    ): SDKResponse {
-        return this.put<WhitelabelConfiguration>("/whitelabel_configuration", mapOf(), body)
+    ): SdkResult<WhitelabelConfiguration, com.looker.sdk.Error> {
+        return this.put<WhitelabelConfiguration, com.looker.sdk.Error>(
+            "/whitelabel_configuration", mapOf(), body
+        )
     }
 
     //endregion Config: Manage General Configuration
@@ -1118,8 +1216,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_connections(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<DBConnection>>(
+    ): SdkResult<Array<DBConnection>, com.looker.sdk.Error> {
+        return this.get<Array<DBConnection>, com.looker.sdk.Error>(
             "/connections",
             mapOf("fields" to fields)
         )
@@ -1134,8 +1232,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_connection(
         body: WriteDBConnection
-    ): SDKResponse {
-        return this.post<DBConnection>("/connections", mapOf(), body)
+    ): SdkResult<DBConnection, com.looker.sdk.Error> {
+        return this.post<DBConnection, com.looker.sdk.Error>(
+            "/connections", mapOf(), body
+        )
     }
 
     /**
@@ -1149,9 +1249,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun connection(
         connection_name: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<DBConnection, com.looker.sdk.Error> {
         val path_connection_name = encodeParam(connection_name)
-        return this.get<DBConnection>(
+        return this.get<DBConnection, com.looker.sdk.Error>(
             "/connections/$path_connection_name",
             mapOf("fields" to fields)
         )
@@ -1168,9 +1268,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     fun update_connection(
         connection_name: String,
         body: WriteDBConnection
-    ): SDKResponse {
+    ): SdkResult<DBConnection, com.looker.sdk.Error> {
         val path_connection_name = encodeParam(connection_name)
-        return this.patch<DBConnection>("/connections/$path_connection_name", mapOf(), body)
+        return this.patch<DBConnection, com.looker.sdk.Error>(
+            "/connections/$path_connection_name", mapOf(), body
+        )
     }
 
     /**
@@ -1182,9 +1284,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_connection(
         connection_name: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_connection_name = encodeParam(connection_name)
-        return this.delete<String>("/connections/$path_connection_name", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/connections/$path_connection_name", mapOf()
+        )
     }
 
     /**
@@ -1198,10 +1302,12 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     fun delete_connection_override(
         connection_name: String,
         override_context: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_connection_name = encodeParam(connection_name)
         val path_override_context = encodeParam(override_context)
-        return this.delete<String>("/connections/$path_connection_name/connection_override/$path_override_context", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/connections/$path_connection_name/connection_override/$path_override_context", mapOf()
+        )
     }
 
     /**
@@ -1222,9 +1328,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun test_connection(
         connection_name: String,
         tests: DelimArray<String>? = null
-    ): SDKResponse {
+    ): SdkResult<Array<DBConnectionTestResult>, com.looker.sdk.Error> {
         val path_connection_name = encodeParam(connection_name)
-        return this.put<Array<DBConnectionTestResult>>(
+        return this.put<Array<DBConnectionTestResult>, com.looker.sdk.Error>(
             "/connections/$path_connection_name/test",
             mapOf("tests" to tests)
         )
@@ -1248,8 +1354,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun test_connection_config(
         body: WriteDBConnection,
         tests: DelimArray<String>? = null
-    ): SDKResponse {
-        return this.put<Array<DBConnectionTestResult>>(
+    ): SdkResult<Array<DBConnectionTestResult>, com.looker.sdk.Error> {
+        return this.put<Array<DBConnectionTestResult>, com.looker.sdk.Error>(
             "/connections/test",
             mapOf("tests" to tests), body
         )
@@ -1264,8 +1370,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_dialect_infos(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<DialectInfo>>(
+    ): SdkResult<Array<DialectInfo>, com.looker.sdk.Error> {
+        return this.get<Array<DialectInfo>, com.looker.sdk.Error>(
             "/dialect_info",
             mapOf("fields" to fields)
         )
@@ -1323,8 +1429,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         sorts: String? = null,
         fields: String? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<Array<ContentFavorite>>(
+    ): SdkResult<Array<ContentFavorite>, com.looker.sdk.Error> {
+        return this.get<Array<ContentFavorite>, com.looker.sdk.Error>(
             "/content_favorite/search",
             mapOf(
                 "id" to id,
@@ -1352,9 +1458,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun content_favorite(
         content_favorite_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ContentFavorite, com.looker.sdk.Error> {
         val path_content_favorite_id = encodeParam(content_favorite_id)
-        return this.get<ContentFavorite>(
+        return this.get<ContentFavorite, com.looker.sdk.Error>(
             "/content_favorite/$path_content_favorite_id",
             mapOf("fields" to fields)
         )
@@ -1369,9 +1475,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_content_favorite(
         content_favorite_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_content_favorite_id = encodeParam(content_favorite_id)
-        return this.delete<String>("/content_favorite/$path_content_favorite_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/content_favorite/$path_content_favorite_id", mapOf()
+        )
     }
 
     /**
@@ -1383,8 +1491,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_content_favorite(
         body: WriteContentFavorite
-    ): SDKResponse {
-        return this.post<ContentFavorite>("/content_favorite", mapOf(), body)
+    ): SdkResult<ContentFavorite, com.looker.sdk.Error> {
+        return this.post<ContentFavorite, com.looker.sdk.Error>(
+            "/content_favorite", mapOf(), body
+        )
     }
 
     /**
@@ -1398,8 +1508,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_content_metadatas(
         parent_id: Long,
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<ContentMeta>>(
+    ): SdkResult<Array<ContentMeta>, com.looker.sdk.Error> {
+        return this.get<Array<ContentMeta>, com.looker.sdk.Error>(
             "/content_metadata",
             mapOf(
                 "parent_id" to parent_id,
@@ -1419,9 +1529,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun content_metadata(
         content_metadata_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ContentMeta, com.looker.sdk.Error> {
         val path_content_metadata_id = encodeParam(content_metadata_id)
-        return this.get<ContentMeta>(
+        return this.get<ContentMeta, com.looker.sdk.Error>(
             "/content_metadata/$path_content_metadata_id",
             mapOf("fields" to fields)
         )
@@ -1438,9 +1548,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     fun update_content_metadata(
         content_metadata_id: Long,
         body: WriteContentMeta
-    ): SDKResponse {
+    ): SdkResult<ContentMeta, com.looker.sdk.Error> {
         val path_content_metadata_id = encodeParam(content_metadata_id)
-        return this.patch<ContentMeta>("/content_metadata/$path_content_metadata_id", mapOf(), body)
+        return this.patch<ContentMeta, com.looker.sdk.Error>(
+            "/content_metadata/$path_content_metadata_id", mapOf(), body
+        )
     }
 
     /**
@@ -1454,8 +1566,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_content_metadata_accesses(
         content_metadata_id: Long,
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<ContentMetaGroupUser>>(
+    ): SdkResult<Array<ContentMetaGroupUser>, com.looker.sdk.Error> {
+        return this.get<Array<ContentMetaGroupUser>, com.looker.sdk.Error>(
             "/content_metadata_access",
             mapOf(
                 "content_metadata_id" to content_metadata_id,
@@ -1475,8 +1587,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_content_metadata_access(
         body: ContentMetaGroupUser,
         send_boards_notification_email: Boolean? = null
-    ): SDKResponse {
-        return this.post<ContentMetaGroupUser>(
+    ): SdkResult<ContentMetaGroupUser, com.looker.sdk.Error> {
+        return this.post<ContentMetaGroupUser, com.looker.sdk.Error>(
             "/content_metadata_access",
             mapOf("send_boards_notification_email" to send_boards_notification_email), body
         )
@@ -1493,9 +1605,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     fun update_content_metadata_access(
         content_metadata_access_id: Long,
         body: ContentMetaGroupUser
-    ): SDKResponse {
+    ): SdkResult<ContentMetaGroupUser, com.looker.sdk.Error> {
         val path_content_metadata_access_id = encodeParam(content_metadata_access_id)
-        return this.put<ContentMetaGroupUser>("/content_metadata_access/$path_content_metadata_access_id", mapOf(), body)
+        return this.put<ContentMetaGroupUser, com.looker.sdk.Error>(
+            "/content_metadata_access/$path_content_metadata_access_id", mapOf(), body
+        )
     }
 
     /**
@@ -1507,9 +1621,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_content_metadata_access(
         content_metadata_access_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_content_metadata_access_id = encodeParam(content_metadata_access_id)
-        return this.delete<String>("/content_metadata_access/$path_content_metadata_access_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/content_metadata_access/$path_content_metadata_access_id", mapOf()
+        )
     }
 
     /**
@@ -1536,10 +1652,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         format: String? = null,
         width: Long? = null,
         height: Long? = null
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_type = encodeParam(type)
         val path_resource_id = encodeParam(resource_id)
-        return this.get<String>(
+        return this.get<String, com.looker.sdk.Error>(
             "/content_thumbnail/$path_type/$path_resource_id",
             mapOf(
                 "reload" to reload,
@@ -1562,8 +1678,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun content_validation(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ContentValidation>(
+    ): SdkResult<ContentValidation, com.looker.sdk.Error> {
+        return this.get<ContentValidation, com.looker.sdk.Error>(
             "/content_validation",
             mapOf("fields" to fields)
         )
@@ -1623,8 +1739,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         offset: Long? = null,
         sorts: String? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<Array<ContentView>>(
+    ): SdkResult<Array<ContentView>, com.looker.sdk.Error> {
+        return this.get<Array<ContentView>, com.looker.sdk.Error>(
             "/content_view/search",
             mapOf(
                 "view_count" to view_count,
@@ -1662,10 +1778,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         type: String,
         resource_id: String,
         reload: String? = null
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_type = encodeParam(type)
         val path_resource_id = encodeParam(resource_id)
-        return this.get<String>(
+        return this.get<String, com.looker.sdk.Error>(
             "/vector_thumbnail/$path_type/$path_resource_id",
             mapOf("reload" to reload)
         )
@@ -1690,8 +1806,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_dashboards(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<DashboardBase>>(
+    ): SdkResult<Array<DashboardBase>, com.looker.sdk.Error> {
+        return this.get<Array<DashboardBase>, com.looker.sdk.Error>(
             "/dashboards",
             mapOf("fields" to fields)
         )
@@ -1719,8 +1835,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_dashboard(
         body: WriteDashboard
-    ): SDKResponse {
-        return this.post<Dashboard>("/dashboards", mapOf(), body)
+    ): SdkResult<Dashboard, com.looker.sdk.Error> {
+        return this.post<Dashboard, com.looker.sdk.Error>(
+            "/dashboards", mapOf(), body
+        )
     }
 
     /**
@@ -1796,8 +1914,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         offset: Long? = null,
         sorts: String? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<Array<Dashboard>>(
+    ): SdkResult<Array<Dashboard>, com.looker.sdk.Error> {
+        return this.get<Array<Dashboard>, com.looker.sdk.Error>(
             "/dashboards/search",
             mapOf(
                 "id" to id,
@@ -1849,10 +1967,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         space_id: String,
         body: WriteDashboard? = null,
         raw_locale: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<Dashboard, com.looker.sdk.Error> {
         val path_lookml_dashboard_id = encodeParam(lookml_dashboard_id)
         val path_space_id = encodeParam(space_id)
-        return this.post<Dashboard>(
+        return this.post<Dashboard, com.looker.sdk.Error>(
             "/dashboards/$path_lookml_dashboard_id/import/$path_space_id",
             mapOf("raw_locale" to raw_locale), body
         )
@@ -1879,9 +1997,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         lookml_dashboard_id: String,
         body: WriteDashboard,
         raw_locale: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<Array<Long>, com.looker.sdk.Error> {
         val path_lookml_dashboard_id = encodeParam(lookml_dashboard_id)
-        return this.patch<Array<Long>>(
+        return this.patch<Array<Long>, com.looker.sdk.Error>(
             "/dashboards/$path_lookml_dashboard_id/sync",
             mapOf("raw_locale" to raw_locale), body
         )
@@ -1904,9 +2022,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun dashboard(
         dashboard_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Dashboard, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
-        return this.get<Dashboard>(
+        return this.get<Dashboard, com.looker.sdk.Error>(
             "/dashboards/$path_dashboard_id",
             mapOf("fields" to fields)
         )
@@ -1932,9 +2050,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     fun update_dashboard(
         dashboard_id: String,
         body: WriteDashboard
-    ): SDKResponse {
+    ): SdkResult<Dashboard, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
-        return this.patch<Dashboard>("/dashboards/$path_dashboard_id", mapOf(), body)
+        return this.patch<Dashboard, com.looker.sdk.Error>(
+            "/dashboards/$path_dashboard_id", mapOf(), body
+        )
     }
 
     /**
@@ -1952,9 +2072,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_dashboard(
         dashboard_id: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
-        return this.delete<String>("/dashboards/$path_dashboard_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/dashboards/$path_dashboard_id", mapOf()
+        )
     }
 
     /**
@@ -1968,9 +2090,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun dashboard_aggregate_table_lookml(
         dashboard_id: String
-    ): SDKResponse {
+    ): SdkResult<DashboardAggregateTableLookml, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
-        return this.get<DashboardAggregateTableLookml>("/dashboards/aggregate_table_lookml/$path_dashboard_id", mapOf())
+        return this.get<DashboardAggregateTableLookml, com.looker.sdk.Error>(
+            "/dashboards/aggregate_table_lookml/$path_dashboard_id", mapOf()
+        )
     }
 
     /**
@@ -1984,9 +2108,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun dashboard_lookml(
         dashboard_id: String
-    ): SDKResponse {
+    ): SdkResult<DashboardLookml, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
-        return this.get<DashboardLookml>("/dashboards/lookml/$path_dashboard_id", mapOf())
+        return this.get<DashboardLookml, com.looker.sdk.Error>(
+            "/dashboards/lookml/$path_dashboard_id", mapOf()
+        )
     }
 
     /**
@@ -2033,8 +2159,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         fields: String? = null,
         filter_or: Boolean? = null,
         sorts: String? = null
-    ): SDKResponse {
-        return this.get<Array<DashboardElement>>(
+    ): SdkResult<Array<DashboardElement>, com.looker.sdk.Error> {
+        return this.get<Array<DashboardElement>, com.looker.sdk.Error>(
             "/dashboard_elements/search",
             mapOf(
                 "dashboard_id" to dashboard_id,
@@ -2059,9 +2185,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun dashboard_element(
         dashboard_element_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<DashboardElement, com.looker.sdk.Error> {
         val path_dashboard_element_id = encodeParam(dashboard_element_id)
-        return this.get<DashboardElement>(
+        return this.get<DashboardElement, com.looker.sdk.Error>(
             "/dashboard_elements/$path_dashboard_element_id",
             mapOf("fields" to fields)
         )
@@ -2080,9 +2206,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         dashboard_element_id: String,
         body: WriteDashboardElement,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<DashboardElement, com.looker.sdk.Error> {
         val path_dashboard_element_id = encodeParam(dashboard_element_id)
-        return this.patch<DashboardElement>(
+        return this.patch<DashboardElement, com.looker.sdk.Error>(
             "/dashboard_elements/$path_dashboard_element_id",
             mapOf("fields" to fields), body
         )
@@ -2097,9 +2223,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_dashboard_element(
         dashboard_element_id: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_dashboard_element_id = encodeParam(dashboard_element_id)
-        return this.delete<String>("/dashboard_elements/$path_dashboard_element_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/dashboard_elements/$path_dashboard_element_id", mapOf()
+        )
     }
 
     /**
@@ -2113,9 +2241,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun dashboard_dashboard_elements(
         dashboard_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<DashboardElement>, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
-        return this.get<Array<DashboardElement>>(
+        return this.get<Array<DashboardElement>, com.looker.sdk.Error>(
             "/dashboards/$path_dashboard_id/dashboard_elements",
             mapOf("fields" to fields)
         )
@@ -2132,8 +2260,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_dashboard_element(
         body: WriteDashboardElement,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<DashboardElement>(
+    ): SdkResult<DashboardElement, com.looker.sdk.Error> {
+        return this.post<DashboardElement, com.looker.sdk.Error>(
             "/dashboard_elements",
             mapOf("fields" to fields), body
         )
@@ -2150,9 +2278,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun dashboard_filter(
         dashboard_filter_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<DashboardFilter, com.looker.sdk.Error> {
         val path_dashboard_filter_id = encodeParam(dashboard_filter_id)
-        return this.get<DashboardFilter>(
+        return this.get<DashboardFilter, com.looker.sdk.Error>(
             "/dashboard_filters/$path_dashboard_filter_id",
             mapOf("fields" to fields)
         )
@@ -2171,9 +2299,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         dashboard_filter_id: String,
         body: WriteDashboardFilter,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<DashboardFilter, com.looker.sdk.Error> {
         val path_dashboard_filter_id = encodeParam(dashboard_filter_id)
-        return this.patch<DashboardFilter>(
+        return this.patch<DashboardFilter, com.looker.sdk.Error>(
             "/dashboard_filters/$path_dashboard_filter_id",
             mapOf("fields" to fields), body
         )
@@ -2188,9 +2316,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_dashboard_filter(
         dashboard_filter_id: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_dashboard_filter_id = encodeParam(dashboard_filter_id)
-        return this.delete<String>("/dashboard_filters/$path_dashboard_filter_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/dashboard_filters/$path_dashboard_filter_id", mapOf()
+        )
     }
 
     /**
@@ -2204,9 +2334,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun dashboard_dashboard_filters(
         dashboard_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<DashboardFilter>, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
-        return this.get<Array<DashboardFilter>>(
+        return this.get<Array<DashboardFilter>, com.looker.sdk.Error>(
             "/dashboards/$path_dashboard_id/dashboard_filters",
             mapOf("fields" to fields)
         )
@@ -2223,8 +2353,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_dashboard_filter(
         body: WriteCreateDashboardFilter,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<DashboardFilter>(
+    ): SdkResult<DashboardFilter, com.looker.sdk.Error> {
+        return this.post<DashboardFilter, com.looker.sdk.Error>(
             "/dashboard_filters",
             mapOf("fields" to fields), body
         )
@@ -2241,9 +2371,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun dashboard_layout_component(
         dashboard_layout_component_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<DashboardLayoutComponent, com.looker.sdk.Error> {
         val path_dashboard_layout_component_id = encodeParam(dashboard_layout_component_id)
-        return this.get<DashboardLayoutComponent>(
+        return this.get<DashboardLayoutComponent, com.looker.sdk.Error>(
             "/dashboard_layout_components/$path_dashboard_layout_component_id",
             mapOf("fields" to fields)
         )
@@ -2262,9 +2392,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         dashboard_layout_component_id: String,
         body: WriteDashboardLayoutComponent,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<DashboardLayoutComponent, com.looker.sdk.Error> {
         val path_dashboard_layout_component_id = encodeParam(dashboard_layout_component_id)
-        return this.patch<DashboardLayoutComponent>(
+        return this.patch<DashboardLayoutComponent, com.looker.sdk.Error>(
             "/dashboard_layout_components/$path_dashboard_layout_component_id",
             mapOf("fields" to fields), body
         )
@@ -2281,9 +2411,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun dashboard_layout_dashboard_layout_components(
         dashboard_layout_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<DashboardLayoutComponent>, com.looker.sdk.Error> {
         val path_dashboard_layout_id = encodeParam(dashboard_layout_id)
-        return this.get<Array<DashboardLayoutComponent>>(
+        return this.get<Array<DashboardLayoutComponent>, com.looker.sdk.Error>(
             "/dashboard_layouts/$path_dashboard_layout_id/dashboard_layout_components",
             mapOf("fields" to fields)
         )
@@ -2300,9 +2430,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun dashboard_layout(
         dashboard_layout_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<DashboardLayout, com.looker.sdk.Error> {
         val path_dashboard_layout_id = encodeParam(dashboard_layout_id)
-        return this.get<DashboardLayout>(
+        return this.get<DashboardLayout, com.looker.sdk.Error>(
             "/dashboard_layouts/$path_dashboard_layout_id",
             mapOf("fields" to fields)
         )
@@ -2321,9 +2451,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         dashboard_layout_id: String,
         body: WriteDashboardLayout,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<DashboardLayout, com.looker.sdk.Error> {
         val path_dashboard_layout_id = encodeParam(dashboard_layout_id)
-        return this.patch<DashboardLayout>(
+        return this.patch<DashboardLayout, com.looker.sdk.Error>(
             "/dashboard_layouts/$path_dashboard_layout_id",
             mapOf("fields" to fields), body
         )
@@ -2338,9 +2468,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_dashboard_layout(
         dashboard_layout_id: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_dashboard_layout_id = encodeParam(dashboard_layout_id)
-        return this.delete<String>("/dashboard_layouts/$path_dashboard_layout_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/dashboard_layouts/$path_dashboard_layout_id", mapOf()
+        )
     }
 
     /**
@@ -2354,9 +2486,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun dashboard_dashboard_layouts(
         dashboard_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<DashboardLayout>, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
-        return this.get<Array<DashboardLayout>>(
+        return this.get<Array<DashboardLayout>, com.looker.sdk.Error>(
             "/dashboards/$path_dashboard_id/dashboard_layouts",
             mapOf("fields" to fields)
         )
@@ -2373,8 +2505,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_dashboard_layout(
         body: WriteDashboardLayout,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<DashboardLayout>(
+    ): SdkResult<DashboardLayout, com.looker.sdk.Error> {
+        return this.post<DashboardLayout, com.looker.sdk.Error>(
             "/dashboard_layouts",
             mapOf("fields" to fields), body
         )
@@ -2393,8 +2525,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun perform_data_action(
         body: DataActionRequest
-    ): SDKResponse {
-        return this.post<DataActionResponse>("/data_actions", mapOf(), body)
+    ): SdkResult<DataActionResponse, com.looker.sdk.Error> {
+        return this.post<DataActionResponse, com.looker.sdk.Error>(
+            "/data_actions", mapOf(), body
+        )
     }
 
     /**
@@ -2406,8 +2540,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun fetch_remote_data_action_form(
         body: Map<String, Any>
-    ): SDKResponse {
-        return this.post<DataActionForm>("/data_actions/form", mapOf(), body)
+    ): SdkResult<DataActionForm, com.looker.sdk.Error> {
+        return this.post<DataActionForm, com.looker.sdk.Error>(
+            "/data_actions/form", mapOf(), body
+        )
     }
 
     //endregion DataAction: Run Data Actions
@@ -2419,8 +2555,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /datagroups -> Array<Datagroup>
      */
-    fun all_datagroups(): SDKResponse {
-        return this.get<Array<Datagroup>>("/datagroups", mapOf())
+    fun all_datagroups(): SdkResult<Array<Datagroup>, com.looker.sdk.Error> {
+        return this.get<Array<Datagroup>, com.looker.sdk.Error>(
+            "/datagroups", mapOf()
+        )
     }
 
     /**
@@ -2432,9 +2570,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun datagroup(
         datagroup_id: String
-    ): SDKResponse {
+    ): SdkResult<Datagroup, com.looker.sdk.Error> {
         val path_datagroup_id = encodeParam(datagroup_id)
-        return this.get<Datagroup>("/datagroups/$path_datagroup_id", mapOf())
+        return this.get<Datagroup, com.looker.sdk.Error>(
+            "/datagroups/$path_datagroup_id", mapOf()
+        )
     }
 
     /**
@@ -2448,9 +2588,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     fun update_datagroup(
         datagroup_id: String,
         body: WriteDatagroup
-    ): SDKResponse {
+    ): SdkResult<Datagroup, com.looker.sdk.Error> {
         val path_datagroup_id = encodeParam(datagroup_id)
-        return this.patch<Datagroup>("/datagroups/$path_datagroup_id", mapOf(), body)
+        return this.patch<Datagroup, com.looker.sdk.Error>(
+            "/datagroups/$path_datagroup_id", mapOf(), body
+        )
     }
 
     //endregion Datagroup: Manage Datagroups
@@ -2486,8 +2628,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         parent_id: String? = null,
         creator_id: String? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<Array<Folder>>(
+    ): SdkResult<Array<Folder>, com.looker.sdk.Error> {
+        return this.get<Array<Folder>, com.looker.sdk.Error>(
             "/folders/search",
             mapOf(
                 "fields" to fields,
@@ -2516,9 +2658,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun folder(
         folder_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Folder, com.looker.sdk.Error> {
         val path_folder_id = encodeParam(folder_id)
-        return this.get<Folder>(
+        return this.get<Folder, com.looker.sdk.Error>(
             "/folders/$path_folder_id",
             mapOf("fields" to fields)
         )
@@ -2535,9 +2677,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     fun update_folder(
         folder_id: String,
         body: UpdateFolder
-    ): SDKResponse {
+    ): SdkResult<Folder, com.looker.sdk.Error> {
         val path_folder_id = encodeParam(folder_id)
-        return this.patch<Folder>("/folders/$path_folder_id", mapOf(), body)
+        return this.patch<Folder, com.looker.sdk.Error>(
+            "/folders/$path_folder_id", mapOf(), body
+        )
     }
 
     /**
@@ -2550,9 +2694,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_folder(
         folder_id: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_folder_id = encodeParam(folder_id)
-        return this.delete<String>("/folders/$path_folder_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/folders/$path_folder_id", mapOf()
+        )
     }
 
     /**
@@ -2564,8 +2710,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_folders(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<Folder>>(
+    ): SdkResult<Array<Folder>, com.looker.sdk.Error> {
+        return this.get<Array<Folder>, com.looker.sdk.Error>(
             "/folders",
             mapOf("fields" to fields)
         )
@@ -2583,8 +2729,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_folder(
         body: CreateFolder
-    ): SDKResponse {
-        return this.post<Folder>("/folders", mapOf(), body)
+    ): SdkResult<Folder, com.looker.sdk.Error> {
+        return this.post<Folder, com.looker.sdk.Error>(
+            "/folders", mapOf(), body
+        )
     }
 
     /**
@@ -2604,9 +2752,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         page: Long? = null,
         per_page: Long? = null,
         sorts: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<Folder>, com.looker.sdk.Error> {
         val path_folder_id = encodeParam(folder_id)
-        return this.get<Array<Folder>>(
+        return this.get<Array<Folder>, com.looker.sdk.Error>(
             "/folders/$path_folder_id/children",
             mapOf(
                 "fields" to fields,
@@ -2632,9 +2780,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         fields: String? = null,
         sorts: String? = null,
         name: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<Folder>, com.looker.sdk.Error> {
         val path_folder_id = encodeParam(folder_id)
-        return this.get<Array<Folder>>(
+        return this.get<Array<Folder>, com.looker.sdk.Error>(
             "/folders/$path_folder_id/children/search",
             mapOf(
                 "fields" to fields,
@@ -2655,9 +2803,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun folder_parent(
         folder_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Folder, com.looker.sdk.Error> {
         val path_folder_id = encodeParam(folder_id)
-        return this.get<Folder>(
+        return this.get<Folder, com.looker.sdk.Error>(
             "/folders/$path_folder_id/parent",
             mapOf("fields" to fields)
         )
@@ -2674,9 +2822,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun folder_ancestors(
         folder_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<Folder>, com.looker.sdk.Error> {
         val path_folder_id = encodeParam(folder_id)
-        return this.get<Array<Folder>>(
+        return this.get<Array<Folder>, com.looker.sdk.Error>(
             "/folders/$path_folder_id/ancestors",
             mapOf("fields" to fields)
         )
@@ -2693,9 +2841,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun folder_looks(
         folder_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<LookWithQuery>, com.looker.sdk.Error> {
         val path_folder_id = encodeParam(folder_id)
-        return this.get<Array<LookWithQuery>>(
+        return this.get<Array<LookWithQuery>, com.looker.sdk.Error>(
             "/folders/$path_folder_id/looks",
             mapOf("fields" to fields)
         )
@@ -2712,9 +2860,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun folder_dashboards(
         folder_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<Dashboard>, com.looker.sdk.Error> {
         val path_folder_id = encodeParam(folder_id)
-        return this.get<Array<Dashboard>>(
+        return this.get<Array<Dashboard>, com.looker.sdk.Error>(
             "/folders/$path_folder_id/dashboards",
             mapOf("fields" to fields)
         )
@@ -2745,8 +2893,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         ids: DelimArray<Long>? = null,
         content_metadata_id: Long? = null,
         can_add_to_content_metadata: Boolean? = null
-    ): SDKResponse {
-        return this.get<Array<Group>>(
+    ): SdkResult<Array<Group>, com.looker.sdk.Error> {
+        return this.get<Array<Group>, com.looker.sdk.Error>(
             "/groups",
             mapOf(
                 "fields" to fields,
@@ -2771,8 +2919,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_group(
         body: WriteGroup,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<Group>(
+    ): SdkResult<Group, com.looker.sdk.Error> {
+        return this.post<Group, com.looker.sdk.Error>(
             "/groups",
             mapOf("fields" to fields), body
         )
@@ -2828,8 +2976,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         external_group_id: String? = null,
         externally_managed: Boolean? = null,
         externally_orphaned: Boolean? = null
-    ): SDKResponse {
-        return this.get<Array<Group>>(
+    ): SdkResult<Array<Group>, com.looker.sdk.Error> {
+        return this.get<Array<Group>, com.looker.sdk.Error>(
             "/groups/search",
             mapOf(
                 "fields" to fields,
@@ -2857,9 +3005,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun group(
         group_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Group, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
-        return this.get<Group>(
+        return this.get<Group, com.looker.sdk.Error>(
             "/groups/$path_group_id",
             mapOf("fields" to fields)
         )
@@ -2878,9 +3026,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         group_id: Long,
         body: WriteGroup,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Group, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
-        return this.patch<Group>(
+        return this.patch<Group, com.looker.sdk.Error>(
             "/groups/$path_group_id",
             mapOf("fields" to fields), body
         )
@@ -2895,9 +3043,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_group(
         group_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
-        return this.delete<String>("/groups/$path_group_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/groups/$path_group_id", mapOf()
+        )
     }
 
     /**
@@ -2911,9 +3061,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_group_groups(
         group_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<Group>, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
-        return this.get<Array<Group>>(
+        return this.get<Array<Group>, com.looker.sdk.Error>(
             "/groups/$path_group_id/groups",
             mapOf("fields" to fields)
         )
@@ -2930,9 +3080,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     fun add_group_group(
         group_id: Long,
         body: GroupIdForGroupInclusion
-    ): SDKResponse {
+    ): SdkResult<Group, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
-        return this.post<Group>("/groups/$path_group_id/groups", mapOf(), body)
+        return this.post<Group, com.looker.sdk.Error>(
+            "/groups/$path_group_id/groups", mapOf(), body
+        )
     }
 
     /**
@@ -2952,9 +3104,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         page: Long? = null,
         per_page: Long? = null,
         sorts: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<User>, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
-        return this.get<Array<User>>(
+        return this.get<Array<User>, com.looker.sdk.Error>(
             "/groups/$path_group_id/users",
             mapOf(
                 "fields" to fields,
@@ -2976,9 +3128,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     fun add_group_user(
         group_id: Long,
         body: GroupIdForGroupUserInclusion
-    ): SDKResponse {
+    ): SdkResult<User, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
-        return this.post<User>("/groups/$path_group_id/users", mapOf(), body)
+        return this.post<User, com.looker.sdk.Error>(
+            "/groups/$path_group_id/users", mapOf(), body
+        )
     }
 
     /**
@@ -2992,10 +3146,12 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     fun delete_group_user(
         group_id: Long,
         user_id: Long
-    ): SDKResponse {
+    ): SdkResult<Void, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
         val path_user_id = encodeParam(user_id)
-        return this.delete<Void>("/groups/$path_group_id/users/$path_user_id", mapOf())
+        return this.delete<Void, com.looker.sdk.Error>(
+            "/groups/$path_group_id/users/$path_user_id", mapOf()
+        )
     }
 
     /**
@@ -3009,10 +3165,12 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     fun delete_group_from_group(
         group_id: Long,
         deleting_group_id: Long
-    ): SDKResponse {
+    ): SdkResult<Void, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
         val path_deleting_group_id = encodeParam(deleting_group_id)
-        return this.delete<Void>("/groups/$path_group_id/groups/$path_deleting_group_id", mapOf())
+        return this.delete<Void, com.looker.sdk.Error>(
+            "/groups/$path_group_id/groups/$path_deleting_group_id", mapOf()
+        )
     }
 
     /**
@@ -3030,10 +3188,12 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         group_id: Long,
         user_attribute_id: Long,
         body: UserAttributeGroupValue
-    ): SDKResponse {
+    ): SdkResult<UserAttributeGroupValue, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
         val path_user_attribute_id = encodeParam(user_attribute_id)
-        return this.patch<UserAttributeGroupValue>("/groups/$path_group_id/attribute_values/$path_user_attribute_id", mapOf(), body)
+        return this.patch<UserAttributeGroupValue, com.looker.sdk.Error>(
+            "/groups/$path_group_id/attribute_values/$path_user_attribute_id", mapOf(), body
+        )
     }
 
     /**
@@ -3047,10 +3207,12 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     fun delete_user_attribute_group_value(
         group_id: Long,
         user_attribute_id: Long
-    ): SDKResponse {
+    ): SdkResult<Void, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
         val path_user_attribute_id = encodeParam(user_attribute_id)
-        return this.delete<Void>("/groups/$path_group_id/attribute_values/$path_user_attribute_id", mapOf())
+        return this.delete<Void, com.looker.sdk.Error>(
+            "/groups/$path_group_id/attribute_values/$path_user_attribute_id", mapOf()
+        )
     }
 
     //endregion Group: Manage Groups
@@ -3066,8 +3228,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_homepages(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<Homepage>>(
+    ): SdkResult<Array<Homepage>, com.looker.sdk.Error> {
+        return this.get<Array<Homepage>, com.looker.sdk.Error>(
             "/homepages",
             mapOf("fields" to fields)
         )
@@ -3084,8 +3246,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_homepage(
         body: WriteHomepage,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<Homepage>(
+    ): SdkResult<Homepage, com.looker.sdk.Error> {
+        return this.post<Homepage, com.looker.sdk.Error>(
             "/homepages",
             mapOf("fields" to fields), body
         )
@@ -3145,8 +3307,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         limit: Long? = null,
         sorts: String? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<Array<Homepage>>(
+    ): SdkResult<Array<Homepage>, com.looker.sdk.Error> {
+        return this.get<Array<Homepage>, com.looker.sdk.Error>(
             "/homepages/search",
             mapOf(
                 "title" to title,
@@ -3177,9 +3339,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun homepage(
         homepage_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Homepage, com.looker.sdk.Error> {
         val path_homepage_id = encodeParam(homepage_id)
-        return this.get<Homepage>(
+        return this.get<Homepage, com.looker.sdk.Error>(
             "/homepages/$path_homepage_id",
             mapOf("fields" to fields)
         )
@@ -3198,9 +3360,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         homepage_id: Long,
         body: WriteHomepage,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Homepage, com.looker.sdk.Error> {
         val path_homepage_id = encodeParam(homepage_id)
-        return this.patch<Homepage>(
+        return this.patch<Homepage, com.looker.sdk.Error>(
             "/homepages/$path_homepage_id",
             mapOf("fields" to fields), body
         )
@@ -3215,9 +3377,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_homepage(
         homepage_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_homepage_id = encodeParam(homepage_id)
-        return this.delete<String>("/homepages/$path_homepage_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/homepages/$path_homepage_id", mapOf()
+        )
     }
 
     /**
@@ -3233,8 +3397,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         fields: String? = null,
         sorts: String? = null,
         homepage_section_id: String? = null
-    ): SDKResponse {
-        return this.get<Array<HomepageItem>>(
+    ): SdkResult<Array<HomepageItem>, com.looker.sdk.Error> {
+        return this.get<Array<HomepageItem>, com.looker.sdk.Error>(
             "/homepage_items",
             mapOf(
                 "fields" to fields,
@@ -3255,8 +3419,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_homepage_item(
         body: WriteHomepageItem,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<HomepageItem>(
+    ): SdkResult<HomepageItem, com.looker.sdk.Error> {
+        return this.post<HomepageItem, com.looker.sdk.Error>(
             "/homepage_items",
             mapOf("fields" to fields), body
         )
@@ -3273,9 +3437,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun homepage_item(
         homepage_item_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<HomepageItem, com.looker.sdk.Error> {
         val path_homepage_item_id = encodeParam(homepage_item_id)
-        return this.get<HomepageItem>(
+        return this.get<HomepageItem, com.looker.sdk.Error>(
             "/homepage_items/$path_homepage_item_id",
             mapOf("fields" to fields)
         )
@@ -3294,9 +3458,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         homepage_item_id: Long,
         body: WriteHomepageItem,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<HomepageItem, com.looker.sdk.Error> {
         val path_homepage_item_id = encodeParam(homepage_item_id)
-        return this.patch<HomepageItem>(
+        return this.patch<HomepageItem, com.looker.sdk.Error>(
             "/homepage_items/$path_homepage_item_id",
             mapOf("fields" to fields), body
         )
@@ -3311,9 +3475,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_homepage_item(
         homepage_item_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_homepage_item_id = encodeParam(homepage_item_id)
-        return this.delete<String>("/homepage_items/$path_homepage_item_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/homepage_items/$path_homepage_item_id", mapOf()
+        )
     }
 
     /**
@@ -3327,8 +3493,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_homepage_sections(
         fields: String? = null,
         sorts: String? = null
-    ): SDKResponse {
-        return this.get<Array<HomepageSection>>(
+    ): SdkResult<Array<HomepageSection>, com.looker.sdk.Error> {
+        return this.get<Array<HomepageSection>, com.looker.sdk.Error>(
             "/homepage_sections",
             mapOf(
                 "fields" to fields,
@@ -3348,8 +3514,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_homepage_section(
         body: WriteHomepageSection,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<HomepageSection>(
+    ): SdkResult<HomepageSection, com.looker.sdk.Error> {
+        return this.post<HomepageSection, com.looker.sdk.Error>(
             "/homepage_sections",
             mapOf("fields" to fields), body
         )
@@ -3366,9 +3532,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun homepage_section(
         homepage_section_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<HomepageSection, com.looker.sdk.Error> {
         val path_homepage_section_id = encodeParam(homepage_section_id)
-        return this.get<HomepageSection>(
+        return this.get<HomepageSection, com.looker.sdk.Error>(
             "/homepage_sections/$path_homepage_section_id",
             mapOf("fields" to fields)
         )
@@ -3387,9 +3553,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         homepage_section_id: Long,
         body: WriteHomepageSection,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<HomepageSection, com.looker.sdk.Error> {
         val path_homepage_section_id = encodeParam(homepage_section_id)
-        return this.patch<HomepageSection>(
+        return this.patch<HomepageSection, com.looker.sdk.Error>(
             "/homepage_sections/$path_homepage_section_id",
             mapOf("fields" to fields), body
         )
@@ -3404,9 +3570,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_homepage_section(
         homepage_section_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_homepage_section_id = encodeParam(homepage_section_id)
-        return this.delete<String>("/homepage_sections/$path_homepage_section_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/homepage_sections/$path_homepage_section_id", mapOf()
+        )
     }
 
     /**
@@ -3418,8 +3586,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_primary_homepage_sections(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<HomepageSection>>(
+    ): SdkResult<Array<HomepageSection>, com.looker.sdk.Error> {
+        return this.get<Array<HomepageSection>, com.looker.sdk.Error>(
             "/primary_homepage_sections",
             mapOf("fields" to fields)
         )
@@ -3438,8 +3606,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_integration_hubs(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<IntegrationHub>>(
+    ): SdkResult<Array<IntegrationHub>, com.looker.sdk.Error> {
+        return this.get<Array<IntegrationHub>, com.looker.sdk.Error>(
             "/integration_hubs",
             mapOf("fields" to fields)
         )
@@ -3458,8 +3626,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_integration_hub(
         body: WriteIntegrationHub,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<IntegrationHub>(
+    ): SdkResult<IntegrationHub, com.looker.sdk.Error> {
+        return this.post<IntegrationHub, com.looker.sdk.Error>(
             "/integration_hubs",
             mapOf("fields" to fields), body
         )
@@ -3476,9 +3644,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun integration_hub(
         integration_hub_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<IntegrationHub, com.looker.sdk.Error> {
         val path_integration_hub_id = encodeParam(integration_hub_id)
-        return this.get<IntegrationHub>(
+        return this.get<IntegrationHub, com.looker.sdk.Error>(
             "/integration_hubs/$path_integration_hub_id",
             mapOf("fields" to fields)
         )
@@ -3499,9 +3667,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         integration_hub_id: Long,
         body: WriteIntegrationHub,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<IntegrationHub, com.looker.sdk.Error> {
         val path_integration_hub_id = encodeParam(integration_hub_id)
-        return this.patch<IntegrationHub>(
+        return this.patch<IntegrationHub, com.looker.sdk.Error>(
             "/integration_hubs/$path_integration_hub_id",
             mapOf("fields" to fields), body
         )
@@ -3516,9 +3684,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_integration_hub(
         integration_hub_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_integration_hub_id = encodeParam(integration_hub_id)
-        return this.delete<String>("/integration_hubs/$path_integration_hub_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/integration_hubs/$path_integration_hub_id", mapOf()
+        )
     }
 
     /**
@@ -3530,9 +3700,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun accept_integration_hub_legal_agreement(
         integration_hub_id: Long
-    ): SDKResponse {
+    ): SdkResult<IntegrationHub, com.looker.sdk.Error> {
         val path_integration_hub_id = encodeParam(integration_hub_id)
-        return this.post<IntegrationHub>("/integration_hubs/$path_integration_hub_id/accept_legal_agreement", mapOf())
+        return this.post<IntegrationHub, com.looker.sdk.Error>(
+            "/integration_hubs/$path_integration_hub_id/accept_legal_agreement", mapOf()
+        )
     }
 
     /**
@@ -3546,8 +3718,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_integrations(
         fields: String? = null,
         integration_hub_id: String? = null
-    ): SDKResponse {
-        return this.get<Array<Integration>>(
+    ): SdkResult<Array<Integration>, com.looker.sdk.Error> {
+        return this.get<Array<Integration>, com.looker.sdk.Error>(
             "/integrations",
             mapOf(
                 "fields" to fields,
@@ -3567,9 +3739,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun integration(
         integration_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Integration, com.looker.sdk.Error> {
         val path_integration_id = encodeParam(integration_id)
-        return this.get<Integration>(
+        return this.get<Integration, com.looker.sdk.Error>(
             "/integrations/$path_integration_id",
             mapOf("fields" to fields)
         )
@@ -3588,9 +3760,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         integration_id: String,
         body: WriteIntegration,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Integration, com.looker.sdk.Error> {
         val path_integration_id = encodeParam(integration_id)
-        return this.patch<Integration>(
+        return this.patch<Integration, com.looker.sdk.Error>(
             "/integrations/$path_integration_id",
             mapOf("fields" to fields), body
         )
@@ -3607,9 +3779,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun fetch_integration_form(
         integration_id: String,
         body: Map<String, Any>? = null
-    ): SDKResponse {
+    ): SdkResult<DataActionForm, com.looker.sdk.Error> {
         val path_integration_id = encodeParam(integration_id)
-        return this.post<DataActionForm>("/integrations/$path_integration_id/form", mapOf(), body)
+        return this.post<DataActionForm, com.looker.sdk.Error>(
+            "/integrations/$path_integration_id/form", mapOf(), body
+        )
     }
 
     /**
@@ -3621,9 +3795,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun test_integration(
         integration_id: String
-    ): SDKResponse {
+    ): SdkResult<IntegrationTestResult, com.looker.sdk.Error> {
         val path_integration_id = encodeParam(integration_id)
-        return this.post<IntegrationTestResult>("/integrations/$path_integration_id/test", mapOf())
+        return this.post<IntegrationTestResult, com.looker.sdk.Error>(
+            "/integrations/$path_integration_id/test", mapOf()
+        )
     }
 
     //endregion Integration: Manage Integrations
@@ -3645,8 +3821,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_looks(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<Look>>(
+    ): SdkResult<Array<Look>, com.looker.sdk.Error> {
+        return this.get<Array<Look>, com.looker.sdk.Error>(
             "/looks",
             mapOf("fields" to fields)
         )
@@ -3669,8 +3845,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_look(
         body: WriteLookWithQuery,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<LookWithQuery>(
+    ): SdkResult<LookWithQuery, com.looker.sdk.Error> {
+        return this.post<LookWithQuery, com.looker.sdk.Error>(
             "/looks",
             mapOf("fields" to fields), body
         )
@@ -3743,8 +3919,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         offset: Long? = null,
         sorts: String? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<Array<Look>>(
+    ): SdkResult<Array<Look>, com.looker.sdk.Error> {
+        return this.get<Array<Look>, com.looker.sdk.Error>(
             "/looks/search",
             mapOf(
                 "id" to id,
@@ -3781,9 +3957,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun look(
         look_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<LookWithQuery, com.looker.sdk.Error> {
         val path_look_id = encodeParam(look_id)
-        return this.get<LookWithQuery>(
+        return this.get<LookWithQuery, com.looker.sdk.Error>(
             "/looks/$path_look_id",
             mapOf("fields" to fields)
         )
@@ -3821,9 +3997,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         look_id: Long,
         body: WriteLookWithQuery,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<LookWithQuery, com.looker.sdk.Error> {
         val path_look_id = encodeParam(look_id)
-        return this.patch<LookWithQuery>(
+        return this.patch<LookWithQuery, com.looker.sdk.Error>(
             "/looks/$path_look_id",
             mapOf("fields" to fields), body
         )
@@ -3844,9 +4020,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_look(
         look_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_look_id = encodeParam(look_id)
-        return this.delete<String>("/looks/$path_look_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/looks/$path_look_id", mapOf()
+        )
     }
 
     /**
@@ -3903,10 +4081,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         path_prefix: String? = null,
         rebuild_pdts: Boolean? = null,
         server_table_calcs: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_look_id = encodeParam(look_id)
         val path_result_format = encodeParam(result_format)
-        return this.get<String>(
+        return this.get<String, com.looker.sdk.Error>(
             "/looks/$path_look_id/run/$path_result_format",
             mapOf(
                 "limit" to limit,
@@ -3938,8 +4116,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_lookml_models(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<LookmlModel>>(
+    ): SdkResult<Array<LookmlModel>, com.looker.sdk.Error> {
+        return this.get<Array<LookmlModel>, com.looker.sdk.Error>(
             "/lookml_models",
             mapOf("fields" to fields)
         )
@@ -3954,8 +4132,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_lookml_model(
         body: WriteLookmlModel
-    ): SDKResponse {
-        return this.post<LookmlModel>("/lookml_models", mapOf(), body)
+    ): SdkResult<LookmlModel, com.looker.sdk.Error> {
+        return this.post<LookmlModel, com.looker.sdk.Error>(
+            "/lookml_models", mapOf(), body
+        )
     }
 
     /**
@@ -3969,9 +4149,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun lookml_model(
         lookml_model_name: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<LookmlModel, com.looker.sdk.Error> {
         val path_lookml_model_name = encodeParam(lookml_model_name)
-        return this.get<LookmlModel>(
+        return this.get<LookmlModel, com.looker.sdk.Error>(
             "/lookml_models/$path_lookml_model_name",
             mapOf("fields" to fields)
         )
@@ -3988,9 +4168,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     fun update_lookml_model(
         lookml_model_name: String,
         body: WriteLookmlModel
-    ): SDKResponse {
+    ): SdkResult<LookmlModel, com.looker.sdk.Error> {
         val path_lookml_model_name = encodeParam(lookml_model_name)
-        return this.patch<LookmlModel>("/lookml_models/$path_lookml_model_name", mapOf(), body)
+        return this.patch<LookmlModel, com.looker.sdk.Error>(
+            "/lookml_models/$path_lookml_model_name", mapOf(), body
+        )
     }
 
     /**
@@ -4002,9 +4184,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_lookml_model(
         lookml_model_name: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_lookml_model_name = encodeParam(lookml_model_name)
-        return this.delete<String>("/lookml_models/$path_lookml_model_name", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/lookml_models/$path_lookml_model_name", mapOf()
+        )
     }
 
     /**
@@ -4020,10 +4204,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         lookml_model_name: String,
         explore_name: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<LookmlModelExplore, com.looker.sdk.Error> {
         val path_lookml_model_name = encodeParam(lookml_model_name)
         val path_explore_name = encodeParam(explore_name)
-        return this.get<LookmlModelExplore>(
+        return this.get<LookmlModelExplore, com.looker.sdk.Error>(
             "/lookml_models/$path_lookml_model_name/explores/$path_explore_name",
             mapOf("fields" to fields)
         )
@@ -4044,9 +4228,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun all_git_branches(
         project_id: String
-    ): SDKResponse {
+    ): SdkResult<Array<GitBranch>, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<Array<GitBranch>>("/projects/$path_project_id/git_branches", mapOf())
+        return this.get<Array<GitBranch>, com.looker.sdk.Error>(
+            "/projects/$path_project_id/git_branches", mapOf()
+        )
     }
 
     /**
@@ -4060,9 +4246,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun git_branch(
         project_id: String
-    ): SDKResponse {
+    ): SdkResult<GitBranch, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<GitBranch>("/projects/$path_project_id/git_branch", mapOf())
+        return this.get<GitBranch, com.looker.sdk.Error>(
+            "/projects/$path_project_id/git_branch", mapOf()
+        )
     }
 
     /**
@@ -4084,9 +4272,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     fun update_git_branch(
         project_id: String,
         body: WriteGitBranch
-    ): SDKResponse {
+    ): SdkResult<GitBranch, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.put<GitBranch>("/projects/$path_project_id/git_branch", mapOf(), body)
+        return this.put<GitBranch, com.looker.sdk.Error>(
+            "/projects/$path_project_id/git_branch", mapOf(), body
+        )
     }
 
     /**
@@ -4107,9 +4297,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     fun create_git_branch(
         project_id: String,
         body: WriteGitBranch
-    ): SDKResponse {
+    ): SdkResult<GitBranch, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.post<GitBranch>("/projects/$path_project_id/git_branch", mapOf(), body)
+        return this.post<GitBranch, com.looker.sdk.Error>(
+            "/projects/$path_project_id/git_branch", mapOf(), body
+        )
     }
 
     /**
@@ -4125,10 +4317,12 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     fun find_git_branch(
         project_id: String,
         branch_name: String
-    ): SDKResponse {
+    ): SdkResult<GitBranch, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
         val path_branch_name = encodeParam(branch_name)
-        return this.get<GitBranch>("/projects/$path_project_id/git_branch/$path_branch_name", mapOf())
+        return this.get<GitBranch, com.looker.sdk.Error>(
+            "/projects/$path_project_id/git_branch/$path_branch_name", mapOf()
+        )
     }
 
     /**
@@ -4144,10 +4338,12 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     fun delete_git_branch(
         project_id: String,
         branch_name: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
         val path_branch_name = encodeParam(branch_name)
-        return this.delete<String>("/projects/$path_project_id/git_branch/$path_branch_name", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/projects/$path_project_id/git_branch/$path_branch_name", mapOf()
+        )
     }
 
     /**
@@ -4171,9 +4367,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         project_id: String,
         branch: String? = null,
         ref: String? = null
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.post<String>(
+        return this.post<String, com.looker.sdk.Error>(
             "/projects/$path_project_id/deploy_ref_to_production",
             mapOf(
                 "branch" to branch,
@@ -4202,9 +4398,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun deploy_to_production(
         project_id: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.post<String>("/projects/$path_project_id/deploy_to_production", mapOf())
+        return this.post<String, com.looker.sdk.Error>(
+            "/projects/$path_project_id/deploy_to_production", mapOf()
+        )
     }
 
     /**
@@ -4218,9 +4416,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun reset_project_to_production(
         project_id: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.post<String>("/projects/$path_project_id/reset_to_production", mapOf())
+        return this.post<String, com.looker.sdk.Error>(
+            "/projects/$path_project_id/reset_to_production", mapOf()
+        )
     }
 
     /**
@@ -4234,9 +4434,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun reset_project_to_remote(
         project_id: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.post<String>("/projects/$path_project_id/reset_to_remote", mapOf())
+        return this.post<String, com.looker.sdk.Error>(
+            "/projects/$path_project_id/reset_to_remote", mapOf()
+        )
     }
 
     /**
@@ -4250,8 +4452,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_projects(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<Project>>(
+    ): SdkResult<Array<Project>, com.looker.sdk.Error> {
+        return this.get<Array<Project>, com.looker.sdk.Error>(
             "/projects",
             mapOf("fields" to fields)
         )
@@ -4272,8 +4474,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_project(
         body: WriteProject
-    ): SDKResponse {
-        return this.post<Project>("/projects", mapOf(), body)
+    ): SdkResult<Project, com.looker.sdk.Error> {
+        return this.post<Project, com.looker.sdk.Error>(
+            "/projects", mapOf(), body
+        )
     }
 
     /**
@@ -4289,9 +4493,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun project(
         project_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Project, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<Project>(
+        return this.get<Project, com.looker.sdk.Error>(
             "/projects/$path_project_id",
             mapOf("fields" to fields)
         )
@@ -4331,9 +4535,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         project_id: String,
         body: WriteProject,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Project, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.patch<Project>(
+        return this.patch<Project, com.looker.sdk.Error>(
             "/projects/$path_project_id",
             mapOf("fields" to fields), body
         )
@@ -4350,9 +4554,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun manifest(
         project_id: String
-    ): SDKResponse {
+    ): SdkResult<Manifest, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<Manifest>("/projects/$path_project_id/manifest", mapOf())
+        return this.get<Manifest, com.looker.sdk.Error>(
+            "/projects/$path_project_id/manifest", mapOf()
+        )
     }
 
     /**
@@ -4366,9 +4572,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun git_deploy_key(
         project_id: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<String>("/projects/$path_project_id/git/deploy_key", mapOf())
+        return this.get<String, com.looker.sdk.Error>(
+            "/projects/$path_project_id/git/deploy_key", mapOf()
+        )
     }
 
     /**
@@ -4388,9 +4596,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_git_deploy_key(
         project_id: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.post<String>("/projects/$path_project_id/git/deploy_key", mapOf())
+        return this.post<String, com.looker.sdk.Error>(
+            "/projects/$path_project_id/git/deploy_key", mapOf()
+        )
     }
 
     /**
@@ -4415,9 +4625,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun project_validation_results(
         project_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ProjectValidationCache, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<ProjectValidationCache>(
+        return this.get<ProjectValidationCache, com.looker.sdk.Error>(
             "/projects/$path_project_id/validate",
             mapOf("fields" to fields)
         )
@@ -4442,9 +4652,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun validate_project(
         project_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ProjectValidation, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.post<ProjectValidation>(
+        return this.post<ProjectValidation, com.looker.sdk.Error>(
             "/projects/$path_project_id/validate",
             mapOf("fields" to fields)
         )
@@ -4463,9 +4673,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun project_workspace(
         project_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ProjectWorkspace, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<ProjectWorkspace>(
+        return this.get<ProjectWorkspace, com.looker.sdk.Error>(
             "/projects/$path_project_id/current_workspace",
             mapOf("fields" to fields)
         )
@@ -4484,9 +4694,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_project_files(
         project_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<ProjectFile>, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<Array<ProjectFile>>(
+        return this.get<Array<ProjectFile>, com.looker.sdk.Error>(
             "/projects/$path_project_id/files",
             mapOf("fields" to fields)
         )
@@ -4507,9 +4717,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         project_id: String,
         file_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ProjectFile, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<ProjectFile>(
+        return this.get<ProjectFile, com.looker.sdk.Error>(
             "/projects/$path_project_id/files/file",
             mapOf(
                 "file_id" to file_id,
@@ -4538,9 +4748,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_git_connection_tests(
         project_id: String,
         remote_url: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<GitConnectionTest>, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<Array<GitConnectionTest>>(
+        return this.get<Array<GitConnectionTest>, com.looker.sdk.Error>(
             "/projects/$path_project_id/git_connection_tests",
             mapOf("remote_url" to remote_url)
         )
@@ -4565,10 +4775,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         project_id: String,
         test_id: String,
         remote_url: String? = null
-    ): SDKResponse {
+    ): SdkResult<GitConnectionTestResult, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
         val path_test_id = encodeParam(test_id)
-        return this.get<GitConnectionTestResult>(
+        return this.get<GitConnectionTestResult, com.looker.sdk.Error>(
             "/projects/$path_project_id/git_connection_tests/$path_test_id",
             mapOf("remote_url" to remote_url)
         )
@@ -4589,9 +4799,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_lookml_tests(
         project_id: String,
         file_id: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<LookmlTest>, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<Array<LookmlTest>>(
+        return this.get<Array<LookmlTest>, com.looker.sdk.Error>(
             "/projects/$path_project_id/lookml_tests",
             mapOf("file_id" to file_id)
         )
@@ -4614,9 +4824,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         file_id: String? = null,
         test: String? = null,
         model: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<LookmlTestResult>, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<Array<LookmlTestResult>>(
+        return this.get<Array<LookmlTestResult>, com.looker.sdk.Error>(
             "/projects/$path_project_id/lookml_tests/run",
             mapOf(
                 "file_id" to file_id,
@@ -4644,10 +4854,12 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         root_project_id: String,
         credential_id: String,
         body: WriteRepositoryCredential
-    ): SDKResponse {
+    ): SdkResult<RepositoryCredential, com.looker.sdk.Error> {
         val path_root_project_id = encodeParam(root_project_id)
         val path_credential_id = encodeParam(credential_id)
-        return this.put<RepositoryCredential>("/projects/$path_root_project_id/credential/$path_credential_id", mapOf(), body)
+        return this.put<RepositoryCredential, com.looker.sdk.Error>(
+            "/projects/$path_root_project_id/credential/$path_credential_id", mapOf(), body
+        )
     }
 
     /**
@@ -4666,10 +4878,12 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     fun delete_repository_credential(
         root_project_id: String,
         credential_id: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_root_project_id = encodeParam(root_project_id)
         val path_credential_id = encodeParam(credential_id)
-        return this.delete<String>("/projects/$path_root_project_id/credential/$path_credential_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/projects/$path_root_project_id/credential/$path_credential_id", mapOf()
+        )
     }
 
     /**
@@ -4683,9 +4897,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun get_all_repository_credentials(
         root_project_id: String
-    ): SDKResponse {
+    ): SdkResult<Array<RepositoryCredential>, com.looker.sdk.Error> {
         val path_root_project_id = encodeParam(root_project_id)
-        return this.get<Array<RepositoryCredential>>("/projects/$path_root_project_id/credentials", mapOf())
+        return this.get<Array<RepositoryCredential>, com.looker.sdk.Error>(
+            "/projects/$path_root_project_id/credentials", mapOf()
+        )
     }
 
     //endregion Project: Manage Projects
@@ -4732,8 +4948,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         rebuild_pdts: Boolean? = null,
         server_table_calcs: Boolean? = null,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<QueryTask>(
+    ): SdkResult<QueryTask, com.looker.sdk.Error> {
+        return this.post<QueryTask, com.looker.sdk.Error>(
             "/query_tasks",
             mapOf(
                 "limit" to limit,
@@ -4769,8 +4985,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun query_task_multi_results(
         query_task_ids: DelimArray<String>
-    ): SDKResponse {
-        return this.get<Map<String, Any>>(
+    ): SdkResult<Map<String, Any>, com.looker.sdk.Error> {
+        return this.get<Map<String, Any>, com.looker.sdk.Error>(
             "/query_tasks/multi_results",
             mapOf("query_task_ids" to query_task_ids)
         )
@@ -4793,9 +5009,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun query_task(
         query_task_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<QueryTask, com.looker.sdk.Error> {
         val path_query_task_id = encodeParam(query_task_id)
-        return this.get<QueryTask>(
+        return this.get<QueryTask, com.looker.sdk.Error>(
             "/query_tasks/$path_query_task_id",
             mapOf("fields" to fields)
         )
@@ -4832,9 +5048,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun query_task_results(
         query_task_id: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_query_task_id = encodeParam(query_task_id)
-        return this.get<String>("/query_tasks/$path_query_task_id/results", mapOf())
+        return this.get<String, com.looker.sdk.Error>(
+            "/query_tasks/$path_query_task_id/results", mapOf()
+        )
     }
 
     /**
@@ -4864,9 +5082,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun query(
         query_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Query, com.looker.sdk.Error> {
         val path_query_id = encodeParam(query_id)
-        return this.get<Query>(
+        return this.get<Query, com.looker.sdk.Error>(
             "/queries/$path_query_id",
             mapOf("fields" to fields)
         )
@@ -4899,9 +5117,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun query_for_slug(
         slug: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Query, com.looker.sdk.Error> {
         val path_slug = encodeParam(slug)
-        return this.get<Query>(
+        return this.get<Query, com.looker.sdk.Error>(
             "/queries/slug/$path_slug",
             mapOf("fields" to fields)
         )
@@ -4925,8 +5143,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_query(
         body: WriteQuery,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<Query>(
+    ): SdkResult<Query, com.looker.sdk.Error> {
+        return this.post<Query, com.looker.sdk.Error>(
             "/queries",
             mapOf("fields" to fields), body
         )
@@ -4989,10 +5207,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         path_prefix: String? = null,
         rebuild_pdts: Boolean? = null,
         server_table_calcs: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_query_id = encodeParam(query_id)
         val path_result_format = encodeParam(result_format)
-        return this.get<String>(
+        return this.get<String, com.looker.sdk.Error>(
             "/queries/$path_query_id/run/$path_result_format",
             mapOf(
                 "limit" to limit,
@@ -5097,9 +5315,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         path_prefix: String? = null,
         rebuild_pdts: Boolean? = null,
         server_table_calcs: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_result_format = encodeParam(result_format)
-        return this.post<String>(
+        return this.post<String, com.looker.sdk.Error>(
             "/queries/run/$path_result_format",
             mapOf(
                 "limit" to limit,
@@ -5185,11 +5403,13 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         model_name: String,
         view_name: String,
         result_format: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_model_name = encodeParam(model_name)
         val path_view_name = encodeParam(view_name)
         val path_result_format = encodeParam(result_format)
-        return this.get<String>("/queries/models/$path_model_name/views/$path_view_name/run/$path_result_format", mapOf())
+        return this.get<String, com.looker.sdk.Error>(
+            "/queries/models/$path_model_name/views/$path_view_name/run/$path_result_format", mapOf()
+        )
     }
 
     /**
@@ -5205,9 +5425,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun merge_query(
         merge_query_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<MergeQuery, com.looker.sdk.Error> {
         val path_merge_query_id = encodeParam(merge_query_id)
-        return this.get<MergeQuery>(
+        return this.get<MergeQuery, com.looker.sdk.Error>(
             "/merge_queries/$path_merge_query_id",
             mapOf("fields" to fields)
         )
@@ -5240,8 +5460,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_merge_query(
         body: WriteMergeQuery? = null,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<MergeQuery>(
+    ): SdkResult<MergeQuery, com.looker.sdk.Error> {
+        return this.post<MergeQuery, com.looker.sdk.Error>(
             "/merge_queries",
             mapOf("fields" to fields), body
         )
@@ -5252,8 +5472,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /running_queries -> Array<RunningQueries>
      */
-    fun all_running_queries(): SDKResponse {
-        return this.get<Array<RunningQueries>>("/running_queries", mapOf())
+    fun all_running_queries(): SdkResult<Array<RunningQueries>, com.looker.sdk.Error> {
+        return this.get<Array<RunningQueries>, com.looker.sdk.Error>(
+            "/running_queries", mapOf()
+        )
     }
 
     /**
@@ -5265,9 +5487,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun kill_query(
         query_task_id: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_query_task_id = encodeParam(query_task_id)
-        return this.delete<String>("/running_queries/$path_query_task_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/running_queries/$path_query_task_id", mapOf()
+        )
     }
 
     /**
@@ -5279,9 +5503,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun sql_query(
         slug: String
-    ): SDKResponse {
+    ): SdkResult<SqlQuery, com.looker.sdk.Error> {
         val path_slug = encodeParam(slug)
-        return this.get<SqlQuery>("/sql_queries/$path_slug", mapOf())
+        return this.get<SqlQuery, com.looker.sdk.Error>(
+            "/sql_queries/$path_slug", mapOf()
+        )
     }
 
     /**
@@ -5295,8 +5521,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_sql_query(
         body: SqlQueryCreate
-    ): SDKResponse {
-        return this.post<SqlQuery>("/sql_queries", mapOf(), body)
+    ): SdkResult<SqlQuery, com.looker.sdk.Error> {
+        return this.post<SqlQuery, com.looker.sdk.Error>(
+            "/sql_queries", mapOf(), body
+        )
     }
 
     /**
@@ -5314,10 +5542,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         slug: String,
         result_format: String,
         download: String? = null
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_slug = encodeParam(slug)
         val path_result_format = encodeParam(result_format)
-        return this.post<String>(
+        return this.post<String, com.looker.sdk.Error>(
             "/sql_queries/$path_slug/run/$path_result_format",
             mapOf("download" to download)
         )
@@ -5356,10 +5584,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         fields: String? = null,
         pdf_paper_size: String? = null,
         pdf_landscape: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<RenderTask, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
         val path_result_format = encodeParam(result_format)
-        return this.post<RenderTask>(
+        return this.post<RenderTask, com.looker.sdk.Error>(
             "/render_tasks/lookml_dashboards/$path_dashboard_id/$path_result_format",
             mapOf(
                 "width" to width,
@@ -5393,10 +5621,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         width: Long,
         height: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<RenderTask, com.looker.sdk.Error> {
         val path_look_id = encodeParam(look_id)
         val path_result_format = encodeParam(result_format)
-        return this.post<RenderTask>(
+        return this.post<RenderTask, com.looker.sdk.Error>(
             "/render_tasks/looks/$path_look_id/$path_result_format",
             mapOf(
                 "width" to width,
@@ -5427,10 +5655,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         width: Long,
         height: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<RenderTask, com.looker.sdk.Error> {
         val path_query_id = encodeParam(query_id)
         val path_result_format = encodeParam(result_format)
-        return this.post<RenderTask>(
+        return this.post<RenderTask, com.looker.sdk.Error>(
             "/render_tasks/queries/$path_query_id/$path_result_format",
             mapOf(
                 "width" to width,
@@ -5467,10 +5695,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         fields: String? = null,
         pdf_paper_size: String? = null,
         pdf_landscape: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<RenderTask, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
         val path_result_format = encodeParam(result_format)
-        return this.post<RenderTask>(
+        return this.post<RenderTask, com.looker.sdk.Error>(
             "/render_tasks/dashboards/$path_dashboard_id/$path_result_format",
             mapOf(
                 "width" to width,
@@ -5498,9 +5726,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun render_task(
         render_task_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<RenderTask, com.looker.sdk.Error> {
         val path_render_task_id = encodeParam(render_task_id)
-        return this.get<RenderTask>(
+        return this.get<RenderTask, com.looker.sdk.Error>(
             "/render_tasks/$path_render_task_id",
             mapOf("fields" to fields)
         )
@@ -5533,9 +5761,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun render_task_results(
         render_task_id: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_render_task_id = encodeParam(render_task_id)
-        return this.get<String>("/render_tasks/$path_render_task_id/results", mapOf())
+        return this.get<String, com.looker.sdk.Error>(
+            "/render_tasks/$path_render_task_id/results", mapOf()
+        )
     }
 
     //endregion RenderTask: Manage Render Tasks
@@ -5588,8 +5818,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         all_access: Boolean? = null,
         built_in: Boolean? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<Array<ModelSet>>(
+    ): SdkResult<Array<ModelSet>, com.looker.sdk.Error> {
+        return this.get<Array<ModelSet>, com.looker.sdk.Error>(
             "/model_sets/search",
             mapOf(
                 "fields" to fields,
@@ -5616,9 +5846,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun model_set(
         model_set_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ModelSet, com.looker.sdk.Error> {
         val path_model_set_id = encodeParam(model_set_id)
-        return this.get<ModelSet>(
+        return this.get<ModelSet, com.looker.sdk.Error>(
             "/model_sets/$path_model_set_id",
             mapOf("fields" to fields)
         )
@@ -5635,9 +5865,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     fun update_model_set(
         model_set_id: Long,
         body: WriteModelSet
-    ): SDKResponse {
+    ): SdkResult<ModelSet, com.looker.sdk.Error> {
         val path_model_set_id = encodeParam(model_set_id)
-        return this.patch<ModelSet>("/model_sets/$path_model_set_id", mapOf(), body)
+        return this.patch<ModelSet, com.looker.sdk.Error>(
+            "/model_sets/$path_model_set_id", mapOf(), body
+        )
     }
 
     /**
@@ -5649,9 +5881,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_model_set(
         model_set_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_model_set_id = encodeParam(model_set_id)
-        return this.delete<String>("/model_sets/$path_model_set_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/model_sets/$path_model_set_id", mapOf()
+        )
     }
 
     /**
@@ -5663,8 +5897,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_model_sets(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<ModelSet>>(
+    ): SdkResult<Array<ModelSet>, com.looker.sdk.Error> {
+        return this.get<Array<ModelSet>, com.looker.sdk.Error>(
             "/model_sets",
             mapOf("fields" to fields)
         )
@@ -5679,8 +5913,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_model_set(
         body: WriteModelSet
-    ): SDKResponse {
-        return this.post<ModelSet>("/model_sets", mapOf(), body)
+    ): SdkResult<ModelSet, com.looker.sdk.Error> {
+        return this.post<ModelSet, com.looker.sdk.Error>(
+            "/model_sets", mapOf(), body
+        )
     }
 
     /**
@@ -5688,8 +5924,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /permissions -> Array<Permission>
      */
-    fun all_permissions(): SDKResponse {
-        return this.get<Array<Permission>>("/permissions", mapOf())
+    fun all_permissions(): SdkResult<Array<Permission>, com.looker.sdk.Error> {
+        return this.get<Array<Permission>, com.looker.sdk.Error>(
+            "/permissions", mapOf()
+        )
     }
 
     /**
@@ -5738,8 +5976,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         all_access: Boolean? = null,
         built_in: Boolean? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<Array<PermissionSet>>(
+    ): SdkResult<Array<PermissionSet>, com.looker.sdk.Error> {
+        return this.get<Array<PermissionSet>, com.looker.sdk.Error>(
             "/permission_sets/search",
             mapOf(
                 "fields" to fields,
@@ -5766,9 +6004,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun permission_set(
         permission_set_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<PermissionSet, com.looker.sdk.Error> {
         val path_permission_set_id = encodeParam(permission_set_id)
-        return this.get<PermissionSet>(
+        return this.get<PermissionSet, com.looker.sdk.Error>(
             "/permission_sets/$path_permission_set_id",
             mapOf("fields" to fields)
         )
@@ -5785,9 +6023,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     fun update_permission_set(
         permission_set_id: Long,
         body: WritePermissionSet
-    ): SDKResponse {
+    ): SdkResult<PermissionSet, com.looker.sdk.Error> {
         val path_permission_set_id = encodeParam(permission_set_id)
-        return this.patch<PermissionSet>("/permission_sets/$path_permission_set_id", mapOf(), body)
+        return this.patch<PermissionSet, com.looker.sdk.Error>(
+            "/permission_sets/$path_permission_set_id", mapOf(), body
+        )
     }
 
     /**
@@ -5799,9 +6039,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_permission_set(
         permission_set_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_permission_set_id = encodeParam(permission_set_id)
-        return this.delete<String>("/permission_sets/$path_permission_set_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/permission_sets/$path_permission_set_id", mapOf()
+        )
     }
 
     /**
@@ -5813,8 +6055,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_permission_sets(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<PermissionSet>>(
+    ): SdkResult<Array<PermissionSet>, com.looker.sdk.Error> {
+        return this.get<Array<PermissionSet>, com.looker.sdk.Error>(
             "/permission_sets",
             mapOf("fields" to fields)
         )
@@ -5829,8 +6071,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_permission_set(
         body: WritePermissionSet
-    ): SDKResponse {
-        return this.post<PermissionSet>("/permission_sets", mapOf(), body)
+    ): SdkResult<PermissionSet, com.looker.sdk.Error> {
+        return this.post<PermissionSet, com.looker.sdk.Error>(
+            "/permission_sets", mapOf(), body
+        )
     }
 
     /**
@@ -5844,8 +6088,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_roles(
         fields: String? = null,
         ids: DelimArray<Long>? = null
-    ): SDKResponse {
-        return this.get<Array<Role>>(
+    ): SdkResult<Array<Role>, com.looker.sdk.Error> {
+        return this.get<Array<Role>, com.looker.sdk.Error>(
             "/roles",
             mapOf(
                 "fields" to fields,
@@ -5863,8 +6107,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_role(
         body: WriteRole
-    ): SDKResponse {
-        return this.post<Role>("/roles", mapOf(), body)
+    ): SdkResult<Role, com.looker.sdk.Error> {
+        return this.post<Role, com.looker.sdk.Error>(
+            "/roles", mapOf(), body
+        )
     }
 
     /**
@@ -5913,8 +6159,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         name: String? = null,
         built_in: Boolean? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<Array<Role>>(
+    ): SdkResult<Array<Role>, com.looker.sdk.Error> {
+        return this.get<Array<Role>, com.looker.sdk.Error>(
             "/roles/search",
             mapOf(
                 "fields" to fields,
@@ -5938,9 +6184,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun role(
         role_id: Long
-    ): SDKResponse {
+    ): SdkResult<Role, com.looker.sdk.Error> {
         val path_role_id = encodeParam(role_id)
-        return this.get<Role>("/roles/$path_role_id", mapOf())
+        return this.get<Role, com.looker.sdk.Error>(
+            "/roles/$path_role_id", mapOf()
+        )
     }
 
     /**
@@ -5954,9 +6202,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     fun update_role(
         role_id: Long,
         body: WriteRole
-    ): SDKResponse {
+    ): SdkResult<Role, com.looker.sdk.Error> {
         val path_role_id = encodeParam(role_id)
-        return this.patch<Role>("/roles/$path_role_id", mapOf(), body)
+        return this.patch<Role, com.looker.sdk.Error>(
+            "/roles/$path_role_id", mapOf(), body
+        )
     }
 
     /**
@@ -5968,9 +6218,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_role(
         role_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_role_id = encodeParam(role_id)
-        return this.delete<String>("/roles/$path_role_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/roles/$path_role_id", mapOf()
+        )
     }
 
     /**
@@ -5984,9 +6236,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun role_groups(
         role_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<Group>, com.looker.sdk.Error> {
         val path_role_id = encodeParam(role_id)
-        return this.get<Array<Group>>(
+        return this.get<Array<Group>, com.looker.sdk.Error>(
             "/roles/$path_role_id/groups",
             mapOf("fields" to fields)
         )
@@ -6003,9 +6255,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     fun set_role_groups(
         role_id: Long,
         body: Array<Long>
-    ): SDKResponse {
+    ): SdkResult<Array<Group>, com.looker.sdk.Error> {
         val path_role_id = encodeParam(role_id)
-        return this.put<Array<Group>>("/roles/$path_role_id/groups", mapOf(), body)
+        return this.put<Array<Group>, com.looker.sdk.Error>(
+            "/roles/$path_role_id/groups", mapOf(), body
+        )
     }
 
     /**
@@ -6021,9 +6275,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         role_id: Long,
         fields: String? = null,
         direct_association_only: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<Array<User>, com.looker.sdk.Error> {
         val path_role_id = encodeParam(role_id)
-        return this.get<Array<User>>(
+        return this.get<Array<User>, com.looker.sdk.Error>(
             "/roles/$path_role_id/users",
             mapOf(
                 "fields" to fields,
@@ -6043,9 +6297,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     fun set_role_users(
         role_id: Long,
         body: Array<Long>
-    ): SDKResponse {
+    ): SdkResult<Array<User>, com.looker.sdk.Error> {
         val path_role_id = encodeParam(role_id)
-        return this.put<Array<User>>("/roles/$path_role_id/users", mapOf(), body)
+        return this.put<Array<User>, com.looker.sdk.Error>(
+            "/roles/$path_role_id/users", mapOf(), body
+        )
     }
 
     //endregion Role: Manage Roles
@@ -6065,9 +6321,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun scheduled_plans_for_space(
         space_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<ScheduledPlan>, com.looker.sdk.Error> {
         val path_space_id = encodeParam(space_id)
-        return this.get<Array<ScheduledPlan>>(
+        return this.get<Array<ScheduledPlan>, com.looker.sdk.Error>(
             "/scheduled_plans/space/$path_space_id",
             mapOf("fields" to fields)
         )
@@ -6086,9 +6342,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun scheduled_plan(
         scheduled_plan_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ScheduledPlan, com.looker.sdk.Error> {
         val path_scheduled_plan_id = encodeParam(scheduled_plan_id)
-        return this.get<ScheduledPlan>(
+        return this.get<ScheduledPlan, com.looker.sdk.Error>(
             "/scheduled_plans/$path_scheduled_plan_id",
             mapOf("fields" to fields)
         )
@@ -6146,9 +6402,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     fun update_scheduled_plan(
         scheduled_plan_id: Long,
         body: WriteScheduledPlan
-    ): SDKResponse {
+    ): SdkResult<ScheduledPlan, com.looker.sdk.Error> {
         val path_scheduled_plan_id = encodeParam(scheduled_plan_id)
-        return this.patch<ScheduledPlan>("/scheduled_plans/$path_scheduled_plan_id", mapOf(), body)
+        return this.patch<ScheduledPlan, com.looker.sdk.Error>(
+            "/scheduled_plans/$path_scheduled_plan_id", mapOf(), body
+        )
     }
 
     /**
@@ -6164,9 +6422,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_scheduled_plan(
         scheduled_plan_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_scheduled_plan_id = encodeParam(scheduled_plan_id)
-        return this.delete<String>("/scheduled_plans/$path_scheduled_plan_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/scheduled_plans/$path_scheduled_plan_id", mapOf()
+        )
     }
 
     /**
@@ -6192,8 +6452,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long? = null,
         fields: String? = null,
         all_users: Boolean? = null
-    ): SDKResponse {
-        return this.get<Array<ScheduledPlan>>(
+    ): SdkResult<Array<ScheduledPlan>, com.looker.sdk.Error> {
+        return this.get<Array<ScheduledPlan>, com.looker.sdk.Error>(
             "/scheduled_plans",
             mapOf(
                 "user_id" to user_id,
@@ -6269,8 +6529,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_scheduled_plan(
         body: WriteScheduledPlan
-    ): SDKResponse {
-        return this.post<ScheduledPlan>("/scheduled_plans", mapOf(), body)
+    ): SdkResult<ScheduledPlan, com.looker.sdk.Error> {
+        return this.post<ScheduledPlan, com.looker.sdk.Error>(
+            "/scheduled_plans", mapOf(), body
+        )
     }
 
     /**
@@ -6318,8 +6580,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun scheduled_plan_run_once(
         body: WriteScheduledPlan
-    ): SDKResponse {
-        return this.post<ScheduledPlan>("/scheduled_plans/run_once", mapOf(), body)
+    ): SdkResult<ScheduledPlan, com.looker.sdk.Error> {
+        return this.post<ScheduledPlan, com.looker.sdk.Error>(
+            "/scheduled_plans/run_once", mapOf(), body
+        )
     }
 
     /**
@@ -6347,9 +6611,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long? = null,
         fields: String? = null,
         all_users: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<Array<ScheduledPlan>, com.looker.sdk.Error> {
         val path_look_id = encodeParam(look_id)
-        return this.get<Array<ScheduledPlan>>(
+        return this.get<Array<ScheduledPlan>, com.looker.sdk.Error>(
             "/scheduled_plans/look/$path_look_id",
             mapOf(
                 "user_id" to user_id,
@@ -6384,9 +6648,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long? = null,
         all_users: Boolean? = null,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<ScheduledPlan>, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
-        return this.get<Array<ScheduledPlan>>(
+        return this.get<Array<ScheduledPlan>, com.looker.sdk.Error>(
             "/scheduled_plans/dashboard/$path_dashboard_id",
             mapOf(
                 "user_id" to user_id,
@@ -6421,9 +6685,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long? = null,
         fields: String? = null,
         all_users: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<Array<ScheduledPlan>, com.looker.sdk.Error> {
         val path_lookml_dashboard_id = encodeParam(lookml_dashboard_id)
-        return this.get<Array<ScheduledPlan>>(
+        return this.get<Array<ScheduledPlan>, com.looker.sdk.Error>(
             "/scheduled_plans/lookml_dashboard/$path_lookml_dashboard_id",
             mapOf(
                 "user_id" to user_id,
@@ -6490,9 +6754,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun scheduled_plan_run_once_by_id(
         scheduled_plan_id: Long,
         body: WriteScheduledPlan? = null
-    ): SDKResponse {
+    ): SdkResult<ScheduledPlan, com.looker.sdk.Error> {
         val path_scheduled_plan_id = encodeParam(scheduled_plan_id)
-        return this.post<ScheduledPlan>("/scheduled_plans/$path_scheduled_plan_id/run_once", mapOf(), body)
+        return this.post<ScheduledPlan, com.looker.sdk.Error>(
+            "/scheduled_plans/$path_scheduled_plan_id/run_once", mapOf(), body
+        )
     }
 
     //endregion ScheduledPlan: Manage Scheduled Plans
@@ -6506,8 +6772,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /session -> ApiSession
      */
-    fun session(): SDKResponse {
-        return this.get<ApiSession>("/session", mapOf())
+    fun session(): SdkResult<ApiSession, com.looker.sdk.Error> {
+        return this.get<ApiSession, com.looker.sdk.Error>(
+            "/session", mapOf()
+        )
     }
 
     /**
@@ -6538,8 +6806,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_session(
         body: WriteApiSession
-    ): SDKResponse {
-        return this.patch<ApiSession>("/session", mapOf(), body)
+    ): SdkResult<ApiSession, com.looker.sdk.Error> {
+        return this.patch<ApiSession, com.looker.sdk.Error>(
+            "/session", mapOf(), body
+        )
     }
 
     //endregion Session: Session Information
@@ -6603,8 +6873,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         parent_id: String? = null,
         creator_id: String? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<Array<Space>>(
+    ): SdkResult<Array<Space>, com.looker.sdk.Error> {
+        return this.get<Array<Space>, com.looker.sdk.Error>(
             "/spaces/search",
             mapOf(
                 "fields" to fields,
@@ -6633,9 +6903,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun space(
         space_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Space, com.looker.sdk.Error> {
         val path_space_id = encodeParam(space_id)
-        return this.get<Space>(
+        return this.get<Space, com.looker.sdk.Error>(
             "/spaces/$path_space_id",
             mapOf("fields" to fields)
         )
@@ -6652,9 +6922,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     fun update_space(
         space_id: String,
         body: UpdateSpace
-    ): SDKResponse {
+    ): SdkResult<Space, com.looker.sdk.Error> {
         val path_space_id = encodeParam(space_id)
-        return this.patch<Space>("/spaces/$path_space_id", mapOf(), body)
+        return this.patch<Space, com.looker.sdk.Error>(
+            "/spaces/$path_space_id", mapOf(), body
+        )
     }
 
     /**
@@ -6667,9 +6939,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_space(
         space_id: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_space_id = encodeParam(space_id)
-        return this.delete<String>("/spaces/$path_space_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/spaces/$path_space_id", mapOf()
+        )
     }
 
     /**
@@ -6681,8 +6955,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_spaces(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<SpaceBase>>(
+    ): SdkResult<Array<SpaceBase>, com.looker.sdk.Error> {
+        return this.get<Array<SpaceBase>, com.looker.sdk.Error>(
             "/spaces",
             mapOf("fields" to fields)
         )
@@ -6700,8 +6974,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_space(
         body: CreateSpace
-    ): SDKResponse {
-        return this.post<Space>("/spaces", mapOf(), body)
+    ): SdkResult<Space, com.looker.sdk.Error> {
+        return this.post<Space, com.looker.sdk.Error>(
+            "/spaces", mapOf(), body
+        )
     }
 
     /**
@@ -6721,9 +6997,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         page: Long? = null,
         per_page: Long? = null,
         sorts: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<Space>, com.looker.sdk.Error> {
         val path_space_id = encodeParam(space_id)
-        return this.get<Array<Space>>(
+        return this.get<Array<Space>, com.looker.sdk.Error>(
             "/spaces/$path_space_id/children",
             mapOf(
                 "fields" to fields,
@@ -6749,9 +7025,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         fields: String? = null,
         sorts: String? = null,
         name: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<Space>, com.looker.sdk.Error> {
         val path_space_id = encodeParam(space_id)
-        return this.get<Array<Space>>(
+        return this.get<Array<Space>, com.looker.sdk.Error>(
             "/spaces/$path_space_id/children/search",
             mapOf(
                 "fields" to fields,
@@ -6772,9 +7048,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun space_parent(
         space_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Space, com.looker.sdk.Error> {
         val path_space_id = encodeParam(space_id)
-        return this.get<Space>(
+        return this.get<Space, com.looker.sdk.Error>(
             "/spaces/$path_space_id/parent",
             mapOf("fields" to fields)
         )
@@ -6791,9 +7067,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun space_ancestors(
         space_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<Space>, com.looker.sdk.Error> {
         val path_space_id = encodeParam(space_id)
-        return this.get<Array<Space>>(
+        return this.get<Array<Space>, com.looker.sdk.Error>(
             "/spaces/$path_space_id/ancestors",
             mapOf("fields" to fields)
         )
@@ -6810,9 +7086,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun space_looks(
         space_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<LookWithQuery>, com.looker.sdk.Error> {
         val path_space_id = encodeParam(space_id)
-        return this.get<Array<LookWithQuery>>(
+        return this.get<Array<LookWithQuery>, com.looker.sdk.Error>(
             "/spaces/$path_space_id/looks",
             mapOf("fields" to fields)
         )
@@ -6829,9 +7105,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun space_dashboards(
         space_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<Dashboard>, com.looker.sdk.Error> {
         val path_space_id = encodeParam(space_id)
-        return this.get<Array<Dashboard>>(
+        return this.get<Array<Dashboard>, com.looker.sdk.Error>(
             "/spaces/$path_space_id/dashboards",
             mapOf("fields" to fields)
         )
@@ -6856,8 +7132,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_themes(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<Theme>>(
+    ): SdkResult<Array<Theme>, com.looker.sdk.Error> {
+        return this.get<Array<Theme>, com.looker.sdk.Error>(
             "/themes",
             mapOf("fields" to fields)
         )
@@ -6886,8 +7162,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_theme(
         body: WriteTheme
-    ): SDKResponse {
-        return this.post<Theme>("/themes", mapOf(), body)
+    ): SdkResult<Theme, com.looker.sdk.Error> {
+        return this.post<Theme, com.looker.sdk.Error>(
+            "/themes", mapOf(), body
+        )
     }
 
     /**
@@ -6952,8 +7230,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         sorts: String? = null,
         fields: String? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<Array<Theme>>(
+    ): SdkResult<Array<Theme>, com.looker.sdk.Error> {
+        return this.get<Array<Theme>, com.looker.sdk.Error>(
             "/themes/search",
             mapOf(
                 "id" to id,
@@ -6984,8 +7262,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun default_theme(
         ts: Date? = null
-    ): SDKResponse {
-        return this.get<Theme>(
+    ): SdkResult<Theme, com.looker.sdk.Error> {
+        return this.get<Theme, com.looker.sdk.Error>(
             "/themes/default",
             mapOf("ts" to ts)
         )
@@ -7010,8 +7288,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun set_default_theme(
         name: String
-    ): SDKResponse {
-        return this.put<Theme>(
+    ): SdkResult<Theme, com.looker.sdk.Error> {
+        return this.put<Theme, com.looker.sdk.Error>(
             "/themes/default",
             mapOf("name" to name)
         )
@@ -7038,8 +7316,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         name: String? = null,
         ts: Date? = null,
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<Theme>>(
+    ): SdkResult<Array<Theme>, com.looker.sdk.Error> {
+        return this.get<Array<Theme>, com.looker.sdk.Error>(
             "/themes/active",
             mapOf(
                 "name" to name,
@@ -7065,8 +7343,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun theme_or_default(
         name: String,
         ts: Date? = null
-    ): SDKResponse {
-        return this.get<Theme>(
+    ): SdkResult<Theme, com.looker.sdk.Error> {
+        return this.get<Theme, com.looker.sdk.Error>(
             "/themes/theme_or_default",
             mapOf(
                 "name" to name,
@@ -7090,8 +7368,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun validate_theme(
         body: WriteTheme
-    ): SDKResponse {
-        return this.post<ValidationError>("/themes/validate", mapOf(), body)
+    ): SdkResult<ValidationError, com.looker.sdk.Error> {
+        return this.post<ValidationError, com.looker.sdk.Error>(
+            "/themes/validate", mapOf(), body
+        )
     }
 
     /**
@@ -7109,9 +7389,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun theme(
         theme_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Theme, com.looker.sdk.Error> {
         val path_theme_id = encodeParam(theme_id)
-        return this.get<Theme>(
+        return this.get<Theme, com.looker.sdk.Error>(
             "/themes/$path_theme_id",
             mapOf("fields" to fields)
         )
@@ -7130,9 +7410,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     fun update_theme(
         theme_id: String,
         body: WriteTheme
-    ): SDKResponse {
+    ): SdkResult<Theme, com.looker.sdk.Error> {
         val path_theme_id = encodeParam(theme_id)
-        return this.patch<Theme>("/themes/$path_theme_id", mapOf(), body)
+        return this.patch<Theme, com.looker.sdk.Error>(
+            "/themes/$path_theme_id", mapOf(), body
+        )
     }
 
     /**
@@ -7152,9 +7434,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_theme(
         theme_id: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_theme_id = encodeParam(theme_id)
-        return this.delete<String>("/themes/$path_theme_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/themes/$path_theme_id", mapOf()
+        )
     }
 
     //endregion Theme: Manage Themes
@@ -7170,8 +7454,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun me(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<User>(
+    ): SdkResult<User, com.looker.sdk.Error> {
+        return this.get<User, com.looker.sdk.Error>(
             "/user",
             mapOf("fields" to fields)
         )
@@ -7194,8 +7478,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         per_page: Long? = null,
         sorts: String? = null,
         ids: DelimArray<Long>? = null
-    ): SDKResponse {
-        return this.get<Array<User>>(
+    ): SdkResult<Array<User>, com.looker.sdk.Error> {
+        return this.get<Array<User>, com.looker.sdk.Error>(
             "/users",
             mapOf(
                 "fields" to fields,
@@ -7218,8 +7502,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_user(
         body: WriteUser? = null,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<User>(
+    ): SdkResult<User, com.looker.sdk.Error> {
+        return this.post<User, com.looker.sdk.Error>(
             "/users",
             mapOf("fields" to fields), body
         )
@@ -7287,8 +7571,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         filter_or: Boolean? = null,
         content_metadata_id: Long? = null,
         group_id: Long? = null
-    ): SDKResponse {
-        return this.get<Array<User>>(
+    ): SdkResult<Array<User>, com.looker.sdk.Error> {
+        return this.get<Array<User>, com.looker.sdk.Error>(
             "/users/search",
             mapOf(
                 "fields" to fields,
@@ -7342,9 +7626,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         verified_looker_employee: Boolean? = null,
         email: String? = null,
         is_disabled: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<Array<User>, com.looker.sdk.Error> {
         val path_pattern = encodeParam(pattern)
-        return this.get<Array<User>>(
+        return this.get<Array<User>, com.looker.sdk.Error>(
             "/users/search/names/$path_pattern",
             mapOf(
                 "fields" to fields,
@@ -7376,9 +7660,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun user(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<User, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<User>(
+        return this.get<User, com.looker.sdk.Error>(
             "/users/$path_user_id",
             mapOf("fields" to fields)
         )
@@ -7397,9 +7681,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         body: WriteUser,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<User, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.patch<User>(
+        return this.patch<User, com.looker.sdk.Error>(
             "/users/$path_user_id",
             mapOf("fields" to fields), body
         )
@@ -7416,9 +7700,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_user(
         user_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.delete<String>("/users/$path_user_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/users/$path_user_id", mapOf()
+        )
     }
 
     /**
@@ -7461,10 +7747,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         credential_type: String,
         credential_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<User, com.looker.sdk.Error> {
         val path_credential_type = encodeParam(credential_type)
         val path_credential_id = encodeParam(credential_id)
-        return this.get<User>(
+        return this.get<User, com.looker.sdk.Error>(
             "/users/credential/$path_credential_type/$path_credential_id",
             mapOf("fields" to fields)
         )
@@ -7481,9 +7767,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun user_credentials_email(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<CredentialsEmail, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<CredentialsEmail>(
+        return this.get<CredentialsEmail, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_email",
             mapOf("fields" to fields)
         )
@@ -7502,9 +7788,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         body: WriteCredentialsEmail,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<CredentialsEmail, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.post<CredentialsEmail>(
+        return this.post<CredentialsEmail, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_email",
             mapOf("fields" to fields), body
         )
@@ -7523,9 +7809,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         body: WriteCredentialsEmail,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<CredentialsEmail, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.patch<CredentialsEmail>(
+        return this.patch<CredentialsEmail, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_email",
             mapOf("fields" to fields), body
         )
@@ -7540,9 +7826,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_user_credentials_email(
         user_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.delete<String>("/users/$path_user_id/credentials_email", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/users/$path_user_id/credentials_email", mapOf()
+        )
     }
 
     /**
@@ -7556,9 +7844,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun user_credentials_totp(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<CredentialsTotp, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<CredentialsTotp>(
+        return this.get<CredentialsTotp, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_totp",
             mapOf("fields" to fields)
         )
@@ -7577,9 +7865,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         body: CredentialsTotp? = null,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<CredentialsTotp, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.post<CredentialsTotp>(
+        return this.post<CredentialsTotp, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_totp",
             mapOf("fields" to fields), body
         )
@@ -7594,9 +7882,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_user_credentials_totp(
         user_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.delete<String>("/users/$path_user_id/credentials_totp", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/users/$path_user_id/credentials_totp", mapOf()
+        )
     }
 
     /**
@@ -7610,9 +7900,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun user_credentials_ldap(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<CredentialsLDAP, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<CredentialsLDAP>(
+        return this.get<CredentialsLDAP, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_ldap",
             mapOf("fields" to fields)
         )
@@ -7627,9 +7917,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_user_credentials_ldap(
         user_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.delete<String>("/users/$path_user_id/credentials_ldap", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/users/$path_user_id/credentials_ldap", mapOf()
+        )
     }
 
     /**
@@ -7643,9 +7935,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun user_credentials_google(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<CredentialsGoogle, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<CredentialsGoogle>(
+        return this.get<CredentialsGoogle, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_google",
             mapOf("fields" to fields)
         )
@@ -7660,9 +7952,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_user_credentials_google(
         user_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.delete<String>("/users/$path_user_id/credentials_google", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/users/$path_user_id/credentials_google", mapOf()
+        )
     }
 
     /**
@@ -7676,9 +7970,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun user_credentials_saml(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<CredentialsSaml, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<CredentialsSaml>(
+        return this.get<CredentialsSaml, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_saml",
             mapOf("fields" to fields)
         )
@@ -7693,9 +7987,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_user_credentials_saml(
         user_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.delete<String>("/users/$path_user_id/credentials_saml", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/users/$path_user_id/credentials_saml", mapOf()
+        )
     }
 
     /**
@@ -7709,9 +8005,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun user_credentials_oidc(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<CredentialsOIDC, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<CredentialsOIDC>(
+        return this.get<CredentialsOIDC, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_oidc",
             mapOf("fields" to fields)
         )
@@ -7726,9 +8022,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_user_credentials_oidc(
         user_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.delete<String>("/users/$path_user_id/credentials_oidc", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/users/$path_user_id/credentials_oidc", mapOf()
+        )
     }
 
     /**
@@ -7744,10 +8042,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         credentials_api3_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<CredentialsApi3, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
         val path_credentials_api3_id = encodeParam(credentials_api3_id)
-        return this.get<CredentialsApi3>(
+        return this.get<CredentialsApi3, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_api3/$path_credentials_api3_id",
             mapOf("fields" to fields)
         )
@@ -7764,10 +8062,12 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     fun delete_user_credentials_api3(
         user_id: Long,
         credentials_api3_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
         val path_credentials_api3_id = encodeParam(credentials_api3_id)
-        return this.delete<String>("/users/$path_user_id/credentials_api3/$path_credentials_api3_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/users/$path_user_id/credentials_api3/$path_credentials_api3_id", mapOf()
+        )
     }
 
     /**
@@ -7781,9 +8081,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_user_credentials_api3s(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<CredentialsApi3>, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<Array<CredentialsApi3>>(
+        return this.get<Array<CredentialsApi3>, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_api3",
             mapOf("fields" to fields)
         )
@@ -7802,9 +8102,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         body: CredentialsApi3? = null,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<CredentialsApi3, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.post<CredentialsApi3>(
+        return this.post<CredentialsApi3, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_api3",
             mapOf("fields" to fields), body
         )
@@ -7823,10 +8123,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         credentials_embed_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<CredentialsEmbed, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
         val path_credentials_embed_id = encodeParam(credentials_embed_id)
-        return this.get<CredentialsEmbed>(
+        return this.get<CredentialsEmbed, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_embed/$path_credentials_embed_id",
             mapOf("fields" to fields)
         )
@@ -7843,10 +8143,12 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     fun delete_user_credentials_embed(
         user_id: Long,
         credentials_embed_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
         val path_credentials_embed_id = encodeParam(credentials_embed_id)
-        return this.delete<String>("/users/$path_user_id/credentials_embed/$path_credentials_embed_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/users/$path_user_id/credentials_embed/$path_credentials_embed_id", mapOf()
+        )
     }
 
     /**
@@ -7860,9 +8162,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_user_credentials_embeds(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<CredentialsEmbed>, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<Array<CredentialsEmbed>>(
+        return this.get<Array<CredentialsEmbed>, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_embed",
             mapOf("fields" to fields)
         )
@@ -7879,9 +8181,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun user_credentials_looker_openid(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<CredentialsLookerOpenid, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<CredentialsLookerOpenid>(
+        return this.get<CredentialsLookerOpenid, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_looker_openid",
             mapOf("fields" to fields)
         )
@@ -7896,9 +8198,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_user_credentials_looker_openid(
         user_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.delete<String>("/users/$path_user_id/credentials_looker_openid", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/users/$path_user_id/credentials_looker_openid", mapOf()
+        )
     }
 
     /**
@@ -7914,10 +8218,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         session_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Session, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
         val path_session_id = encodeParam(session_id)
-        return this.get<Session>(
+        return this.get<Session, com.looker.sdk.Error>(
             "/users/$path_user_id/sessions/$path_session_id",
             mapOf("fields" to fields)
         )
@@ -7934,10 +8238,12 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     fun delete_user_session(
         user_id: Long,
         session_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
         val path_session_id = encodeParam(session_id)
-        return this.delete<String>("/users/$path_user_id/sessions/$path_session_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/users/$path_user_id/sessions/$path_session_id", mapOf()
+        )
     }
 
     /**
@@ -7951,9 +8257,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_user_sessions(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<Session>, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<Array<Session>>(
+        return this.get<Array<Session>, com.looker.sdk.Error>(
             "/users/$path_user_id/sessions",
             mapOf("fields" to fields)
         )
@@ -7980,9 +8286,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         expires: Boolean? = null,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<CredentialsEmail, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.post<CredentialsEmail>(
+        return this.post<CredentialsEmail, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_email/password_reset",
             mapOf(
                 "expires" to expires,
@@ -8004,9 +8310,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         fields: String? = null,
         direct_association_only: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<Array<Role>, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<Array<Role>>(
+        return this.get<Array<Role>, com.looker.sdk.Error>(
             "/users/$path_user_id/roles",
             mapOf(
                 "fields" to fields,
@@ -8028,9 +8334,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         body: Array<Long>,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<Role>, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.put<Array<Role>>(
+        return this.put<Array<Role>, com.looker.sdk.Error>(
             "/users/$path_user_id/roles",
             mapOf("fields" to fields), body
         )
@@ -8068,9 +8374,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         user_attribute_ids: DelimArray<Long>? = null,
         all_values: Boolean? = null,
         include_unset: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<Array<UserAttributeWithValue>, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<Array<UserAttributeWithValue>>(
+        return this.get<Array<UserAttributeWithValue>, com.looker.sdk.Error>(
             "/users/$path_user_id/attribute_values",
             mapOf(
                 "fields" to fields,
@@ -8096,10 +8402,12 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         user_attribute_id: Long,
         body: WriteUserAttributeWithValue
-    ): SDKResponse {
+    ): SdkResult<UserAttributeWithValue, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
         val path_user_attribute_id = encodeParam(user_attribute_id)
-        return this.patch<UserAttributeWithValue>("/users/$path_user_id/attribute_values/$path_user_attribute_id", mapOf(), body)
+        return this.patch<UserAttributeWithValue, com.looker.sdk.Error>(
+            "/users/$path_user_id/attribute_values/$path_user_attribute_id", mapOf(), body
+        )
     }
 
     /**
@@ -8118,10 +8426,12 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     fun delete_user_attribute_user_value(
         user_id: Long,
         user_attribute_id: Long
-    ): SDKResponse {
+    ): SdkResult<Void, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
         val path_user_attribute_id = encodeParam(user_attribute_id)
-        return this.delete<Void>("/users/$path_user_id/attribute_values/$path_user_attribute_id", mapOf())
+        return this.delete<Void, com.looker.sdk.Error>(
+            "/users/$path_user_id/attribute_values/$path_user_attribute_id", mapOf()
+        )
     }
 
     //endregion User: Manage Users
@@ -8139,8 +8449,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_user_attributes(
         fields: String? = null,
         sorts: String? = null
-    ): SDKResponse {
-        return this.get<Array<UserAttribute>>(
+    ): SdkResult<Array<UserAttribute>, com.looker.sdk.Error> {
+        return this.get<Array<UserAttribute>, com.looker.sdk.Error>(
             "/user_attributes",
             mapOf(
                 "fields" to fields,
@@ -8169,8 +8479,8 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_user_attribute(
         body: WriteUserAttribute,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<UserAttribute>(
+    ): SdkResult<UserAttribute, com.looker.sdk.Error> {
+        return this.post<UserAttribute, com.looker.sdk.Error>(
             "/user_attributes",
             mapOf("fields" to fields), body
         )
@@ -8187,9 +8497,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun user_attribute(
         user_attribute_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<UserAttribute, com.looker.sdk.Error> {
         val path_user_attribute_id = encodeParam(user_attribute_id)
-        return this.get<UserAttribute>(
+        return this.get<UserAttribute, com.looker.sdk.Error>(
             "/user_attributes/$path_user_attribute_id",
             mapOf("fields" to fields)
         )
@@ -8208,9 +8518,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
         user_attribute_id: Long,
         body: WriteUserAttribute,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<UserAttribute, com.looker.sdk.Error> {
         val path_user_attribute_id = encodeParam(user_attribute_id)
-        return this.patch<UserAttribute>(
+        return this.patch<UserAttribute, com.looker.sdk.Error>(
             "/user_attributes/$path_user_attribute_id",
             mapOf("fields" to fields), body
         )
@@ -8225,9 +8535,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_user_attribute(
         user_attribute_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_user_attribute_id = encodeParam(user_attribute_id)
-        return this.delete<String>("/user_attributes/$path_user_attribute_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/user_attributes/$path_user_attribute_id", mapOf()
+        )
     }
 
     /**
@@ -8247,9 +8559,9 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_user_attribute_group_values(
         user_attribute_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<UserAttributeGroupValue>, com.looker.sdk.Error> {
         val path_user_attribute_id = encodeParam(user_attribute_id)
-        return this.get<Array<UserAttributeGroupValue>>(
+        return this.get<Array<UserAttributeGroupValue>, com.looker.sdk.Error>(
             "/user_attributes/$path_user_attribute_id/group_values",
             mapOf("fields" to fields)
         )
@@ -8285,9 +8597,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
     fun set_user_attribute_group_values(
         user_attribute_id: Long,
         body: Array<UserAttributeGroupValue>
-    ): SDKResponse {
+    ): SdkResult<Array<UserAttributeGroupValue>, com.looker.sdk.Error> {
         val path_user_attribute_id = encodeParam(user_attribute_id)
-        return this.post<Array<UserAttributeGroupValue>>("/user_attributes/$path_user_attribute_id/group_values", mapOf(), body)
+        return this.post<Array<UserAttributeGroupValue>, com.looker.sdk.Error>(
+            "/user_attributes/$path_user_attribute_id/group_values", mapOf(), body
+        )
     }
 
     //endregion UserAttribute: Manage User Attributes
@@ -8301,8 +8615,10 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /workspaces -> Array<Workspace>
      */
-    fun all_workspaces(): SDKResponse {
-        return this.get<Array<Workspace>>("/workspaces", mapOf())
+    fun all_workspaces(): SdkResult<Array<Workspace>, com.looker.sdk.Error> {
+        return this.get<Array<Workspace>, com.looker.sdk.Error>(
+            "/workspaces", mapOf()
+        )
     }
 
     /**
@@ -8342,9 +8658,11 @@ class Looker31SDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun workspace(
         workspace_id: String
-    ): SDKResponse {
+    ): SdkResult<Workspace, com.looker.sdk.Error> {
         val path_workspace_id = encodeParam(workspace_id)
-        return this.get<Workspace>("/workspaces/$path_workspace_id", mapOf())
+        return this.get<Workspace, com.looker.sdk.Error>(
+            "/workspaces/$path_workspace_id", mapOf()
+        )
     }
 
     //endregion Workspace: Manage Workspaces

--- a/kotlin/src/main/com/looker/sdk/3.1/streams.kt
+++ b/kotlin/src/main/com/looker/sdk/3.1/streams.kt
@@ -76,8 +76,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun login(
         client_id: String? = null,
         client_secret: String? = null
-    ): SDKResponse {
-        return this.post<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/login",
             mapOf(
                 "client_id" to client_id,
@@ -112,9 +112,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun login_user(
         user_id: Long,
         associative: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.post<ByteArray>(
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/login/$path_user_id",
             mapOf("associative" to associative)
         )
@@ -125,8 +125,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * DELETE /logout -> ByteArray
      */
-    fun logout(): SDKResponse {
-        return this.delete<ByteArray>("/logout", mapOf())
+    fun logout(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/logout", mapOf()
+        )
     }
 
     //endregion ApiAuth: API Authentication
@@ -175,8 +177,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_sso_embed_url(
         body: EmbedSsoParams
-    ): SDKResponse {
-        return this.post<ByteArray>("/embed/sso_url", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/embed/sso_url", mapOf(), body
+        )
     }
 
     /**
@@ -199,8 +203,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /ldap_config -> ByteArray
      */
-    fun ldap_config(): SDKResponse {
-        return this.get<ByteArray>("/ldap_config", mapOf())
+    fun ldap_config(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/ldap_config", mapOf()
+        )
     }
 
     /**
@@ -222,8 +228,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_ldap_config(
         body: WriteLDAPConfig
-    ): SDKResponse {
-        return this.patch<ByteArray>("/ldap_config", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/ldap_config", mapOf(), body
+        )
     }
 
     /**
@@ -252,8 +260,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun test_ldap_config_connection(
         body: WriteLDAPConfig
-    ): SDKResponse {
-        return this.put<ByteArray>("/ldap_config/test_connection", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.put<ByteArray, com.looker.sdk.Error>(
+            "/ldap_config/test_connection", mapOf(), body
+        )
     }
 
     /**
@@ -284,8 +294,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun test_ldap_config_auth(
         body: WriteLDAPConfig
-    ): SDKResponse {
-        return this.put<ByteArray>("/ldap_config/test_auth", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.put<ByteArray, com.looker.sdk.Error>(
+            "/ldap_config/test_auth", mapOf(), body
+        )
     }
 
     /**
@@ -305,8 +317,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun test_ldap_config_user_info(
         body: WriteLDAPConfig
-    ): SDKResponse {
-        return this.put<ByteArray>("/ldap_config/test_user_info", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.put<ByteArray, com.looker.sdk.Error>(
+            "/ldap_config/test_user_info", mapOf(), body
+        )
     }
 
     /**
@@ -326,8 +340,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun test_ldap_config_user_auth(
         body: WriteLDAPConfig
-    ): SDKResponse {
-        return this.put<ByteArray>("/ldap_config/test_user_auth", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.put<ByteArray, com.looker.sdk.Error>(
+            "/ldap_config/test_user_auth", mapOf(), body
+        )
     }
 
     /**
@@ -346,8 +362,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /oidc_config -> ByteArray
      */
-    fun oidc_config(): SDKResponse {
-        return this.get<ByteArray>("/oidc_config", mapOf())
+    fun oidc_config(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/oidc_config", mapOf()
+        )
     }
 
     /**
@@ -367,8 +385,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_oidc_config(
         body: WriteOIDCConfig
-    ): SDKResponse {
-        return this.patch<ByteArray>("/oidc_config", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/oidc_config", mapOf(), body
+        )
     }
 
     /**
@@ -380,9 +400,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun oidc_test_config(
         test_slug: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_test_slug = encodeParam(test_slug)
-        return this.get<ByteArray>("/oidc_test_configs/$path_test_slug", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/oidc_test_configs/$path_test_slug", mapOf()
+        )
     }
 
     /**
@@ -394,9 +416,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_oidc_test_config(
         test_slug: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_test_slug = encodeParam(test_slug)
-        return this.delete<ByteArray>("/oidc_test_configs/$path_test_slug", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/oidc_test_configs/$path_test_slug", mapOf()
+        )
     }
 
     /**
@@ -408,8 +432,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_oidc_test_config(
         body: WriteOIDCConfig
-    ): SDKResponse {
-        return this.post<ByteArray>("/oidc_test_configs", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/oidc_test_configs", mapOf(), body
+        )
     }
 
     /**
@@ -417,8 +443,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /password_config -> ByteArray
      */
-    fun password_config(): SDKResponse {
-        return this.get<ByteArray>("/password_config", mapOf())
+    fun password_config(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/password_config", mapOf()
+        )
     }
 
     /**
@@ -430,8 +458,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_password_config(
         body: WritePasswordConfig
-    ): SDKResponse {
-        return this.patch<ByteArray>("/password_config", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/password_config", mapOf(), body
+        )
     }
 
     /**
@@ -439,8 +469,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * PUT /password_config/force_password_reset_at_next_login_for_all_users -> ByteArray
      */
-    fun force_password_reset_at_next_login_for_all_users(): SDKResponse {
-        return this.put<ByteArray>("/password_config/force_password_reset_at_next_login_for_all_users", mapOf())
+    fun force_password_reset_at_next_login_for_all_users(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.put<ByteArray, com.looker.sdk.Error>(
+            "/password_config/force_password_reset_at_next_login_for_all_users", mapOf()
+        )
     }
 
     /**
@@ -459,8 +491,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /saml_config -> ByteArray
      */
-    fun saml_config(): SDKResponse {
-        return this.get<ByteArray>("/saml_config", mapOf())
+    fun saml_config(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/saml_config", mapOf()
+        )
     }
 
     /**
@@ -480,8 +514,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_saml_config(
         body: WriteSamlConfig
-    ): SDKResponse {
-        return this.patch<ByteArray>("/saml_config", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/saml_config", mapOf(), body
+        )
     }
 
     /**
@@ -493,9 +529,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun saml_test_config(
         test_slug: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_test_slug = encodeParam(test_slug)
-        return this.get<ByteArray>("/saml_test_configs/$path_test_slug", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/saml_test_configs/$path_test_slug", mapOf()
+        )
     }
 
     /**
@@ -507,9 +545,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_saml_test_config(
         test_slug: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_test_slug = encodeParam(test_slug)
-        return this.delete<ByteArray>("/saml_test_configs/$path_test_slug", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/saml_test_configs/$path_test_slug", mapOf()
+        )
     }
 
     /**
@@ -521,8 +561,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_saml_test_config(
         body: WriteSamlConfig
-    ): SDKResponse {
-        return this.post<ByteArray>("/saml_test_configs", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/saml_test_configs", mapOf(), body
+        )
     }
 
     /**
@@ -534,8 +576,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun parse_saml_idp_metadata(
         body: String
-    ): SDKResponse {
-        return this.post<ByteArray>("/parse_saml_idp_metadata", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/parse_saml_idp_metadata", mapOf(), body
+        )
     }
 
     /**
@@ -549,8 +593,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun fetch_and_parse_saml_idp_metadata(
         body: String
-    ): SDKResponse {
-        return this.post<ByteArray>("/fetch_and_parse_saml_idp_metadata", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/fetch_and_parse_saml_idp_metadata", mapOf(), body
+        )
     }
 
     /**
@@ -558,8 +604,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /session_config -> ByteArray
      */
-    fun session_config(): SDKResponse {
-        return this.get<ByteArray>("/session_config", mapOf())
+    fun session_config(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/session_config", mapOf()
+        )
     }
 
     /**
@@ -571,8 +619,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_session_config(
         body: WriteSessionConfig
-    ): SDKResponse {
-        return this.patch<ByteArray>("/session_config", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/session_config", mapOf(), body
+        )
     }
 
     /**
@@ -584,8 +634,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_user_login_lockouts(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/user_login_lockouts",
             mapOf("fields" to fields)
         )
@@ -616,8 +666,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         email: String? = null,
         remote_id: String? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/user_login_lockouts/search",
             mapOf(
                 "fields" to fields,
@@ -642,9 +692,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_user_login_lockout(
         key: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_key = encodeParam(key)
-        return this.delete<ByteArray>("/user_login_lockout/$path_key", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/user_login_lockout/$path_key", mapOf()
+        )
     }
 
     //endregion Auth: Manage User Authentication Configuration
@@ -667,8 +719,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_color_collections(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/color_collections",
             mapOf("fields" to fields)
         )
@@ -691,8 +743,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_color_collection(
         body: WriteColorCollection
-    ): SDKResponse {
-        return this.post<ByteArray>("/color_collections", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/color_collections", mapOf(), body
+        )
     }
 
     /**
@@ -709,8 +763,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun color_collections_custom(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/color_collections/custom",
             mapOf("fields" to fields)
         )
@@ -730,8 +784,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun color_collections_standard(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/color_collections/standard",
             mapOf("fields" to fields)
         )
@@ -746,8 +800,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /color_collections/default -> ByteArray
      */
-    fun default_color_collection(): SDKResponse {
-        return this.get<ByteArray>("/color_collections/default", mapOf())
+    fun default_color_collection(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/color_collections/default", mapOf()
+        )
     }
 
     /**
@@ -762,8 +818,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun set_default_color_collection(
         collection_id: String
-    ): SDKResponse {
-        return this.put<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.put<ByteArray, com.looker.sdk.Error>(
             "/color_collections/default",
             mapOf("collection_id" to collection_id)
         )
@@ -789,9 +845,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun color_collection(
         collection_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_collection_id = encodeParam(collection_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/color_collections/$path_collection_id",
             mapOf("fields" to fields)
         )
@@ -809,9 +865,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun update_color_collection(
         collection_id: String,
         body: WriteColorCollection
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_collection_id = encodeParam(collection_id)
-        return this.patch<ByteArray>("/color_collections/$path_collection_id", mapOf(), body)
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/color_collections/$path_collection_id", mapOf(), body
+        )
     }
 
     /**
@@ -830,9 +888,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_color_collection(
         collection_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_collection_id = encodeParam(collection_id)
-        return this.delete<ByteArray>("/color_collections/$path_collection_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/color_collections/$path_collection_id", mapOf()
+        )
     }
 
     //endregion ColorCollection: Manage Color Collections
@@ -844,8 +904,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /backup_configuration -> ByteArray
      */
-    fun backup_configuration(): SDKResponse {
-        return this.get<ByteArray>("/backup_configuration", mapOf())
+    fun backup_configuration(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/backup_configuration", mapOf()
+        )
     }
 
     /**
@@ -857,8 +919,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_backup_configuration(
         body: WriteBackupConfiguration
-    ): SDKResponse {
-        return this.patch<ByteArray>("/backup_configuration", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/backup_configuration", mapOf(), body
+        )
     }
 
     /**
@@ -866,8 +930,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /cloud_storage -> ByteArray
      */
-    fun cloud_storage_configuration(): SDKResponse {
-        return this.get<ByteArray>("/cloud_storage", mapOf())
+    fun cloud_storage_configuration(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/cloud_storage", mapOf()
+        )
     }
 
     /**
@@ -879,8 +945,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_cloud_storage_configuration(
         body: WriteBackupConfiguration
-    ): SDKResponse {
-        return this.patch<ByteArray>("/cloud_storage", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/cloud_storage", mapOf(), body
+        )
     }
 
     /**
@@ -888,8 +956,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /custom_welcome_email -> ByteArray
      */
-    fun custom_welcome_email(): SDKResponse {
-        return this.get<ByteArray>("/custom_welcome_email", mapOf())
+    fun custom_welcome_email(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/custom_welcome_email", mapOf()
+        )
     }
 
     /**
@@ -903,8 +973,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun update_custom_welcome_email(
         body: WriteCustomWelcomeEmail,
         send_test_welcome_email: Boolean? = null
-    ): SDKResponse {
-        return this.patch<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.patch<ByteArray, com.looker.sdk.Error>(
             "/custom_welcome_email",
             mapOf("send_test_welcome_email" to send_test_welcome_email), body
         )
@@ -919,8 +989,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_custom_welcome_email_test(
         body: WelcomeEmailTest
-    ): SDKResponse {
-        return this.put<ByteArray>("/custom_welcome_email_test", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.put<ByteArray, com.looker.sdk.Error>(
+            "/custom_welcome_email_test", mapOf(), body
+        )
     }
 
     /**
@@ -928,8 +1000,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /digest_emails_enabled -> ByteArray
      */
-    fun digest_emails_enabled(): SDKResponse {
-        return this.get<ByteArray>("/digest_emails_enabled", mapOf())
+    fun digest_emails_enabled(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/digest_emails_enabled", mapOf()
+        )
     }
 
     /**
@@ -941,8 +1015,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_digest_emails_enabled(
         body: DigestEmails
-    ): SDKResponse {
-        return this.patch<ByteArray>("/digest_emails_enabled", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/digest_emails_enabled", mapOf(), body
+        )
     }
 
     /**
@@ -952,8 +1028,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * POST /digest_email_send -> ByteArray
      */
-    fun create_digest_email_send(): SDKResponse {
-        return this.post<ByteArray>("/digest_email_send", mapOf())
+    fun create_digest_email_send(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/digest_email_send", mapOf()
+        )
     }
 
     /**
@@ -961,8 +1039,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /internal_help_resources_content -> ByteArray
      */
-    fun internal_help_resources_content(): SDKResponse {
-        return this.get<ByteArray>("/internal_help_resources_content", mapOf())
+    fun internal_help_resources_content(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/internal_help_resources_content", mapOf()
+        )
     }
 
     /**
@@ -974,8 +1054,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_internal_help_resources_content(
         body: WriteInternalHelpResourcesContent
-    ): SDKResponse {
-        return this.patch<ByteArray>("/internal_help_resources_content", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/internal_help_resources_content", mapOf(), body
+        )
     }
 
     /**
@@ -983,8 +1065,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /internal_help_resources_enabled -> ByteArray
      */
-    fun internal_help_resources(): SDKResponse {
-        return this.get<ByteArray>("/internal_help_resources_enabled", mapOf())
+    fun internal_help_resources(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/internal_help_resources_enabled", mapOf()
+        )
     }
 
     /**
@@ -996,8 +1080,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_internal_help_resources(
         body: WriteInternalHelpResources
-    ): SDKResponse {
-        return this.patch<ByteArray>("/internal_help_resources", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/internal_help_resources", mapOf(), body
+        )
     }
 
     /**
@@ -1005,8 +1091,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /legacy_features -> ByteArray
      */
-    fun all_legacy_features(): SDKResponse {
-        return this.get<ByteArray>("/legacy_features", mapOf())
+    fun all_legacy_features(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/legacy_features", mapOf()
+        )
     }
 
     /**
@@ -1018,9 +1106,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun legacy_feature(
         legacy_feature_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_legacy_feature_id = encodeParam(legacy_feature_id)
-        return this.get<ByteArray>("/legacy_features/$path_legacy_feature_id", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/legacy_features/$path_legacy_feature_id", mapOf()
+        )
     }
 
     /**
@@ -1034,9 +1124,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun update_legacy_feature(
         legacy_feature_id: Long,
         body: WriteLegacyFeature
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_legacy_feature_id = encodeParam(legacy_feature_id)
-        return this.patch<ByteArray>("/legacy_features/$path_legacy_feature_id", mapOf(), body)
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/legacy_features/$path_legacy_feature_id", mapOf(), body
+        )
     }
 
     /**
@@ -1044,8 +1136,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /locales -> ByteArray
      */
-    fun all_locales(): SDKResponse {
-        return this.get<ByteArray>("/locales", mapOf())
+    fun all_locales(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/locales", mapOf()
+        )
     }
 
     /**
@@ -1053,8 +1147,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /timezones -> ByteArray
      */
-    fun all_timezones(): SDKResponse {
-        return this.get<ByteArray>("/timezones", mapOf())
+    fun all_timezones(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/timezones", mapOf()
+        )
     }
 
     /**
@@ -1066,8 +1162,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun versions(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/versions",
             mapOf("fields" to fields)
         )
@@ -1083,8 +1179,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun whitelabel_configuration(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/whitelabel_configuration",
             mapOf("fields" to fields)
         )
@@ -1099,8 +1195,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_whitelabel_configuration(
         body: WriteWhitelabelConfiguration
-    ): SDKResponse {
-        return this.put<ByteArray>("/whitelabel_configuration", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.put<ByteArray, com.looker.sdk.Error>(
+            "/whitelabel_configuration", mapOf(), body
+        )
     }
 
     //endregion Config: Manage General Configuration
@@ -1116,8 +1214,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_connections(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/connections",
             mapOf("fields" to fields)
         )
@@ -1132,8 +1230,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_connection(
         body: WriteDBConnection
-    ): SDKResponse {
-        return this.post<ByteArray>("/connections", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/connections", mapOf(), body
+        )
     }
 
     /**
@@ -1147,9 +1247,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun connection(
         connection_name: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_connection_name = encodeParam(connection_name)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/connections/$path_connection_name",
             mapOf("fields" to fields)
         )
@@ -1166,9 +1266,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun update_connection(
         connection_name: String,
         body: WriteDBConnection
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_connection_name = encodeParam(connection_name)
-        return this.patch<ByteArray>("/connections/$path_connection_name", mapOf(), body)
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/connections/$path_connection_name", mapOf(), body
+        )
     }
 
     /**
@@ -1180,9 +1282,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_connection(
         connection_name: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_connection_name = encodeParam(connection_name)
-        return this.delete<ByteArray>("/connections/$path_connection_name", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/connections/$path_connection_name", mapOf()
+        )
     }
 
     /**
@@ -1196,10 +1300,12 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun delete_connection_override(
         connection_name: String,
         override_context: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_connection_name = encodeParam(connection_name)
         val path_override_context = encodeParam(override_context)
-        return this.delete<ByteArray>("/connections/$path_connection_name/connection_override/$path_override_context", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/connections/$path_connection_name/connection_override/$path_override_context", mapOf()
+        )
     }
 
     /**
@@ -1220,9 +1326,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun test_connection(
         connection_name: String,
         tests: DelimArray<String>? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_connection_name = encodeParam(connection_name)
-        return this.put<ByteArray>(
+        return this.put<ByteArray, com.looker.sdk.Error>(
             "/connections/$path_connection_name/test",
             mapOf("tests" to tests)
         )
@@ -1246,8 +1352,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun test_connection_config(
         body: WriteDBConnection,
         tests: DelimArray<String>? = null
-    ): SDKResponse {
-        return this.put<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.put<ByteArray, com.looker.sdk.Error>(
             "/connections/test",
             mapOf("tests" to tests), body
         )
@@ -1262,8 +1368,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_dialect_infos(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/dialect_info",
             mapOf("fields" to fields)
         )
@@ -1321,8 +1427,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         sorts: String? = null,
         fields: String? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/content_favorite/search",
             mapOf(
                 "id" to id,
@@ -1350,9 +1456,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun content_favorite(
         content_favorite_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_content_favorite_id = encodeParam(content_favorite_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/content_favorite/$path_content_favorite_id",
             mapOf("fields" to fields)
         )
@@ -1367,9 +1473,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_content_favorite(
         content_favorite_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_content_favorite_id = encodeParam(content_favorite_id)
-        return this.delete<ByteArray>("/content_favorite/$path_content_favorite_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/content_favorite/$path_content_favorite_id", mapOf()
+        )
     }
 
     /**
@@ -1381,8 +1489,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_content_favorite(
         body: WriteContentFavorite
-    ): SDKResponse {
-        return this.post<ByteArray>("/content_favorite", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/content_favorite", mapOf(), body
+        )
     }
 
     /**
@@ -1396,8 +1506,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_content_metadatas(
         parent_id: Long,
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/content_metadata",
             mapOf(
                 "parent_id" to parent_id,
@@ -1417,9 +1527,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun content_metadata(
         content_metadata_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_content_metadata_id = encodeParam(content_metadata_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/content_metadata/$path_content_metadata_id",
             mapOf("fields" to fields)
         )
@@ -1436,9 +1546,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun update_content_metadata(
         content_metadata_id: Long,
         body: WriteContentMeta
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_content_metadata_id = encodeParam(content_metadata_id)
-        return this.patch<ByteArray>("/content_metadata/$path_content_metadata_id", mapOf(), body)
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/content_metadata/$path_content_metadata_id", mapOf(), body
+        )
     }
 
     /**
@@ -1452,8 +1564,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_content_metadata_accesses(
         content_metadata_id: Long,
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/content_metadata_access",
             mapOf(
                 "content_metadata_id" to content_metadata_id,
@@ -1473,8 +1585,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_content_metadata_access(
         body: ContentMetaGroupUser,
         send_boards_notification_email: Boolean? = null
-    ): SDKResponse {
-        return this.post<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/content_metadata_access",
             mapOf("send_boards_notification_email" to send_boards_notification_email), body
         )
@@ -1491,9 +1603,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun update_content_metadata_access(
         content_metadata_access_id: Long,
         body: ContentMetaGroupUser
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_content_metadata_access_id = encodeParam(content_metadata_access_id)
-        return this.put<ByteArray>("/content_metadata_access/$path_content_metadata_access_id", mapOf(), body)
+        return this.put<ByteArray, com.looker.sdk.Error>(
+            "/content_metadata_access/$path_content_metadata_access_id", mapOf(), body
+        )
     }
 
     /**
@@ -1505,9 +1619,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_content_metadata_access(
         content_metadata_access_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_content_metadata_access_id = encodeParam(content_metadata_access_id)
-        return this.delete<ByteArray>("/content_metadata_access/$path_content_metadata_access_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/content_metadata_access/$path_content_metadata_access_id", mapOf()
+        )
     }
 
     /**
@@ -1534,10 +1650,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         format: String? = null,
         width: Long? = null,
         height: Long? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_type = encodeParam(type)
         val path_resource_id = encodeParam(resource_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/content_thumbnail/$path_type/$path_resource_id",
             mapOf(
                 "reload" to reload,
@@ -1560,8 +1676,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun content_validation(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/content_validation",
             mapOf("fields" to fields)
         )
@@ -1621,8 +1737,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         offset: Long? = null,
         sorts: String? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/content_view/search",
             mapOf(
                 "view_count" to view_count,
@@ -1660,10 +1776,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         type: String,
         resource_id: String,
         reload: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_type = encodeParam(type)
         val path_resource_id = encodeParam(resource_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/vector_thumbnail/$path_type/$path_resource_id",
             mapOf("reload" to reload)
         )
@@ -1688,8 +1804,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_dashboards(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/dashboards",
             mapOf("fields" to fields)
         )
@@ -1717,8 +1833,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_dashboard(
         body: WriteDashboard
-    ): SDKResponse {
-        return this.post<ByteArray>("/dashboards", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/dashboards", mapOf(), body
+        )
     }
 
     /**
@@ -1794,8 +1912,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         offset: Long? = null,
         sorts: String? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/dashboards/search",
             mapOf(
                 "id" to id,
@@ -1847,10 +1965,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         space_id: String,
         body: WriteDashboard? = null,
         raw_locale: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_lookml_dashboard_id = encodeParam(lookml_dashboard_id)
         val path_space_id = encodeParam(space_id)
-        return this.post<ByteArray>(
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/dashboards/$path_lookml_dashboard_id/import/$path_space_id",
             mapOf("raw_locale" to raw_locale), body
         )
@@ -1877,9 +1995,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         lookml_dashboard_id: String,
         body: WriteDashboard,
         raw_locale: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_lookml_dashboard_id = encodeParam(lookml_dashboard_id)
-        return this.patch<ByteArray>(
+        return this.patch<ByteArray, com.looker.sdk.Error>(
             "/dashboards/$path_lookml_dashboard_id/sync",
             mapOf("raw_locale" to raw_locale), body
         )
@@ -1902,9 +2020,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun dashboard(
         dashboard_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/dashboards/$path_dashboard_id",
             mapOf("fields" to fields)
         )
@@ -1930,9 +2048,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun update_dashboard(
         dashboard_id: String,
         body: WriteDashboard
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
-        return this.patch<ByteArray>("/dashboards/$path_dashboard_id", mapOf(), body)
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/dashboards/$path_dashboard_id", mapOf(), body
+        )
     }
 
     /**
@@ -1950,9 +2070,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_dashboard(
         dashboard_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
-        return this.delete<ByteArray>("/dashboards/$path_dashboard_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/dashboards/$path_dashboard_id", mapOf()
+        )
     }
 
     /**
@@ -1966,9 +2088,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun dashboard_aggregate_table_lookml(
         dashboard_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
-        return this.get<ByteArray>("/dashboards/aggregate_table_lookml/$path_dashboard_id", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/dashboards/aggregate_table_lookml/$path_dashboard_id", mapOf()
+        )
     }
 
     /**
@@ -1982,9 +2106,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun dashboard_lookml(
         dashboard_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
-        return this.get<ByteArray>("/dashboards/lookml/$path_dashboard_id", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/dashboards/lookml/$path_dashboard_id", mapOf()
+        )
     }
 
     /**
@@ -2031,8 +2157,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         fields: String? = null,
         filter_or: Boolean? = null,
         sorts: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/dashboard_elements/search",
             mapOf(
                 "dashboard_id" to dashboard_id,
@@ -2057,9 +2183,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun dashboard_element(
         dashboard_element_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_element_id = encodeParam(dashboard_element_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/dashboard_elements/$path_dashboard_element_id",
             mapOf("fields" to fields)
         )
@@ -2078,9 +2204,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         dashboard_element_id: String,
         body: WriteDashboardElement,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_element_id = encodeParam(dashboard_element_id)
-        return this.patch<ByteArray>(
+        return this.patch<ByteArray, com.looker.sdk.Error>(
             "/dashboard_elements/$path_dashboard_element_id",
             mapOf("fields" to fields), body
         )
@@ -2095,9 +2221,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_dashboard_element(
         dashboard_element_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_element_id = encodeParam(dashboard_element_id)
-        return this.delete<ByteArray>("/dashboard_elements/$path_dashboard_element_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/dashboard_elements/$path_dashboard_element_id", mapOf()
+        )
     }
 
     /**
@@ -2111,9 +2239,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun dashboard_dashboard_elements(
         dashboard_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/dashboards/$path_dashboard_id/dashboard_elements",
             mapOf("fields" to fields)
         )
@@ -2130,8 +2258,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_dashboard_element(
         body: WriteDashboardElement,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/dashboard_elements",
             mapOf("fields" to fields), body
         )
@@ -2148,9 +2276,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun dashboard_filter(
         dashboard_filter_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_filter_id = encodeParam(dashboard_filter_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/dashboard_filters/$path_dashboard_filter_id",
             mapOf("fields" to fields)
         )
@@ -2169,9 +2297,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         dashboard_filter_id: String,
         body: WriteDashboardFilter,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_filter_id = encodeParam(dashboard_filter_id)
-        return this.patch<ByteArray>(
+        return this.patch<ByteArray, com.looker.sdk.Error>(
             "/dashboard_filters/$path_dashboard_filter_id",
             mapOf("fields" to fields), body
         )
@@ -2186,9 +2314,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_dashboard_filter(
         dashboard_filter_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_filter_id = encodeParam(dashboard_filter_id)
-        return this.delete<ByteArray>("/dashboard_filters/$path_dashboard_filter_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/dashboard_filters/$path_dashboard_filter_id", mapOf()
+        )
     }
 
     /**
@@ -2202,9 +2332,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun dashboard_dashboard_filters(
         dashboard_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/dashboards/$path_dashboard_id/dashboard_filters",
             mapOf("fields" to fields)
         )
@@ -2221,8 +2351,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_dashboard_filter(
         body: WriteCreateDashboardFilter,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/dashboard_filters",
             mapOf("fields" to fields), body
         )
@@ -2239,9 +2369,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun dashboard_layout_component(
         dashboard_layout_component_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_layout_component_id = encodeParam(dashboard_layout_component_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/dashboard_layout_components/$path_dashboard_layout_component_id",
             mapOf("fields" to fields)
         )
@@ -2260,9 +2390,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         dashboard_layout_component_id: String,
         body: WriteDashboardLayoutComponent,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_layout_component_id = encodeParam(dashboard_layout_component_id)
-        return this.patch<ByteArray>(
+        return this.patch<ByteArray, com.looker.sdk.Error>(
             "/dashboard_layout_components/$path_dashboard_layout_component_id",
             mapOf("fields" to fields), body
         )
@@ -2279,9 +2409,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun dashboard_layout_dashboard_layout_components(
         dashboard_layout_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_layout_id = encodeParam(dashboard_layout_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/dashboard_layouts/$path_dashboard_layout_id/dashboard_layout_components",
             mapOf("fields" to fields)
         )
@@ -2298,9 +2428,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun dashboard_layout(
         dashboard_layout_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_layout_id = encodeParam(dashboard_layout_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/dashboard_layouts/$path_dashboard_layout_id",
             mapOf("fields" to fields)
         )
@@ -2319,9 +2449,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         dashboard_layout_id: String,
         body: WriteDashboardLayout,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_layout_id = encodeParam(dashboard_layout_id)
-        return this.patch<ByteArray>(
+        return this.patch<ByteArray, com.looker.sdk.Error>(
             "/dashboard_layouts/$path_dashboard_layout_id",
             mapOf("fields" to fields), body
         )
@@ -2336,9 +2466,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_dashboard_layout(
         dashboard_layout_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_layout_id = encodeParam(dashboard_layout_id)
-        return this.delete<ByteArray>("/dashboard_layouts/$path_dashboard_layout_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/dashboard_layouts/$path_dashboard_layout_id", mapOf()
+        )
     }
 
     /**
@@ -2352,9 +2484,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun dashboard_dashboard_layouts(
         dashboard_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/dashboards/$path_dashboard_id/dashboard_layouts",
             mapOf("fields" to fields)
         )
@@ -2371,8 +2503,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_dashboard_layout(
         body: WriteDashboardLayout,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/dashboard_layouts",
             mapOf("fields" to fields), body
         )
@@ -2391,8 +2523,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun perform_data_action(
         body: DataActionRequest
-    ): SDKResponse {
-        return this.post<ByteArray>("/data_actions", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/data_actions", mapOf(), body
+        )
     }
 
     /**
@@ -2404,8 +2538,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun fetch_remote_data_action_form(
         body: Map<String, Any>
-    ): SDKResponse {
-        return this.post<ByteArray>("/data_actions/form", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/data_actions/form", mapOf(), body
+        )
     }
 
     //endregion DataAction: Run Data Actions
@@ -2417,8 +2553,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /datagroups -> ByteArray
      */
-    fun all_datagroups(): SDKResponse {
-        return this.get<ByteArray>("/datagroups", mapOf())
+    fun all_datagroups(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/datagroups", mapOf()
+        )
     }
 
     /**
@@ -2430,9 +2568,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun datagroup(
         datagroup_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_datagroup_id = encodeParam(datagroup_id)
-        return this.get<ByteArray>("/datagroups/$path_datagroup_id", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/datagroups/$path_datagroup_id", mapOf()
+        )
     }
 
     /**
@@ -2446,9 +2586,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun update_datagroup(
         datagroup_id: String,
         body: WriteDatagroup
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_datagroup_id = encodeParam(datagroup_id)
-        return this.patch<ByteArray>("/datagroups/$path_datagroup_id", mapOf(), body)
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/datagroups/$path_datagroup_id", mapOf(), body
+        )
     }
 
     //endregion Datagroup: Manage Datagroups
@@ -2484,8 +2626,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         parent_id: String? = null,
         creator_id: String? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/folders/search",
             mapOf(
                 "fields" to fields,
@@ -2514,9 +2656,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun folder(
         folder_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_folder_id = encodeParam(folder_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/folders/$path_folder_id",
             mapOf("fields" to fields)
         )
@@ -2533,9 +2675,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun update_folder(
         folder_id: String,
         body: UpdateFolder
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_folder_id = encodeParam(folder_id)
-        return this.patch<ByteArray>("/folders/$path_folder_id", mapOf(), body)
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/folders/$path_folder_id", mapOf(), body
+        )
     }
 
     /**
@@ -2548,9 +2692,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_folder(
         folder_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_folder_id = encodeParam(folder_id)
-        return this.delete<ByteArray>("/folders/$path_folder_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/folders/$path_folder_id", mapOf()
+        )
     }
 
     /**
@@ -2562,8 +2708,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_folders(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/folders",
             mapOf("fields" to fields)
         )
@@ -2581,8 +2727,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_folder(
         body: CreateFolder
-    ): SDKResponse {
-        return this.post<ByteArray>("/folders", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/folders", mapOf(), body
+        )
     }
 
     /**
@@ -2602,9 +2750,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         page: Long? = null,
         per_page: Long? = null,
         sorts: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_folder_id = encodeParam(folder_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/folders/$path_folder_id/children",
             mapOf(
                 "fields" to fields,
@@ -2630,9 +2778,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         fields: String? = null,
         sorts: String? = null,
         name: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_folder_id = encodeParam(folder_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/folders/$path_folder_id/children/search",
             mapOf(
                 "fields" to fields,
@@ -2653,9 +2801,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun folder_parent(
         folder_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_folder_id = encodeParam(folder_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/folders/$path_folder_id/parent",
             mapOf("fields" to fields)
         )
@@ -2672,9 +2820,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun folder_ancestors(
         folder_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_folder_id = encodeParam(folder_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/folders/$path_folder_id/ancestors",
             mapOf("fields" to fields)
         )
@@ -2691,9 +2839,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun folder_looks(
         folder_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_folder_id = encodeParam(folder_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/folders/$path_folder_id/looks",
             mapOf("fields" to fields)
         )
@@ -2710,9 +2858,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun folder_dashboards(
         folder_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_folder_id = encodeParam(folder_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/folders/$path_folder_id/dashboards",
             mapOf("fields" to fields)
         )
@@ -2743,8 +2891,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         ids: DelimArray<Long>? = null,
         content_metadata_id: Long? = null,
         can_add_to_content_metadata: Boolean? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/groups",
             mapOf(
                 "fields" to fields,
@@ -2769,8 +2917,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_group(
         body: WriteGroup,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/groups",
             mapOf("fields" to fields), body
         )
@@ -2826,8 +2974,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         external_group_id: String? = null,
         externally_managed: Boolean? = null,
         externally_orphaned: Boolean? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/groups/search",
             mapOf(
                 "fields" to fields,
@@ -2855,9 +3003,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun group(
         group_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/groups/$path_group_id",
             mapOf("fields" to fields)
         )
@@ -2876,9 +3024,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         group_id: Long,
         body: WriteGroup,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
-        return this.patch<ByteArray>(
+        return this.patch<ByteArray, com.looker.sdk.Error>(
             "/groups/$path_group_id",
             mapOf("fields" to fields), body
         )
@@ -2893,9 +3041,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_group(
         group_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
-        return this.delete<ByteArray>("/groups/$path_group_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/groups/$path_group_id", mapOf()
+        )
     }
 
     /**
@@ -2909,9 +3059,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_group_groups(
         group_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/groups/$path_group_id/groups",
             mapOf("fields" to fields)
         )
@@ -2928,9 +3078,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun add_group_group(
         group_id: Long,
         body: GroupIdForGroupInclusion
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
-        return this.post<ByteArray>("/groups/$path_group_id/groups", mapOf(), body)
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/groups/$path_group_id/groups", mapOf(), body
+        )
     }
 
     /**
@@ -2950,9 +3102,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         page: Long? = null,
         per_page: Long? = null,
         sorts: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/groups/$path_group_id/users",
             mapOf(
                 "fields" to fields,
@@ -2974,9 +3126,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun add_group_user(
         group_id: Long,
         body: GroupIdForGroupUserInclusion
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
-        return this.post<ByteArray>("/groups/$path_group_id/users", mapOf(), body)
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/groups/$path_group_id/users", mapOf(), body
+        )
     }
 
     /**
@@ -2990,10 +3144,12 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun delete_group_user(
         group_id: Long,
         user_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
         val path_user_id = encodeParam(user_id)
-        return this.delete<ByteArray>("/groups/$path_group_id/users/$path_user_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/groups/$path_group_id/users/$path_user_id", mapOf()
+        )
     }
 
     /**
@@ -3007,10 +3163,12 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun delete_group_from_group(
         group_id: Long,
         deleting_group_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
         val path_deleting_group_id = encodeParam(deleting_group_id)
-        return this.delete<ByteArray>("/groups/$path_group_id/groups/$path_deleting_group_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/groups/$path_group_id/groups/$path_deleting_group_id", mapOf()
+        )
     }
 
     /**
@@ -3028,10 +3186,12 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         group_id: Long,
         user_attribute_id: Long,
         body: UserAttributeGroupValue
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
         val path_user_attribute_id = encodeParam(user_attribute_id)
-        return this.patch<ByteArray>("/groups/$path_group_id/attribute_values/$path_user_attribute_id", mapOf(), body)
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/groups/$path_group_id/attribute_values/$path_user_attribute_id", mapOf(), body
+        )
     }
 
     /**
@@ -3045,10 +3205,12 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun delete_user_attribute_group_value(
         group_id: Long,
         user_attribute_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
         val path_user_attribute_id = encodeParam(user_attribute_id)
-        return this.delete<ByteArray>("/groups/$path_group_id/attribute_values/$path_user_attribute_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/groups/$path_group_id/attribute_values/$path_user_attribute_id", mapOf()
+        )
     }
 
     //endregion Group: Manage Groups
@@ -3064,8 +3226,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_homepages(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/homepages",
             mapOf("fields" to fields)
         )
@@ -3082,8 +3244,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_homepage(
         body: WriteHomepage,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/homepages",
             mapOf("fields" to fields), body
         )
@@ -3143,8 +3305,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         limit: Long? = null,
         sorts: String? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/homepages/search",
             mapOf(
                 "title" to title,
@@ -3175,9 +3337,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun homepage(
         homepage_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_homepage_id = encodeParam(homepage_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/homepages/$path_homepage_id",
             mapOf("fields" to fields)
         )
@@ -3196,9 +3358,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         homepage_id: Long,
         body: WriteHomepage,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_homepage_id = encodeParam(homepage_id)
-        return this.patch<ByteArray>(
+        return this.patch<ByteArray, com.looker.sdk.Error>(
             "/homepages/$path_homepage_id",
             mapOf("fields" to fields), body
         )
@@ -3213,9 +3375,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_homepage(
         homepage_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_homepage_id = encodeParam(homepage_id)
-        return this.delete<ByteArray>("/homepages/$path_homepage_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/homepages/$path_homepage_id", mapOf()
+        )
     }
 
     /**
@@ -3231,8 +3395,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         fields: String? = null,
         sorts: String? = null,
         homepage_section_id: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/homepage_items",
             mapOf(
                 "fields" to fields,
@@ -3253,8 +3417,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_homepage_item(
         body: WriteHomepageItem,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/homepage_items",
             mapOf("fields" to fields), body
         )
@@ -3271,9 +3435,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun homepage_item(
         homepage_item_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_homepage_item_id = encodeParam(homepage_item_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/homepage_items/$path_homepage_item_id",
             mapOf("fields" to fields)
         )
@@ -3292,9 +3456,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         homepage_item_id: Long,
         body: WriteHomepageItem,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_homepage_item_id = encodeParam(homepage_item_id)
-        return this.patch<ByteArray>(
+        return this.patch<ByteArray, com.looker.sdk.Error>(
             "/homepage_items/$path_homepage_item_id",
             mapOf("fields" to fields), body
         )
@@ -3309,9 +3473,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_homepage_item(
         homepage_item_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_homepage_item_id = encodeParam(homepage_item_id)
-        return this.delete<ByteArray>("/homepage_items/$path_homepage_item_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/homepage_items/$path_homepage_item_id", mapOf()
+        )
     }
 
     /**
@@ -3325,8 +3491,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_homepage_sections(
         fields: String? = null,
         sorts: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/homepage_sections",
             mapOf(
                 "fields" to fields,
@@ -3346,8 +3512,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_homepage_section(
         body: WriteHomepageSection,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/homepage_sections",
             mapOf("fields" to fields), body
         )
@@ -3364,9 +3530,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun homepage_section(
         homepage_section_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_homepage_section_id = encodeParam(homepage_section_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/homepage_sections/$path_homepage_section_id",
             mapOf("fields" to fields)
         )
@@ -3385,9 +3551,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         homepage_section_id: Long,
         body: WriteHomepageSection,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_homepage_section_id = encodeParam(homepage_section_id)
-        return this.patch<ByteArray>(
+        return this.patch<ByteArray, com.looker.sdk.Error>(
             "/homepage_sections/$path_homepage_section_id",
             mapOf("fields" to fields), body
         )
@@ -3402,9 +3568,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_homepage_section(
         homepage_section_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_homepage_section_id = encodeParam(homepage_section_id)
-        return this.delete<ByteArray>("/homepage_sections/$path_homepage_section_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/homepage_sections/$path_homepage_section_id", mapOf()
+        )
     }
 
     /**
@@ -3416,8 +3584,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_primary_homepage_sections(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/primary_homepage_sections",
             mapOf("fields" to fields)
         )
@@ -3436,8 +3604,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_integration_hubs(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/integration_hubs",
             mapOf("fields" to fields)
         )
@@ -3456,8 +3624,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_integration_hub(
         body: WriteIntegrationHub,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/integration_hubs",
             mapOf("fields" to fields), body
         )
@@ -3474,9 +3642,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun integration_hub(
         integration_hub_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_integration_hub_id = encodeParam(integration_hub_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/integration_hubs/$path_integration_hub_id",
             mapOf("fields" to fields)
         )
@@ -3497,9 +3665,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         integration_hub_id: Long,
         body: WriteIntegrationHub,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_integration_hub_id = encodeParam(integration_hub_id)
-        return this.patch<ByteArray>(
+        return this.patch<ByteArray, com.looker.sdk.Error>(
             "/integration_hubs/$path_integration_hub_id",
             mapOf("fields" to fields), body
         )
@@ -3514,9 +3682,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_integration_hub(
         integration_hub_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_integration_hub_id = encodeParam(integration_hub_id)
-        return this.delete<ByteArray>("/integration_hubs/$path_integration_hub_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/integration_hubs/$path_integration_hub_id", mapOf()
+        )
     }
 
     /**
@@ -3528,9 +3698,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun accept_integration_hub_legal_agreement(
         integration_hub_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_integration_hub_id = encodeParam(integration_hub_id)
-        return this.post<ByteArray>("/integration_hubs/$path_integration_hub_id/accept_legal_agreement", mapOf())
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/integration_hubs/$path_integration_hub_id/accept_legal_agreement", mapOf()
+        )
     }
 
     /**
@@ -3544,8 +3716,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_integrations(
         fields: String? = null,
         integration_hub_id: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/integrations",
             mapOf(
                 "fields" to fields,
@@ -3565,9 +3737,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun integration(
         integration_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_integration_id = encodeParam(integration_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/integrations/$path_integration_id",
             mapOf("fields" to fields)
         )
@@ -3586,9 +3758,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         integration_id: String,
         body: WriteIntegration,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_integration_id = encodeParam(integration_id)
-        return this.patch<ByteArray>(
+        return this.patch<ByteArray, com.looker.sdk.Error>(
             "/integrations/$path_integration_id",
             mapOf("fields" to fields), body
         )
@@ -3605,9 +3777,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun fetch_integration_form(
         integration_id: String,
         body: Map<String, Any>? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_integration_id = encodeParam(integration_id)
-        return this.post<ByteArray>("/integrations/$path_integration_id/form", mapOf(), body)
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/integrations/$path_integration_id/form", mapOf(), body
+        )
     }
 
     /**
@@ -3619,9 +3793,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun test_integration(
         integration_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_integration_id = encodeParam(integration_id)
-        return this.post<ByteArray>("/integrations/$path_integration_id/test", mapOf())
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/integrations/$path_integration_id/test", mapOf()
+        )
     }
 
     //endregion Integration: Manage Integrations
@@ -3643,8 +3819,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_looks(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/looks",
             mapOf("fields" to fields)
         )
@@ -3667,8 +3843,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_look(
         body: WriteLookWithQuery,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/looks",
             mapOf("fields" to fields), body
         )
@@ -3741,8 +3917,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         offset: Long? = null,
         sorts: String? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/looks/search",
             mapOf(
                 "id" to id,
@@ -3779,9 +3955,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun look(
         look_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_look_id = encodeParam(look_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/looks/$path_look_id",
             mapOf("fields" to fields)
         )
@@ -3819,9 +3995,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         look_id: Long,
         body: WriteLookWithQuery,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_look_id = encodeParam(look_id)
-        return this.patch<ByteArray>(
+        return this.patch<ByteArray, com.looker.sdk.Error>(
             "/looks/$path_look_id",
             mapOf("fields" to fields), body
         )
@@ -3842,9 +4018,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_look(
         look_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_look_id = encodeParam(look_id)
-        return this.delete<ByteArray>("/looks/$path_look_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/looks/$path_look_id", mapOf()
+        )
     }
 
     /**
@@ -3901,10 +4079,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         path_prefix: String? = null,
         rebuild_pdts: Boolean? = null,
         server_table_calcs: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_look_id = encodeParam(look_id)
         val path_result_format = encodeParam(result_format)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/looks/$path_look_id/run/$path_result_format",
             mapOf(
                 "limit" to limit,
@@ -3936,8 +4114,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_lookml_models(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/lookml_models",
             mapOf("fields" to fields)
         )
@@ -3952,8 +4130,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_lookml_model(
         body: WriteLookmlModel
-    ): SDKResponse {
-        return this.post<ByteArray>("/lookml_models", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/lookml_models", mapOf(), body
+        )
     }
 
     /**
@@ -3967,9 +4147,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun lookml_model(
         lookml_model_name: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_lookml_model_name = encodeParam(lookml_model_name)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/lookml_models/$path_lookml_model_name",
             mapOf("fields" to fields)
         )
@@ -3986,9 +4166,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun update_lookml_model(
         lookml_model_name: String,
         body: WriteLookmlModel
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_lookml_model_name = encodeParam(lookml_model_name)
-        return this.patch<ByteArray>("/lookml_models/$path_lookml_model_name", mapOf(), body)
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/lookml_models/$path_lookml_model_name", mapOf(), body
+        )
     }
 
     /**
@@ -4000,9 +4182,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_lookml_model(
         lookml_model_name: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_lookml_model_name = encodeParam(lookml_model_name)
-        return this.delete<ByteArray>("/lookml_models/$path_lookml_model_name", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/lookml_models/$path_lookml_model_name", mapOf()
+        )
     }
 
     /**
@@ -4018,10 +4202,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         lookml_model_name: String,
         explore_name: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_lookml_model_name = encodeParam(lookml_model_name)
         val path_explore_name = encodeParam(explore_name)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/lookml_models/$path_lookml_model_name/explores/$path_explore_name",
             mapOf("fields" to fields)
         )
@@ -4042,9 +4226,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun all_git_branches(
         project_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<ByteArray>("/projects/$path_project_id/git_branches", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/projects/$path_project_id/git_branches", mapOf()
+        )
     }
 
     /**
@@ -4058,9 +4244,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun git_branch(
         project_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<ByteArray>("/projects/$path_project_id/git_branch", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/projects/$path_project_id/git_branch", mapOf()
+        )
     }
 
     /**
@@ -4082,9 +4270,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun update_git_branch(
         project_id: String,
         body: WriteGitBranch
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.put<ByteArray>("/projects/$path_project_id/git_branch", mapOf(), body)
+        return this.put<ByteArray, com.looker.sdk.Error>(
+            "/projects/$path_project_id/git_branch", mapOf(), body
+        )
     }
 
     /**
@@ -4105,9 +4295,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun create_git_branch(
         project_id: String,
         body: WriteGitBranch
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.post<ByteArray>("/projects/$path_project_id/git_branch", mapOf(), body)
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/projects/$path_project_id/git_branch", mapOf(), body
+        )
     }
 
     /**
@@ -4123,10 +4315,12 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun find_git_branch(
         project_id: String,
         branch_name: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
         val path_branch_name = encodeParam(branch_name)
-        return this.get<ByteArray>("/projects/$path_project_id/git_branch/$path_branch_name", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/projects/$path_project_id/git_branch/$path_branch_name", mapOf()
+        )
     }
 
     /**
@@ -4142,10 +4336,12 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun delete_git_branch(
         project_id: String,
         branch_name: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
         val path_branch_name = encodeParam(branch_name)
-        return this.delete<ByteArray>("/projects/$path_project_id/git_branch/$path_branch_name", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/projects/$path_project_id/git_branch/$path_branch_name", mapOf()
+        )
     }
 
     /**
@@ -4169,9 +4365,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         project_id: String,
         branch: String? = null,
         ref: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.post<ByteArray>(
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/projects/$path_project_id/deploy_ref_to_production",
             mapOf(
                 "branch" to branch,
@@ -4200,9 +4396,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun deploy_to_production(
         project_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.post<ByteArray>("/projects/$path_project_id/deploy_to_production", mapOf())
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/projects/$path_project_id/deploy_to_production", mapOf()
+        )
     }
 
     /**
@@ -4216,9 +4414,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun reset_project_to_production(
         project_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.post<ByteArray>("/projects/$path_project_id/reset_to_production", mapOf())
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/projects/$path_project_id/reset_to_production", mapOf()
+        )
     }
 
     /**
@@ -4232,9 +4432,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun reset_project_to_remote(
         project_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.post<ByteArray>("/projects/$path_project_id/reset_to_remote", mapOf())
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/projects/$path_project_id/reset_to_remote", mapOf()
+        )
     }
 
     /**
@@ -4248,8 +4450,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_projects(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/projects",
             mapOf("fields" to fields)
         )
@@ -4270,8 +4472,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_project(
         body: WriteProject
-    ): SDKResponse {
-        return this.post<ByteArray>("/projects", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/projects", mapOf(), body
+        )
     }
 
     /**
@@ -4287,9 +4491,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun project(
         project_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/projects/$path_project_id",
             mapOf("fields" to fields)
         )
@@ -4329,9 +4533,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         project_id: String,
         body: WriteProject,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.patch<ByteArray>(
+        return this.patch<ByteArray, com.looker.sdk.Error>(
             "/projects/$path_project_id",
             mapOf("fields" to fields), body
         )
@@ -4348,9 +4552,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun manifest(
         project_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<ByteArray>("/projects/$path_project_id/manifest", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/projects/$path_project_id/manifest", mapOf()
+        )
     }
 
     /**
@@ -4364,9 +4570,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun git_deploy_key(
         project_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<ByteArray>("/projects/$path_project_id/git/deploy_key", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/projects/$path_project_id/git/deploy_key", mapOf()
+        )
     }
 
     /**
@@ -4386,9 +4594,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_git_deploy_key(
         project_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.post<ByteArray>("/projects/$path_project_id/git/deploy_key", mapOf())
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/projects/$path_project_id/git/deploy_key", mapOf()
+        )
     }
 
     /**
@@ -4413,9 +4623,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun project_validation_results(
         project_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/projects/$path_project_id/validate",
             mapOf("fields" to fields)
         )
@@ -4440,9 +4650,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun validate_project(
         project_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.post<ByteArray>(
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/projects/$path_project_id/validate",
             mapOf("fields" to fields)
         )
@@ -4461,9 +4671,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun project_workspace(
         project_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/projects/$path_project_id/current_workspace",
             mapOf("fields" to fields)
         )
@@ -4482,9 +4692,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_project_files(
         project_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/projects/$path_project_id/files",
             mapOf("fields" to fields)
         )
@@ -4505,9 +4715,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         project_id: String,
         file_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/projects/$path_project_id/files/file",
             mapOf(
                 "file_id" to file_id,
@@ -4536,9 +4746,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_git_connection_tests(
         project_id: String,
         remote_url: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/projects/$path_project_id/git_connection_tests",
             mapOf("remote_url" to remote_url)
         )
@@ -4563,10 +4773,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         project_id: String,
         test_id: String,
         remote_url: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
         val path_test_id = encodeParam(test_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/projects/$path_project_id/git_connection_tests/$path_test_id",
             mapOf("remote_url" to remote_url)
         )
@@ -4587,9 +4797,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_lookml_tests(
         project_id: String,
         file_id: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/projects/$path_project_id/lookml_tests",
             mapOf("file_id" to file_id)
         )
@@ -4612,9 +4822,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         file_id: String? = null,
         test: String? = null,
         model: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/projects/$path_project_id/lookml_tests/run",
             mapOf(
                 "file_id" to file_id,
@@ -4642,10 +4852,12 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         root_project_id: String,
         credential_id: String,
         body: WriteRepositoryCredential
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_root_project_id = encodeParam(root_project_id)
         val path_credential_id = encodeParam(credential_id)
-        return this.put<ByteArray>("/projects/$path_root_project_id/credential/$path_credential_id", mapOf(), body)
+        return this.put<ByteArray, com.looker.sdk.Error>(
+            "/projects/$path_root_project_id/credential/$path_credential_id", mapOf(), body
+        )
     }
 
     /**
@@ -4664,10 +4876,12 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun delete_repository_credential(
         root_project_id: String,
         credential_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_root_project_id = encodeParam(root_project_id)
         val path_credential_id = encodeParam(credential_id)
-        return this.delete<ByteArray>("/projects/$path_root_project_id/credential/$path_credential_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/projects/$path_root_project_id/credential/$path_credential_id", mapOf()
+        )
     }
 
     /**
@@ -4681,9 +4895,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun get_all_repository_credentials(
         root_project_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_root_project_id = encodeParam(root_project_id)
-        return this.get<ByteArray>("/projects/$path_root_project_id/credentials", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/projects/$path_root_project_id/credentials", mapOf()
+        )
     }
 
     //endregion Project: Manage Projects
@@ -4730,8 +4946,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         rebuild_pdts: Boolean? = null,
         server_table_calcs: Boolean? = null,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/query_tasks",
             mapOf(
                 "limit" to limit,
@@ -4767,8 +4983,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun query_task_multi_results(
         query_task_ids: DelimArray<String>
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/query_tasks/multi_results",
             mapOf("query_task_ids" to query_task_ids)
         )
@@ -4791,9 +5007,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun query_task(
         query_task_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_query_task_id = encodeParam(query_task_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/query_tasks/$path_query_task_id",
             mapOf("fields" to fields)
         )
@@ -4830,9 +5046,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun query_task_results(
         query_task_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_query_task_id = encodeParam(query_task_id)
-        return this.get<ByteArray>("/query_tasks/$path_query_task_id/results", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/query_tasks/$path_query_task_id/results", mapOf()
+        )
     }
 
     /**
@@ -4862,9 +5080,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun query(
         query_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_query_id = encodeParam(query_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/queries/$path_query_id",
             mapOf("fields" to fields)
         )
@@ -4897,9 +5115,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun query_for_slug(
         slug: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_slug = encodeParam(slug)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/queries/slug/$path_slug",
             mapOf("fields" to fields)
         )
@@ -4923,8 +5141,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_query(
         body: WriteQuery,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/queries",
             mapOf("fields" to fields), body
         )
@@ -4987,10 +5205,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         path_prefix: String? = null,
         rebuild_pdts: Boolean? = null,
         server_table_calcs: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_query_id = encodeParam(query_id)
         val path_result_format = encodeParam(result_format)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/queries/$path_query_id/run/$path_result_format",
             mapOf(
                 "limit" to limit,
@@ -5095,9 +5313,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         path_prefix: String? = null,
         rebuild_pdts: Boolean? = null,
         server_table_calcs: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_result_format = encodeParam(result_format)
-        return this.post<ByteArray>(
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/queries/run/$path_result_format",
             mapOf(
                 "limit" to limit,
@@ -5183,11 +5401,13 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         model_name: String,
         view_name: String,
         result_format: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_model_name = encodeParam(model_name)
         val path_view_name = encodeParam(view_name)
         val path_result_format = encodeParam(result_format)
-        return this.get<ByteArray>("/queries/models/$path_model_name/views/$path_view_name/run/$path_result_format", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/queries/models/$path_model_name/views/$path_view_name/run/$path_result_format", mapOf()
+        )
     }
 
     /**
@@ -5203,9 +5423,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun merge_query(
         merge_query_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_merge_query_id = encodeParam(merge_query_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/merge_queries/$path_merge_query_id",
             mapOf("fields" to fields)
         )
@@ -5238,8 +5458,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_merge_query(
         body: WriteMergeQuery? = null,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/merge_queries",
             mapOf("fields" to fields), body
         )
@@ -5250,8 +5470,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /running_queries -> ByteArray
      */
-    fun all_running_queries(): SDKResponse {
-        return this.get<ByteArray>("/running_queries", mapOf())
+    fun all_running_queries(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/running_queries", mapOf()
+        )
     }
 
     /**
@@ -5263,9 +5485,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun kill_query(
         query_task_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_query_task_id = encodeParam(query_task_id)
-        return this.delete<ByteArray>("/running_queries/$path_query_task_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/running_queries/$path_query_task_id", mapOf()
+        )
     }
 
     /**
@@ -5277,9 +5501,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun sql_query(
         slug: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_slug = encodeParam(slug)
-        return this.get<ByteArray>("/sql_queries/$path_slug", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/sql_queries/$path_slug", mapOf()
+        )
     }
 
     /**
@@ -5293,8 +5519,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_sql_query(
         body: SqlQueryCreate
-    ): SDKResponse {
-        return this.post<ByteArray>("/sql_queries", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/sql_queries", mapOf(), body
+        )
     }
 
     /**
@@ -5312,10 +5540,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         slug: String,
         result_format: String,
         download: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_slug = encodeParam(slug)
         val path_result_format = encodeParam(result_format)
-        return this.post<ByteArray>(
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/sql_queries/$path_slug/run/$path_result_format",
             mapOf("download" to download)
         )
@@ -5354,10 +5582,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         fields: String? = null,
         pdf_paper_size: String? = null,
         pdf_landscape: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
         val path_result_format = encodeParam(result_format)
-        return this.post<ByteArray>(
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/render_tasks/lookml_dashboards/$path_dashboard_id/$path_result_format",
             mapOf(
                 "width" to width,
@@ -5391,10 +5619,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         width: Long,
         height: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_look_id = encodeParam(look_id)
         val path_result_format = encodeParam(result_format)
-        return this.post<ByteArray>(
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/render_tasks/looks/$path_look_id/$path_result_format",
             mapOf(
                 "width" to width,
@@ -5425,10 +5653,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         width: Long,
         height: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_query_id = encodeParam(query_id)
         val path_result_format = encodeParam(result_format)
-        return this.post<ByteArray>(
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/render_tasks/queries/$path_query_id/$path_result_format",
             mapOf(
                 "width" to width,
@@ -5465,10 +5693,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         fields: String? = null,
         pdf_paper_size: String? = null,
         pdf_landscape: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
         val path_result_format = encodeParam(result_format)
-        return this.post<ByteArray>(
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/render_tasks/dashboards/$path_dashboard_id/$path_result_format",
             mapOf(
                 "width" to width,
@@ -5496,9 +5724,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun render_task(
         render_task_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_render_task_id = encodeParam(render_task_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/render_tasks/$path_render_task_id",
             mapOf("fields" to fields)
         )
@@ -5531,9 +5759,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun render_task_results(
         render_task_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_render_task_id = encodeParam(render_task_id)
-        return this.get<ByteArray>("/render_tasks/$path_render_task_id/results", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/render_tasks/$path_render_task_id/results", mapOf()
+        )
     }
 
     //endregion RenderTask: Manage Render Tasks
@@ -5586,8 +5816,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         all_access: Boolean? = null,
         built_in: Boolean? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/model_sets/search",
             mapOf(
                 "fields" to fields,
@@ -5614,9 +5844,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun model_set(
         model_set_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_model_set_id = encodeParam(model_set_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/model_sets/$path_model_set_id",
             mapOf("fields" to fields)
         )
@@ -5633,9 +5863,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun update_model_set(
         model_set_id: Long,
         body: WriteModelSet
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_model_set_id = encodeParam(model_set_id)
-        return this.patch<ByteArray>("/model_sets/$path_model_set_id", mapOf(), body)
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/model_sets/$path_model_set_id", mapOf(), body
+        )
     }
 
     /**
@@ -5647,9 +5879,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_model_set(
         model_set_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_model_set_id = encodeParam(model_set_id)
-        return this.delete<ByteArray>("/model_sets/$path_model_set_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/model_sets/$path_model_set_id", mapOf()
+        )
     }
 
     /**
@@ -5661,8 +5895,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_model_sets(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/model_sets",
             mapOf("fields" to fields)
         )
@@ -5677,8 +5911,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_model_set(
         body: WriteModelSet
-    ): SDKResponse {
-        return this.post<ByteArray>("/model_sets", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/model_sets", mapOf(), body
+        )
     }
 
     /**
@@ -5686,8 +5922,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /permissions -> ByteArray
      */
-    fun all_permissions(): SDKResponse {
-        return this.get<ByteArray>("/permissions", mapOf())
+    fun all_permissions(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/permissions", mapOf()
+        )
     }
 
     /**
@@ -5736,8 +5974,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         all_access: Boolean? = null,
         built_in: Boolean? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/permission_sets/search",
             mapOf(
                 "fields" to fields,
@@ -5764,9 +6002,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun permission_set(
         permission_set_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_permission_set_id = encodeParam(permission_set_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/permission_sets/$path_permission_set_id",
             mapOf("fields" to fields)
         )
@@ -5783,9 +6021,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun update_permission_set(
         permission_set_id: Long,
         body: WritePermissionSet
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_permission_set_id = encodeParam(permission_set_id)
-        return this.patch<ByteArray>("/permission_sets/$path_permission_set_id", mapOf(), body)
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/permission_sets/$path_permission_set_id", mapOf(), body
+        )
     }
 
     /**
@@ -5797,9 +6037,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_permission_set(
         permission_set_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_permission_set_id = encodeParam(permission_set_id)
-        return this.delete<ByteArray>("/permission_sets/$path_permission_set_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/permission_sets/$path_permission_set_id", mapOf()
+        )
     }
 
     /**
@@ -5811,8 +6053,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_permission_sets(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/permission_sets",
             mapOf("fields" to fields)
         )
@@ -5827,8 +6069,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_permission_set(
         body: WritePermissionSet
-    ): SDKResponse {
-        return this.post<ByteArray>("/permission_sets", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/permission_sets", mapOf(), body
+        )
     }
 
     /**
@@ -5842,8 +6086,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_roles(
         fields: String? = null,
         ids: DelimArray<Long>? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/roles",
             mapOf(
                 "fields" to fields,
@@ -5861,8 +6105,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_role(
         body: WriteRole
-    ): SDKResponse {
-        return this.post<ByteArray>("/roles", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/roles", mapOf(), body
+        )
     }
 
     /**
@@ -5911,8 +6157,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         name: String? = null,
         built_in: Boolean? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/roles/search",
             mapOf(
                 "fields" to fields,
@@ -5936,9 +6182,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun role(
         role_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_role_id = encodeParam(role_id)
-        return this.get<ByteArray>("/roles/$path_role_id", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/roles/$path_role_id", mapOf()
+        )
     }
 
     /**
@@ -5952,9 +6200,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun update_role(
         role_id: Long,
         body: WriteRole
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_role_id = encodeParam(role_id)
-        return this.patch<ByteArray>("/roles/$path_role_id", mapOf(), body)
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/roles/$path_role_id", mapOf(), body
+        )
     }
 
     /**
@@ -5966,9 +6216,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_role(
         role_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_role_id = encodeParam(role_id)
-        return this.delete<ByteArray>("/roles/$path_role_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/roles/$path_role_id", mapOf()
+        )
     }
 
     /**
@@ -5982,9 +6234,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun role_groups(
         role_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_role_id = encodeParam(role_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/roles/$path_role_id/groups",
             mapOf("fields" to fields)
         )
@@ -6001,9 +6253,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun set_role_groups(
         role_id: Long,
         body: Array<Long>
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_role_id = encodeParam(role_id)
-        return this.put<ByteArray>("/roles/$path_role_id/groups", mapOf(), body)
+        return this.put<ByteArray, com.looker.sdk.Error>(
+            "/roles/$path_role_id/groups", mapOf(), body
+        )
     }
 
     /**
@@ -6019,9 +6273,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         role_id: Long,
         fields: String? = null,
         direct_association_only: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_role_id = encodeParam(role_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/roles/$path_role_id/users",
             mapOf(
                 "fields" to fields,
@@ -6041,9 +6295,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun set_role_users(
         role_id: Long,
         body: Array<Long>
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_role_id = encodeParam(role_id)
-        return this.put<ByteArray>("/roles/$path_role_id/users", mapOf(), body)
+        return this.put<ByteArray, com.looker.sdk.Error>(
+            "/roles/$path_role_id/users", mapOf(), body
+        )
     }
 
     //endregion Role: Manage Roles
@@ -6063,9 +6319,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun scheduled_plans_for_space(
         space_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_space_id = encodeParam(space_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/scheduled_plans/space/$path_space_id",
             mapOf("fields" to fields)
         )
@@ -6084,9 +6340,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun scheduled_plan(
         scheduled_plan_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_scheduled_plan_id = encodeParam(scheduled_plan_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/scheduled_plans/$path_scheduled_plan_id",
             mapOf("fields" to fields)
         )
@@ -6144,9 +6400,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun update_scheduled_plan(
         scheduled_plan_id: Long,
         body: WriteScheduledPlan
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_scheduled_plan_id = encodeParam(scheduled_plan_id)
-        return this.patch<ByteArray>("/scheduled_plans/$path_scheduled_plan_id", mapOf(), body)
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/scheduled_plans/$path_scheduled_plan_id", mapOf(), body
+        )
     }
 
     /**
@@ -6162,9 +6420,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_scheduled_plan(
         scheduled_plan_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_scheduled_plan_id = encodeParam(scheduled_plan_id)
-        return this.delete<ByteArray>("/scheduled_plans/$path_scheduled_plan_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/scheduled_plans/$path_scheduled_plan_id", mapOf()
+        )
     }
 
     /**
@@ -6190,8 +6450,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long? = null,
         fields: String? = null,
         all_users: Boolean? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/scheduled_plans",
             mapOf(
                 "user_id" to user_id,
@@ -6267,8 +6527,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_scheduled_plan(
         body: WriteScheduledPlan
-    ): SDKResponse {
-        return this.post<ByteArray>("/scheduled_plans", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/scheduled_plans", mapOf(), body
+        )
     }
 
     /**
@@ -6316,8 +6578,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun scheduled_plan_run_once(
         body: WriteScheduledPlan
-    ): SDKResponse {
-        return this.post<ByteArray>("/scheduled_plans/run_once", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/scheduled_plans/run_once", mapOf(), body
+        )
     }
 
     /**
@@ -6345,9 +6609,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long? = null,
         fields: String? = null,
         all_users: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_look_id = encodeParam(look_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/scheduled_plans/look/$path_look_id",
             mapOf(
                 "user_id" to user_id,
@@ -6382,9 +6646,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long? = null,
         all_users: Boolean? = null,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/scheduled_plans/dashboard/$path_dashboard_id",
             mapOf(
                 "user_id" to user_id,
@@ -6419,9 +6683,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long? = null,
         fields: String? = null,
         all_users: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_lookml_dashboard_id = encodeParam(lookml_dashboard_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/scheduled_plans/lookml_dashboard/$path_lookml_dashboard_id",
             mapOf(
                 "user_id" to user_id,
@@ -6488,9 +6752,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun scheduled_plan_run_once_by_id(
         scheduled_plan_id: Long,
         body: WriteScheduledPlan? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_scheduled_plan_id = encodeParam(scheduled_plan_id)
-        return this.post<ByteArray>("/scheduled_plans/$path_scheduled_plan_id/run_once", mapOf(), body)
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/scheduled_plans/$path_scheduled_plan_id/run_once", mapOf(), body
+        )
     }
 
     //endregion ScheduledPlan: Manage Scheduled Plans
@@ -6504,8 +6770,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /session -> ByteArray
      */
-    fun session(): SDKResponse {
-        return this.get<ByteArray>("/session", mapOf())
+    fun session(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/session", mapOf()
+        )
     }
 
     /**
@@ -6536,8 +6804,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_session(
         body: WriteApiSession
-    ): SDKResponse {
-        return this.patch<ByteArray>("/session", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/session", mapOf(), body
+        )
     }
 
     //endregion Session: Session Information
@@ -6601,8 +6871,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         parent_id: String? = null,
         creator_id: String? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/spaces/search",
             mapOf(
                 "fields" to fields,
@@ -6631,9 +6901,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun space(
         space_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_space_id = encodeParam(space_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/spaces/$path_space_id",
             mapOf("fields" to fields)
         )
@@ -6650,9 +6920,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun update_space(
         space_id: String,
         body: UpdateSpace
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_space_id = encodeParam(space_id)
-        return this.patch<ByteArray>("/spaces/$path_space_id", mapOf(), body)
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/spaces/$path_space_id", mapOf(), body
+        )
     }
 
     /**
@@ -6665,9 +6937,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_space(
         space_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_space_id = encodeParam(space_id)
-        return this.delete<ByteArray>("/spaces/$path_space_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/spaces/$path_space_id", mapOf()
+        )
     }
 
     /**
@@ -6679,8 +6953,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_spaces(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/spaces",
             mapOf("fields" to fields)
         )
@@ -6698,8 +6972,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_space(
         body: CreateSpace
-    ): SDKResponse {
-        return this.post<ByteArray>("/spaces", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/spaces", mapOf(), body
+        )
     }
 
     /**
@@ -6719,9 +6995,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         page: Long? = null,
         per_page: Long? = null,
         sorts: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_space_id = encodeParam(space_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/spaces/$path_space_id/children",
             mapOf(
                 "fields" to fields,
@@ -6747,9 +7023,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         fields: String? = null,
         sorts: String? = null,
         name: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_space_id = encodeParam(space_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/spaces/$path_space_id/children/search",
             mapOf(
                 "fields" to fields,
@@ -6770,9 +7046,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun space_parent(
         space_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_space_id = encodeParam(space_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/spaces/$path_space_id/parent",
             mapOf("fields" to fields)
         )
@@ -6789,9 +7065,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun space_ancestors(
         space_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_space_id = encodeParam(space_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/spaces/$path_space_id/ancestors",
             mapOf("fields" to fields)
         )
@@ -6808,9 +7084,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun space_looks(
         space_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_space_id = encodeParam(space_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/spaces/$path_space_id/looks",
             mapOf("fields" to fields)
         )
@@ -6827,9 +7103,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun space_dashboards(
         space_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_space_id = encodeParam(space_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/spaces/$path_space_id/dashboards",
             mapOf("fields" to fields)
         )
@@ -6854,8 +7130,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_themes(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/themes",
             mapOf("fields" to fields)
         )
@@ -6884,8 +7160,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_theme(
         body: WriteTheme
-    ): SDKResponse {
-        return this.post<ByteArray>("/themes", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/themes", mapOf(), body
+        )
     }
 
     /**
@@ -6950,8 +7228,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         sorts: String? = null,
         fields: String? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/themes/search",
             mapOf(
                 "id" to id,
@@ -6982,8 +7260,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun default_theme(
         ts: Date? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/themes/default",
             mapOf("ts" to ts)
         )
@@ -7008,8 +7286,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun set_default_theme(
         name: String
-    ): SDKResponse {
-        return this.put<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.put<ByteArray, com.looker.sdk.Error>(
             "/themes/default",
             mapOf("name" to name)
         )
@@ -7036,8 +7314,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         name: String? = null,
         ts: Date? = null,
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/themes/active",
             mapOf(
                 "name" to name,
@@ -7063,8 +7341,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun theme_or_default(
         name: String,
         ts: Date? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/themes/theme_or_default",
             mapOf(
                 "name" to name,
@@ -7088,8 +7366,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun validate_theme(
         body: WriteTheme
-    ): SDKResponse {
-        return this.post<ByteArray>("/themes/validate", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/themes/validate", mapOf(), body
+        )
     }
 
     /**
@@ -7107,9 +7387,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun theme(
         theme_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_theme_id = encodeParam(theme_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/themes/$path_theme_id",
             mapOf("fields" to fields)
         )
@@ -7128,9 +7408,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun update_theme(
         theme_id: String,
         body: WriteTheme
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_theme_id = encodeParam(theme_id)
-        return this.patch<ByteArray>("/themes/$path_theme_id", mapOf(), body)
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/themes/$path_theme_id", mapOf(), body
+        )
     }
 
     /**
@@ -7150,9 +7432,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_theme(
         theme_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_theme_id = encodeParam(theme_id)
-        return this.delete<ByteArray>("/themes/$path_theme_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/themes/$path_theme_id", mapOf()
+        )
     }
 
     //endregion Theme: Manage Themes
@@ -7168,8 +7452,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun me(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/user",
             mapOf("fields" to fields)
         )
@@ -7192,8 +7476,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         per_page: Long? = null,
         sorts: String? = null,
         ids: DelimArray<Long>? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/users",
             mapOf(
                 "fields" to fields,
@@ -7216,8 +7500,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_user(
         body: WriteUser? = null,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/users",
             mapOf("fields" to fields), body
         )
@@ -7285,8 +7569,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         filter_or: Boolean? = null,
         content_metadata_id: Long? = null,
         group_id: Long? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/users/search",
             mapOf(
                 "fields" to fields,
@@ -7340,9 +7624,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         verified_looker_employee: Boolean? = null,
         email: String? = null,
         is_disabled: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_pattern = encodeParam(pattern)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/users/search/names/$path_pattern",
             mapOf(
                 "fields" to fields,
@@ -7374,9 +7658,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun user(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id",
             mapOf("fields" to fields)
         )
@@ -7395,9 +7679,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         body: WriteUser,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.patch<ByteArray>(
+        return this.patch<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id",
             mapOf("fields" to fields), body
         )
@@ -7414,9 +7698,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_user(
         user_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.delete<ByteArray>("/users/$path_user_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/users/$path_user_id", mapOf()
+        )
     }
 
     /**
@@ -7459,10 +7745,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         credential_type: String,
         credential_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_credential_type = encodeParam(credential_type)
         val path_credential_id = encodeParam(credential_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/users/credential/$path_credential_type/$path_credential_id",
             mapOf("fields" to fields)
         )
@@ -7479,9 +7765,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun user_credentials_email(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_email",
             mapOf("fields" to fields)
         )
@@ -7500,9 +7786,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         body: WriteCredentialsEmail,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.post<ByteArray>(
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_email",
             mapOf("fields" to fields), body
         )
@@ -7521,9 +7807,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         body: WriteCredentialsEmail,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.patch<ByteArray>(
+        return this.patch<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_email",
             mapOf("fields" to fields), body
         )
@@ -7538,9 +7824,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_user_credentials_email(
         user_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.delete<ByteArray>("/users/$path_user_id/credentials_email", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/users/$path_user_id/credentials_email", mapOf()
+        )
     }
 
     /**
@@ -7554,9 +7842,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun user_credentials_totp(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_totp",
             mapOf("fields" to fields)
         )
@@ -7575,9 +7863,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         body: CredentialsTotp? = null,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.post<ByteArray>(
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_totp",
             mapOf("fields" to fields), body
         )
@@ -7592,9 +7880,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_user_credentials_totp(
         user_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.delete<ByteArray>("/users/$path_user_id/credentials_totp", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/users/$path_user_id/credentials_totp", mapOf()
+        )
     }
 
     /**
@@ -7608,9 +7898,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun user_credentials_ldap(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_ldap",
             mapOf("fields" to fields)
         )
@@ -7625,9 +7915,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_user_credentials_ldap(
         user_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.delete<ByteArray>("/users/$path_user_id/credentials_ldap", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/users/$path_user_id/credentials_ldap", mapOf()
+        )
     }
 
     /**
@@ -7641,9 +7933,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun user_credentials_google(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_google",
             mapOf("fields" to fields)
         )
@@ -7658,9 +7950,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_user_credentials_google(
         user_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.delete<ByteArray>("/users/$path_user_id/credentials_google", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/users/$path_user_id/credentials_google", mapOf()
+        )
     }
 
     /**
@@ -7674,9 +7968,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun user_credentials_saml(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_saml",
             mapOf("fields" to fields)
         )
@@ -7691,9 +7985,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_user_credentials_saml(
         user_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.delete<ByteArray>("/users/$path_user_id/credentials_saml", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/users/$path_user_id/credentials_saml", mapOf()
+        )
     }
 
     /**
@@ -7707,9 +8003,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun user_credentials_oidc(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_oidc",
             mapOf("fields" to fields)
         )
@@ -7724,9 +8020,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_user_credentials_oidc(
         user_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.delete<ByteArray>("/users/$path_user_id/credentials_oidc", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/users/$path_user_id/credentials_oidc", mapOf()
+        )
     }
 
     /**
@@ -7742,10 +8040,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         credentials_api3_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
         val path_credentials_api3_id = encodeParam(credentials_api3_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_api3/$path_credentials_api3_id",
             mapOf("fields" to fields)
         )
@@ -7762,10 +8060,12 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun delete_user_credentials_api3(
         user_id: Long,
         credentials_api3_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
         val path_credentials_api3_id = encodeParam(credentials_api3_id)
-        return this.delete<ByteArray>("/users/$path_user_id/credentials_api3/$path_credentials_api3_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/users/$path_user_id/credentials_api3/$path_credentials_api3_id", mapOf()
+        )
     }
 
     /**
@@ -7779,9 +8079,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_user_credentials_api3s(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_api3",
             mapOf("fields" to fields)
         )
@@ -7800,9 +8100,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         body: CredentialsApi3? = null,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.post<ByteArray>(
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_api3",
             mapOf("fields" to fields), body
         )
@@ -7821,10 +8121,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         credentials_embed_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
         val path_credentials_embed_id = encodeParam(credentials_embed_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_embed/$path_credentials_embed_id",
             mapOf("fields" to fields)
         )
@@ -7841,10 +8141,12 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun delete_user_credentials_embed(
         user_id: Long,
         credentials_embed_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
         val path_credentials_embed_id = encodeParam(credentials_embed_id)
-        return this.delete<ByteArray>("/users/$path_user_id/credentials_embed/$path_credentials_embed_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/users/$path_user_id/credentials_embed/$path_credentials_embed_id", mapOf()
+        )
     }
 
     /**
@@ -7858,9 +8160,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_user_credentials_embeds(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_embed",
             mapOf("fields" to fields)
         )
@@ -7877,9 +8179,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun user_credentials_looker_openid(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_looker_openid",
             mapOf("fields" to fields)
         )
@@ -7894,9 +8196,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_user_credentials_looker_openid(
         user_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.delete<ByteArray>("/users/$path_user_id/credentials_looker_openid", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/users/$path_user_id/credentials_looker_openid", mapOf()
+        )
     }
 
     /**
@@ -7912,10 +8216,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         session_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
         val path_session_id = encodeParam(session_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/sessions/$path_session_id",
             mapOf("fields" to fields)
         )
@@ -7932,10 +8236,12 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun delete_user_session(
         user_id: Long,
         session_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
         val path_session_id = encodeParam(session_id)
-        return this.delete<ByteArray>("/users/$path_user_id/sessions/$path_session_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/users/$path_user_id/sessions/$path_session_id", mapOf()
+        )
     }
 
     /**
@@ -7949,9 +8255,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_user_sessions(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/sessions",
             mapOf("fields" to fields)
         )
@@ -7978,9 +8284,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         expires: Boolean? = null,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.post<ByteArray>(
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_email/password_reset",
             mapOf(
                 "expires" to expires,
@@ -8002,9 +8308,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         fields: String? = null,
         direct_association_only: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/roles",
             mapOf(
                 "fields" to fields,
@@ -8026,9 +8332,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         body: Array<Long>,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.put<ByteArray>(
+        return this.put<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/roles",
             mapOf("fields" to fields), body
         )
@@ -8066,9 +8372,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         user_attribute_ids: DelimArray<Long>? = null,
         all_values: Boolean? = null,
         include_unset: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/attribute_values",
             mapOf(
                 "fields" to fields,
@@ -8094,10 +8400,12 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         user_attribute_id: Long,
         body: WriteUserAttributeWithValue
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
         val path_user_attribute_id = encodeParam(user_attribute_id)
-        return this.patch<ByteArray>("/users/$path_user_id/attribute_values/$path_user_attribute_id", mapOf(), body)
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/users/$path_user_id/attribute_values/$path_user_attribute_id", mapOf(), body
+        )
     }
 
     /**
@@ -8116,10 +8424,12 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun delete_user_attribute_user_value(
         user_id: Long,
         user_attribute_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
         val path_user_attribute_id = encodeParam(user_attribute_id)
-        return this.delete<ByteArray>("/users/$path_user_id/attribute_values/$path_user_attribute_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/users/$path_user_id/attribute_values/$path_user_attribute_id", mapOf()
+        )
     }
 
     //endregion User: Manage Users
@@ -8137,8 +8447,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_user_attributes(
         fields: String? = null,
         sorts: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/user_attributes",
             mapOf(
                 "fields" to fields,
@@ -8167,8 +8477,8 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_user_attribute(
         body: WriteUserAttribute,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/user_attributes",
             mapOf("fields" to fields), body
         )
@@ -8185,9 +8495,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun user_attribute(
         user_attribute_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_attribute_id = encodeParam(user_attribute_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/user_attributes/$path_user_attribute_id",
             mapOf("fields" to fields)
         )
@@ -8206,9 +8516,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
         user_attribute_id: Long,
         body: WriteUserAttribute,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_attribute_id = encodeParam(user_attribute_id)
-        return this.patch<ByteArray>(
+        return this.patch<ByteArray, com.looker.sdk.Error>(
             "/user_attributes/$path_user_attribute_id",
             mapOf("fields" to fields), body
         )
@@ -8223,9 +8533,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_user_attribute(
         user_attribute_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_attribute_id = encodeParam(user_attribute_id)
-        return this.delete<ByteArray>("/user_attributes/$path_user_attribute_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/user_attributes/$path_user_attribute_id", mapOf()
+        )
     }
 
     /**
@@ -8245,9 +8557,9 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_user_attribute_group_values(
         user_attribute_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_attribute_id = encodeParam(user_attribute_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/user_attributes/$path_user_attribute_id/group_values",
             mapOf("fields" to fields)
         )
@@ -8283,9 +8595,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun set_user_attribute_group_values(
         user_attribute_id: Long,
         body: Array<UserAttributeGroupValue>
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_attribute_id = encodeParam(user_attribute_id)
-        return this.post<ByteArray>("/user_attributes/$path_user_attribute_id/group_values", mapOf(), body)
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/user_attributes/$path_user_attribute_id/group_values", mapOf(), body
+        )
     }
 
     //endregion UserAttribute: Manage User Attributes
@@ -8299,8 +8613,10 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /workspaces -> ByteArray
      */
-    fun all_workspaces(): SDKResponse {
-        return this.get<ByteArray>("/workspaces", mapOf())
+    fun all_workspaces(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/workspaces", mapOf()
+        )
     }
 
     /**
@@ -8340,9 +8656,11 @@ class Looker31SDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun workspace(
         workspace_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_workspace_id = encodeParam(workspace_id)
-        return this.get<ByteArray>("/workspaces/$path_workspace_id", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/workspaces/$path_workspace_id", mapOf()
+        )
     }
 
     //endregion Workspace: Manage Workspaces

--- a/kotlin/src/main/com/looker/sdk/4.0/methods.kt
+++ b/kotlin/src/main/com/looker/sdk/4.0/methods.kt
@@ -78,8 +78,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun login(
         client_id: String? = null,
         client_secret: String? = null
-    ): SDKResponse {
-        return this.post<AccessToken>(
+    ): SdkResult<AccessToken, com.looker.sdk.Error> {
+        return this.post<AccessToken, com.looker.sdk.Error>(
             "/login",
             mapOf(
                 "client_id" to client_id,
@@ -114,9 +114,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun login_user(
         user_id: Long,
         associative: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<AccessToken, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.post<AccessToken>(
+        return this.post<AccessToken, com.looker.sdk.Error>(
             "/login/$path_user_id",
             mapOf("associative" to associative)
         )
@@ -127,8 +127,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * DELETE /logout -> String
      */
-    fun logout(): SDKResponse {
-        return this.delete<String>("/logout", mapOf())
+    fun logout(): SdkResult<String, com.looker.sdk.Error> {
+        return this.delete<String, com.looker.sdk.Error>(
+            "/logout", mapOf()
+        )
     }
 
     //endregion ApiAuth: API Authentication
@@ -177,8 +179,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_sso_embed_url(
         body: EmbedSsoParams
-    ): SDKResponse {
-        return this.post<EmbedUrlResponse>("/embed/sso_url", mapOf(), body)
+    ): SdkResult<EmbedUrlResponse, com.looker.sdk.Error> {
+        return this.post<EmbedUrlResponse, com.looker.sdk.Error>(
+            "/embed/sso_url", mapOf(), body
+        )
     }
 
     /**
@@ -208,8 +212,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_embed_url_as_me(
         body: EmbedParams
-    ): SDKResponse {
-        return this.post<EmbedUrlResponse>("/embed/token_url/me", mapOf(), body)
+    ): SdkResult<EmbedUrlResponse, com.looker.sdk.Error> {
+        return this.post<EmbedUrlResponse, com.looker.sdk.Error>(
+            "/embed/token_url/me", mapOf(), body
+        )
     }
 
     /**
@@ -232,8 +238,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /ldap_config -> LDAPConfig
      */
-    fun ldap_config(): SDKResponse {
-        return this.get<LDAPConfig>("/ldap_config", mapOf())
+    fun ldap_config(): SdkResult<LDAPConfig, com.looker.sdk.Error> {
+        return this.get<LDAPConfig, com.looker.sdk.Error>(
+            "/ldap_config", mapOf()
+        )
     }
 
     /**
@@ -255,8 +263,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_ldap_config(
         body: WriteLDAPConfig
-    ): SDKResponse {
-        return this.patch<LDAPConfig>("/ldap_config", mapOf(), body)
+    ): SdkResult<LDAPConfig, com.looker.sdk.Error> {
+        return this.patch<LDAPConfig, com.looker.sdk.Error>(
+            "/ldap_config", mapOf(), body
+        )
     }
 
     /**
@@ -285,8 +295,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun test_ldap_config_connection(
         body: WriteLDAPConfig
-    ): SDKResponse {
-        return this.put<LDAPConfigTestResult>("/ldap_config/test_connection", mapOf(), body)
+    ): SdkResult<LDAPConfigTestResult, com.looker.sdk.Error> {
+        return this.put<LDAPConfigTestResult, com.looker.sdk.Error>(
+            "/ldap_config/test_connection", mapOf(), body
+        )
     }
 
     /**
@@ -317,8 +329,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun test_ldap_config_auth(
         body: WriteLDAPConfig
-    ): SDKResponse {
-        return this.put<LDAPConfigTestResult>("/ldap_config/test_auth", mapOf(), body)
+    ): SdkResult<LDAPConfigTestResult, com.looker.sdk.Error> {
+        return this.put<LDAPConfigTestResult, com.looker.sdk.Error>(
+            "/ldap_config/test_auth", mapOf(), body
+        )
     }
 
     /**
@@ -338,8 +352,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun test_ldap_config_user_info(
         body: WriteLDAPConfig
-    ): SDKResponse {
-        return this.put<LDAPConfigTestResult>("/ldap_config/test_user_info", mapOf(), body)
+    ): SdkResult<LDAPConfigTestResult, com.looker.sdk.Error> {
+        return this.put<LDAPConfigTestResult, com.looker.sdk.Error>(
+            "/ldap_config/test_user_info", mapOf(), body
+        )
     }
 
     /**
@@ -359,8 +375,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun test_ldap_config_user_auth(
         body: WriteLDAPConfig
-    ): SDKResponse {
-        return this.put<LDAPConfigTestResult>("/ldap_config/test_user_auth", mapOf(), body)
+    ): SdkResult<LDAPConfigTestResult, com.looker.sdk.Error> {
+        return this.put<LDAPConfigTestResult, com.looker.sdk.Error>(
+            "/ldap_config/test_user_auth", mapOf(), body
+        )
     }
 
     /**
@@ -378,8 +396,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_oauth_client_apps(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<OauthClientApp>>(
+    ): SdkResult<Array<OauthClientApp>, com.looker.sdk.Error> {
+        return this.get<Array<OauthClientApp>, com.looker.sdk.Error>(
             "/oauth_client_apps",
             mapOf("fields" to fields)
         )
@@ -398,9 +416,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun oauth_client_app(
         client_guid: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<OauthClientApp, com.looker.sdk.Error> {
         val path_client_guid = encodeParam(client_guid)
-        return this.get<OauthClientApp>(
+        return this.get<OauthClientApp, com.looker.sdk.Error>(
             "/oauth_client_apps/$path_client_guid",
             mapOf("fields" to fields)
         )
@@ -424,9 +442,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         client_guid: String,
         body: WriteOauthClientApp,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<OauthClientApp, com.looker.sdk.Error> {
         val path_client_guid = encodeParam(client_guid)
-        return this.post<OauthClientApp>(
+        return this.post<OauthClientApp, com.looker.sdk.Error>(
             "/oauth_client_apps/$path_client_guid",
             mapOf("fields" to fields), body
         )
@@ -447,9 +465,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         client_guid: String,
         body: WriteOauthClientApp,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<OauthClientApp, com.looker.sdk.Error> {
         val path_client_guid = encodeParam(client_guid)
-        return this.patch<OauthClientApp>(
+        return this.patch<OauthClientApp, com.looker.sdk.Error>(
             "/oauth_client_apps/$path_client_guid",
             mapOf("fields" to fields), body
         )
@@ -469,9 +487,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_oauth_client_app(
         client_guid: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_client_guid = encodeParam(client_guid)
-        return this.delete<String>("/oauth_client_apps/$path_client_guid", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/oauth_client_apps/$path_client_guid", mapOf()
+        )
     }
 
     /**
@@ -486,9 +506,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun invalidate_tokens(
         client_guid: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_client_guid = encodeParam(client_guid)
-        return this.delete<String>("/oauth_client_apps/$path_client_guid/tokens", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/oauth_client_apps/$path_client_guid/tokens", mapOf()
+        )
     }
 
     /**
@@ -510,10 +532,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         client_guid: String,
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_client_guid = encodeParam(client_guid)
         val path_user_id = encodeParam(user_id)
-        return this.post<String>(
+        return this.post<String, com.looker.sdk.Error>(
             "/oauth_client_apps/$path_client_guid/users/$path_user_id",
             mapOf("fields" to fields)
         )
@@ -541,10 +563,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         client_guid: String,
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_client_guid = encodeParam(client_guid)
         val path_user_id = encodeParam(user_id)
-        return this.delete<String>(
+        return this.delete<String, com.looker.sdk.Error>(
             "/oauth_client_apps/$path_client_guid/users/$path_user_id",
             mapOf("fields" to fields)
         )
@@ -566,8 +588,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /oidc_config -> OIDCConfig
      */
-    fun oidc_config(): SDKResponse {
-        return this.get<OIDCConfig>("/oidc_config", mapOf())
+    fun oidc_config(): SdkResult<OIDCConfig, com.looker.sdk.Error> {
+        return this.get<OIDCConfig, com.looker.sdk.Error>(
+            "/oidc_config", mapOf()
+        )
     }
 
     /**
@@ -587,8 +611,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_oidc_config(
         body: WriteOIDCConfig
-    ): SDKResponse {
-        return this.patch<OIDCConfig>("/oidc_config", mapOf(), body)
+    ): SdkResult<OIDCConfig, com.looker.sdk.Error> {
+        return this.patch<OIDCConfig, com.looker.sdk.Error>(
+            "/oidc_config", mapOf(), body
+        )
     }
 
     /**
@@ -600,9 +626,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun oidc_test_config(
         test_slug: String
-    ): SDKResponse {
+    ): SdkResult<OIDCConfig, com.looker.sdk.Error> {
         val path_test_slug = encodeParam(test_slug)
-        return this.get<OIDCConfig>("/oidc_test_configs/$path_test_slug", mapOf())
+        return this.get<OIDCConfig, com.looker.sdk.Error>(
+            "/oidc_test_configs/$path_test_slug", mapOf()
+        )
     }
 
     /**
@@ -614,9 +642,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_oidc_test_config(
         test_slug: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_test_slug = encodeParam(test_slug)
-        return this.delete<String>("/oidc_test_configs/$path_test_slug", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/oidc_test_configs/$path_test_slug", mapOf()
+        )
     }
 
     /**
@@ -628,8 +658,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_oidc_test_config(
         body: WriteOIDCConfig
-    ): SDKResponse {
-        return this.post<OIDCConfig>("/oidc_test_configs", mapOf(), body)
+    ): SdkResult<OIDCConfig, com.looker.sdk.Error> {
+        return this.post<OIDCConfig, com.looker.sdk.Error>(
+            "/oidc_test_configs", mapOf(), body
+        )
     }
 
     /**
@@ -637,8 +669,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /password_config -> PasswordConfig
      */
-    fun password_config(): SDKResponse {
-        return this.get<PasswordConfig>("/password_config", mapOf())
+    fun password_config(): SdkResult<PasswordConfig, com.looker.sdk.Error> {
+        return this.get<PasswordConfig, com.looker.sdk.Error>(
+            "/password_config", mapOf()
+        )
     }
 
     /**
@@ -650,8 +684,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_password_config(
         body: WritePasswordConfig
-    ): SDKResponse {
-        return this.patch<PasswordConfig>("/password_config", mapOf(), body)
+    ): SdkResult<PasswordConfig, com.looker.sdk.Error> {
+        return this.patch<PasswordConfig, com.looker.sdk.Error>(
+            "/password_config", mapOf(), body
+        )
     }
 
     /**
@@ -659,8 +695,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * PUT /password_config/force_password_reset_at_next_login_for_all_users -> String
      */
-    fun force_password_reset_at_next_login_for_all_users(): SDKResponse {
-        return this.put<String>("/password_config/force_password_reset_at_next_login_for_all_users", mapOf())
+    fun force_password_reset_at_next_login_for_all_users(): SdkResult<String, com.looker.sdk.Error> {
+        return this.put<String, com.looker.sdk.Error>(
+            "/password_config/force_password_reset_at_next_login_for_all_users", mapOf()
+        )
     }
 
     /**
@@ -679,8 +717,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /saml_config -> SamlConfig
      */
-    fun saml_config(): SDKResponse {
-        return this.get<SamlConfig>("/saml_config", mapOf())
+    fun saml_config(): SdkResult<SamlConfig, com.looker.sdk.Error> {
+        return this.get<SamlConfig, com.looker.sdk.Error>(
+            "/saml_config", mapOf()
+        )
     }
 
     /**
@@ -700,8 +740,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_saml_config(
         body: WriteSamlConfig
-    ): SDKResponse {
-        return this.patch<SamlConfig>("/saml_config", mapOf(), body)
+    ): SdkResult<SamlConfig, com.looker.sdk.Error> {
+        return this.patch<SamlConfig, com.looker.sdk.Error>(
+            "/saml_config", mapOf(), body
+        )
     }
 
     /**
@@ -713,9 +755,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun saml_test_config(
         test_slug: String
-    ): SDKResponse {
+    ): SdkResult<SamlConfig, com.looker.sdk.Error> {
         val path_test_slug = encodeParam(test_slug)
-        return this.get<SamlConfig>("/saml_test_configs/$path_test_slug", mapOf())
+        return this.get<SamlConfig, com.looker.sdk.Error>(
+            "/saml_test_configs/$path_test_slug", mapOf()
+        )
     }
 
     /**
@@ -727,9 +771,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_saml_test_config(
         test_slug: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_test_slug = encodeParam(test_slug)
-        return this.delete<String>("/saml_test_configs/$path_test_slug", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/saml_test_configs/$path_test_slug", mapOf()
+        )
     }
 
     /**
@@ -741,8 +787,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_saml_test_config(
         body: WriteSamlConfig
-    ): SDKResponse {
-        return this.post<SamlConfig>("/saml_test_configs", mapOf(), body)
+    ): SdkResult<SamlConfig, com.looker.sdk.Error> {
+        return this.post<SamlConfig, com.looker.sdk.Error>(
+            "/saml_test_configs", mapOf(), body
+        )
     }
 
     /**
@@ -754,8 +802,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun parse_saml_idp_metadata(
         body: String
-    ): SDKResponse {
-        return this.post<SamlMetadataParseResult>("/parse_saml_idp_metadata", mapOf(), body)
+    ): SdkResult<SamlMetadataParseResult, com.looker.sdk.Error> {
+        return this.post<SamlMetadataParseResult, com.looker.sdk.Error>(
+            "/parse_saml_idp_metadata", mapOf(), body
+        )
     }
 
     /**
@@ -769,8 +819,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun fetch_and_parse_saml_idp_metadata(
         body: String
-    ): SDKResponse {
-        return this.post<SamlMetadataParseResult>("/fetch_and_parse_saml_idp_metadata", mapOf(), body)
+    ): SdkResult<SamlMetadataParseResult, com.looker.sdk.Error> {
+        return this.post<SamlMetadataParseResult, com.looker.sdk.Error>(
+            "/fetch_and_parse_saml_idp_metadata", mapOf(), body
+        )
     }
 
     /**
@@ -778,8 +830,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /session_config -> SessionConfig
      */
-    fun session_config(): SDKResponse {
-        return this.get<SessionConfig>("/session_config", mapOf())
+    fun session_config(): SdkResult<SessionConfig, com.looker.sdk.Error> {
+        return this.get<SessionConfig, com.looker.sdk.Error>(
+            "/session_config", mapOf()
+        )
     }
 
     /**
@@ -791,8 +845,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_session_config(
         body: WriteSessionConfig
-    ): SDKResponse {
-        return this.patch<SessionConfig>("/session_config", mapOf(), body)
+    ): SdkResult<SessionConfig, com.looker.sdk.Error> {
+        return this.patch<SessionConfig, com.looker.sdk.Error>(
+            "/session_config", mapOf(), body
+        )
     }
 
     /**
@@ -804,8 +860,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_user_login_lockouts(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<UserLoginLockout>>(
+    ): SdkResult<Array<UserLoginLockout>, com.looker.sdk.Error> {
+        return this.get<Array<UserLoginLockout>, com.looker.sdk.Error>(
             "/user_login_lockouts",
             mapOf("fields" to fields)
         )
@@ -836,8 +892,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         email: String? = null,
         remote_id: String? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<Array<UserLoginLockout>>(
+    ): SdkResult<Array<UserLoginLockout>, com.looker.sdk.Error> {
+        return this.get<Array<UserLoginLockout>, com.looker.sdk.Error>(
             "/user_login_lockouts/search",
             mapOf(
                 "fields" to fields,
@@ -862,9 +918,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_user_login_lockout(
         key: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_key = encodeParam(key)
-        return this.delete<String>("/user_login_lockout/$path_key", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/user_login_lockout/$path_key", mapOf()
+        )
     }
 
     //endregion Auth: Manage User Authentication Configuration
@@ -880,8 +938,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_boards(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<Board>>(
+    ): SdkResult<Array<Board>, com.looker.sdk.Error> {
+        return this.get<Array<Board>, com.looker.sdk.Error>(
             "/boards",
             mapOf("fields" to fields)
         )
@@ -898,8 +956,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_board(
         body: WriteBoard,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<Board>(
+    ): SdkResult<Board, com.looker.sdk.Error> {
+        return this.post<Board, com.looker.sdk.Error>(
             "/boards",
             mapOf("fields" to fields), body
         )
@@ -959,8 +1017,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         offset: Long? = null,
         limit: Long? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<Array<Board>>(
+    ): SdkResult<Array<Board>, com.looker.sdk.Error> {
+        return this.get<Array<Board>, com.looker.sdk.Error>(
             "/boards/search",
             mapOf(
                 "title" to title,
@@ -991,9 +1049,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun board(
         board_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Board, com.looker.sdk.Error> {
         val path_board_id = encodeParam(board_id)
-        return this.get<Board>(
+        return this.get<Board, com.looker.sdk.Error>(
             "/boards/$path_board_id",
             mapOf("fields" to fields)
         )
@@ -1012,9 +1070,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         board_id: Long,
         body: WriteBoard,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Board, com.looker.sdk.Error> {
         val path_board_id = encodeParam(board_id)
-        return this.patch<Board>(
+        return this.patch<Board, com.looker.sdk.Error>(
             "/boards/$path_board_id",
             mapOf("fields" to fields), body
         )
@@ -1029,9 +1087,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_board(
         board_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_board_id = encodeParam(board_id)
-        return this.delete<String>("/boards/$path_board_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/boards/$path_board_id", mapOf()
+        )
     }
 
     /**
@@ -1047,8 +1107,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         fields: String? = null,
         sorts: String? = null,
         board_section_id: String? = null
-    ): SDKResponse {
-        return this.get<Array<BoardItem>>(
+    ): SdkResult<Array<BoardItem>, com.looker.sdk.Error> {
+        return this.get<Array<BoardItem>, com.looker.sdk.Error>(
             "/board_items",
             mapOf(
                 "fields" to fields,
@@ -1069,8 +1129,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_board_item(
         body: WriteBoardItem,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<BoardItem>(
+    ): SdkResult<BoardItem, com.looker.sdk.Error> {
+        return this.post<BoardItem, com.looker.sdk.Error>(
             "/board_items",
             mapOf("fields" to fields), body
         )
@@ -1087,9 +1147,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun board_item(
         board_item_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<BoardItem, com.looker.sdk.Error> {
         val path_board_item_id = encodeParam(board_item_id)
-        return this.get<BoardItem>(
+        return this.get<BoardItem, com.looker.sdk.Error>(
             "/board_items/$path_board_item_id",
             mapOf("fields" to fields)
         )
@@ -1108,9 +1168,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         board_item_id: Long,
         body: WriteBoardItem,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<BoardItem, com.looker.sdk.Error> {
         val path_board_item_id = encodeParam(board_item_id)
-        return this.patch<BoardItem>(
+        return this.patch<BoardItem, com.looker.sdk.Error>(
             "/board_items/$path_board_item_id",
             mapOf("fields" to fields), body
         )
@@ -1125,9 +1185,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_board_item(
         board_item_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_board_item_id = encodeParam(board_item_id)
-        return this.delete<String>("/board_items/$path_board_item_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/board_items/$path_board_item_id", mapOf()
+        )
     }
 
     /**
@@ -1141,8 +1203,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_board_sections(
         fields: String? = null,
         sorts: String? = null
-    ): SDKResponse {
-        return this.get<Array<BoardSection>>(
+    ): SdkResult<Array<BoardSection>, com.looker.sdk.Error> {
+        return this.get<Array<BoardSection>, com.looker.sdk.Error>(
             "/board_sections",
             mapOf(
                 "fields" to fields,
@@ -1162,8 +1224,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_board_section(
         body: WriteBoardSection,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<BoardSection>(
+    ): SdkResult<BoardSection, com.looker.sdk.Error> {
+        return this.post<BoardSection, com.looker.sdk.Error>(
             "/board_sections",
             mapOf("fields" to fields), body
         )
@@ -1180,9 +1242,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun board_section(
         board_section_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<BoardSection, com.looker.sdk.Error> {
         val path_board_section_id = encodeParam(board_section_id)
-        return this.get<BoardSection>(
+        return this.get<BoardSection, com.looker.sdk.Error>(
             "/board_sections/$path_board_section_id",
             mapOf("fields" to fields)
         )
@@ -1201,9 +1263,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         board_section_id: Long,
         body: WriteBoardSection,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<BoardSection, com.looker.sdk.Error> {
         val path_board_section_id = encodeParam(board_section_id)
-        return this.patch<BoardSection>(
+        return this.patch<BoardSection, com.looker.sdk.Error>(
             "/board_sections/$path_board_section_id",
             mapOf("fields" to fields), body
         )
@@ -1218,9 +1280,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_board_section(
         board_section_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_board_section_id = encodeParam(board_section_id)
-        return this.delete<String>("/board_sections/$path_board_section_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/board_sections/$path_board_section_id", mapOf()
+        )
     }
 
     //endregion Board: Manage Boards
@@ -1243,8 +1307,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_color_collections(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<ColorCollection>>(
+    ): SdkResult<Array<ColorCollection>, com.looker.sdk.Error> {
+        return this.get<Array<ColorCollection>, com.looker.sdk.Error>(
             "/color_collections",
             mapOf("fields" to fields)
         )
@@ -1267,8 +1331,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_color_collection(
         body: WriteColorCollection
-    ): SDKResponse {
-        return this.post<ColorCollection>("/color_collections", mapOf(), body)
+    ): SdkResult<ColorCollection, com.looker.sdk.Error> {
+        return this.post<ColorCollection, com.looker.sdk.Error>(
+            "/color_collections", mapOf(), body
+        )
     }
 
     /**
@@ -1285,8 +1351,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun color_collections_custom(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<ColorCollection>>(
+    ): SdkResult<Array<ColorCollection>, com.looker.sdk.Error> {
+        return this.get<Array<ColorCollection>, com.looker.sdk.Error>(
             "/color_collections/custom",
             mapOf("fields" to fields)
         )
@@ -1306,8 +1372,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun color_collections_standard(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<ColorCollection>>(
+    ): SdkResult<Array<ColorCollection>, com.looker.sdk.Error> {
+        return this.get<Array<ColorCollection>, com.looker.sdk.Error>(
             "/color_collections/standard",
             mapOf("fields" to fields)
         )
@@ -1322,8 +1388,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /color_collections/default -> ColorCollection
      */
-    fun default_color_collection(): SDKResponse {
-        return this.get<ColorCollection>("/color_collections/default", mapOf())
+    fun default_color_collection(): SdkResult<ColorCollection, com.looker.sdk.Error> {
+        return this.get<ColorCollection, com.looker.sdk.Error>(
+            "/color_collections/default", mapOf()
+        )
     }
 
     /**
@@ -1338,8 +1406,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun set_default_color_collection(
         collection_id: String
-    ): SDKResponse {
-        return this.put<ColorCollection>(
+    ): SdkResult<ColorCollection, com.looker.sdk.Error> {
+        return this.put<ColorCollection, com.looker.sdk.Error>(
             "/color_collections/default",
             mapOf("collection_id" to collection_id)
         )
@@ -1365,9 +1433,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun color_collection(
         collection_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ColorCollection, com.looker.sdk.Error> {
         val path_collection_id = encodeParam(collection_id)
-        return this.get<ColorCollection>(
+        return this.get<ColorCollection, com.looker.sdk.Error>(
             "/color_collections/$path_collection_id",
             mapOf("fields" to fields)
         )
@@ -1385,9 +1453,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     fun update_color_collection(
         collection_id: String,
         body: WriteColorCollection
-    ): SDKResponse {
+    ): SdkResult<ColorCollection, com.looker.sdk.Error> {
         val path_collection_id = encodeParam(collection_id)
-        return this.patch<ColorCollection>("/color_collections/$path_collection_id", mapOf(), body)
+        return this.patch<ColorCollection, com.looker.sdk.Error>(
+            "/color_collections/$path_collection_id", mapOf(), body
+        )
     }
 
     /**
@@ -1406,9 +1476,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_color_collection(
         collection_id: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_collection_id = encodeParam(collection_id)
-        return this.delete<String>("/color_collections/$path_collection_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/color_collections/$path_collection_id", mapOf()
+        )
     }
 
     //endregion ColorCollection: Manage Color Collections
@@ -1428,8 +1500,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         content_id: String? = null,
         content_type: String? = null,
         limit: Long? = null
-    ): SDKResponse {
-        return this.get<Array<Command>>(
+    ): SdkResult<Array<Command>, com.looker.sdk.Error> {
+        return this.get<Array<Command>, com.looker.sdk.Error>(
             "/commands",
             mapOf(
                 "content_id" to content_id,
@@ -1451,8 +1523,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_command(
         body: WriteCommand
-    ): SDKResponse {
-        return this.post<Command>("/commands", mapOf(), body)
+    ): SdkResult<Command, com.looker.sdk.Error> {
+        return this.post<Command, com.looker.sdk.Error>(
+            "/commands", mapOf(), body
+        )
     }
 
     /**
@@ -1468,9 +1542,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     fun update_command(
         command_id: Long,
         body: UpdateCommand
-    ): SDKResponse {
+    ): SdkResult<Command, com.looker.sdk.Error> {
         val path_command_id = encodeParam(command_id)
-        return this.patch<Command>("/commands/$path_command_id", mapOf(), body)
+        return this.patch<Command, com.looker.sdk.Error>(
+            "/commands/$path_command_id", mapOf(), body
+        )
     }
 
     /**
@@ -1482,9 +1558,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_command(
         command_id: Long
-    ): SDKResponse {
+    ): SdkResult<Void, com.looker.sdk.Error> {
         val path_command_id = encodeParam(command_id)
-        return this.delete<Void>("/commands/$path_command_id", mapOf())
+        return this.delete<Void, com.looker.sdk.Error>(
+            "/commands/$path_command_id", mapOf()
+        )
     }
 
     //endregion Command: Manage Commands
@@ -1496,8 +1574,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /cloud_storage -> BackupConfiguration
      */
-    fun cloud_storage_configuration(): SDKResponse {
-        return this.get<BackupConfiguration>("/cloud_storage", mapOf())
+    fun cloud_storage_configuration(): SdkResult<BackupConfiguration, com.looker.sdk.Error> {
+        return this.get<BackupConfiguration, com.looker.sdk.Error>(
+            "/cloud_storage", mapOf()
+        )
     }
 
     /**
@@ -1509,8 +1589,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_cloud_storage_configuration(
         body: WriteBackupConfiguration
-    ): SDKResponse {
-        return this.patch<BackupConfiguration>("/cloud_storage", mapOf(), body)
+    ): SdkResult<BackupConfiguration, com.looker.sdk.Error> {
+        return this.patch<BackupConfiguration, com.looker.sdk.Error>(
+            "/cloud_storage", mapOf(), body
+        )
     }
 
     /**
@@ -1518,8 +1600,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /custom_welcome_email -> CustomWelcomeEmail
      */
-    fun custom_welcome_email(): SDKResponse {
-        return this.get<CustomWelcomeEmail>("/custom_welcome_email", mapOf())
+    fun custom_welcome_email(): SdkResult<CustomWelcomeEmail, com.looker.sdk.Error> {
+        return this.get<CustomWelcomeEmail, com.looker.sdk.Error>(
+            "/custom_welcome_email", mapOf()
+        )
     }
 
     /**
@@ -1533,8 +1617,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun update_custom_welcome_email(
         body: WriteCustomWelcomeEmail,
         send_test_welcome_email: Boolean? = null
-    ): SDKResponse {
-        return this.patch<CustomWelcomeEmail>(
+    ): SdkResult<CustomWelcomeEmail, com.looker.sdk.Error> {
+        return this.patch<CustomWelcomeEmail, com.looker.sdk.Error>(
             "/custom_welcome_email",
             mapOf("send_test_welcome_email" to send_test_welcome_email), body
         )
@@ -1549,8 +1633,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_custom_welcome_email_test(
         body: WelcomeEmailTest
-    ): SDKResponse {
-        return this.put<WelcomeEmailTest>("/custom_welcome_email_test", mapOf(), body)
+    ): SdkResult<WelcomeEmailTest, com.looker.sdk.Error> {
+        return this.put<WelcomeEmailTest, com.looker.sdk.Error>(
+            "/custom_welcome_email_test", mapOf(), body
+        )
     }
 
     /**
@@ -1558,8 +1644,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /digest_emails_enabled -> DigestEmails
      */
-    fun digest_emails_enabled(): SDKResponse {
-        return this.get<DigestEmails>("/digest_emails_enabled", mapOf())
+    fun digest_emails_enabled(): SdkResult<DigestEmails, com.looker.sdk.Error> {
+        return this.get<DigestEmails, com.looker.sdk.Error>(
+            "/digest_emails_enabled", mapOf()
+        )
     }
 
     /**
@@ -1571,8 +1659,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_digest_emails_enabled(
         body: DigestEmails
-    ): SDKResponse {
-        return this.patch<DigestEmails>("/digest_emails_enabled", mapOf(), body)
+    ): SdkResult<DigestEmails, com.looker.sdk.Error> {
+        return this.patch<DigestEmails, com.looker.sdk.Error>(
+            "/digest_emails_enabled", mapOf(), body
+        )
     }
 
     /**
@@ -1582,8 +1672,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * POST /digest_email_send -> DigestEmailSend
      */
-    fun create_digest_email_send(): SDKResponse {
-        return this.post<DigestEmailSend>("/digest_email_send", mapOf())
+    fun create_digest_email_send(): SdkResult<DigestEmailSend, com.looker.sdk.Error> {
+        return this.post<DigestEmailSend, com.looker.sdk.Error>(
+            "/digest_email_send", mapOf()
+        )
     }
 
     /**
@@ -1591,8 +1683,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /internal_help_resources_content -> InternalHelpResourcesContent
      */
-    fun internal_help_resources_content(): SDKResponse {
-        return this.get<InternalHelpResourcesContent>("/internal_help_resources_content", mapOf())
+    fun internal_help_resources_content(): SdkResult<InternalHelpResourcesContent, com.looker.sdk.Error> {
+        return this.get<InternalHelpResourcesContent, com.looker.sdk.Error>(
+            "/internal_help_resources_content", mapOf()
+        )
     }
 
     /**
@@ -1604,8 +1698,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_internal_help_resources_content(
         body: WriteInternalHelpResourcesContent
-    ): SDKResponse {
-        return this.patch<InternalHelpResourcesContent>("/internal_help_resources_content", mapOf(), body)
+    ): SdkResult<InternalHelpResourcesContent, com.looker.sdk.Error> {
+        return this.patch<InternalHelpResourcesContent, com.looker.sdk.Error>(
+            "/internal_help_resources_content", mapOf(), body
+        )
     }
 
     /**
@@ -1613,8 +1709,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /internal_help_resources_enabled -> InternalHelpResources
      */
-    fun internal_help_resources(): SDKResponse {
-        return this.get<InternalHelpResources>("/internal_help_resources_enabled", mapOf())
+    fun internal_help_resources(): SdkResult<InternalHelpResources, com.looker.sdk.Error> {
+        return this.get<InternalHelpResources, com.looker.sdk.Error>(
+            "/internal_help_resources_enabled", mapOf()
+        )
     }
 
     /**
@@ -1626,8 +1724,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_internal_help_resources(
         body: WriteInternalHelpResources
-    ): SDKResponse {
-        return this.patch<InternalHelpResources>("/internal_help_resources", mapOf(), body)
+    ): SdkResult<InternalHelpResources, com.looker.sdk.Error> {
+        return this.patch<InternalHelpResources, com.looker.sdk.Error>(
+            "/internal_help_resources", mapOf(), body
+        )
     }
 
     /**
@@ -1635,8 +1735,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /legacy_features -> Array<LegacyFeature>
      */
-    fun all_legacy_features(): SDKResponse {
-        return this.get<Array<LegacyFeature>>("/legacy_features", mapOf())
+    fun all_legacy_features(): SdkResult<Array<LegacyFeature>, com.looker.sdk.Error> {
+        return this.get<Array<LegacyFeature>, com.looker.sdk.Error>(
+            "/legacy_features", mapOf()
+        )
     }
 
     /**
@@ -1648,9 +1750,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun legacy_feature(
         legacy_feature_id: String
-    ): SDKResponse {
+    ): SdkResult<LegacyFeature, com.looker.sdk.Error> {
         val path_legacy_feature_id = encodeParam(legacy_feature_id)
-        return this.get<LegacyFeature>("/legacy_features/$path_legacy_feature_id", mapOf())
+        return this.get<LegacyFeature, com.looker.sdk.Error>(
+            "/legacy_features/$path_legacy_feature_id", mapOf()
+        )
     }
 
     /**
@@ -1664,9 +1768,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     fun update_legacy_feature(
         legacy_feature_id: String,
         body: WriteLegacyFeature
-    ): SDKResponse {
+    ): SdkResult<LegacyFeature, com.looker.sdk.Error> {
         val path_legacy_feature_id = encodeParam(legacy_feature_id)
-        return this.patch<LegacyFeature>("/legacy_features/$path_legacy_feature_id", mapOf(), body)
+        return this.patch<LegacyFeature, com.looker.sdk.Error>(
+            "/legacy_features/$path_legacy_feature_id", mapOf(), body
+        )
     }
 
     /**
@@ -1674,8 +1780,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /locales -> Array<Locale>
      */
-    fun all_locales(): SDKResponse {
-        return this.get<Array<Locale>>("/locales", mapOf())
+    fun all_locales(): SdkResult<Array<Locale>, com.looker.sdk.Error> {
+        return this.get<Array<Locale>, com.looker.sdk.Error>(
+            "/locales", mapOf()
+        )
     }
 
     /**
@@ -1683,8 +1791,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /timezones -> Array<Timezone>
      */
-    fun all_timezones(): SDKResponse {
-        return this.get<Array<Timezone>>("/timezones", mapOf())
+    fun all_timezones(): SdkResult<Array<Timezone>, com.looker.sdk.Error> {
+        return this.get<Array<Timezone>, com.looker.sdk.Error>(
+            "/timezones", mapOf()
+        )
     }
 
     /**
@@ -1696,8 +1806,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun versions(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ApiVersion>(
+    ): SdkResult<ApiVersion, com.looker.sdk.Error> {
+        return this.get<ApiVersion, com.looker.sdk.Error>(
             "/versions",
             mapOf("fields" to fields)
         )
@@ -1713,8 +1823,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun whitelabel_configuration(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<WhitelabelConfiguration>(
+    ): SdkResult<WhitelabelConfiguration, com.looker.sdk.Error> {
+        return this.get<WhitelabelConfiguration, com.looker.sdk.Error>(
             "/whitelabel_configuration",
             mapOf("fields" to fields)
         )
@@ -1729,8 +1839,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_whitelabel_configuration(
         body: WriteWhitelabelConfiguration
-    ): SDKResponse {
-        return this.put<WhitelabelConfiguration>("/whitelabel_configuration", mapOf(), body)
+    ): SdkResult<WhitelabelConfiguration, com.looker.sdk.Error> {
+        return this.put<WhitelabelConfiguration, com.looker.sdk.Error>(
+            "/whitelabel_configuration", mapOf(), body
+        )
     }
 
     //endregion Config: Manage General Configuration
@@ -1746,8 +1858,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_connections(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<DBConnection>>(
+    ): SdkResult<Array<DBConnection>, com.looker.sdk.Error> {
+        return this.get<Array<DBConnection>, com.looker.sdk.Error>(
             "/connections",
             mapOf("fields" to fields)
         )
@@ -1762,8 +1874,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_connection(
         body: WriteDBConnection
-    ): SDKResponse {
-        return this.post<DBConnection>("/connections", mapOf(), body)
+    ): SdkResult<DBConnection, com.looker.sdk.Error> {
+        return this.post<DBConnection, com.looker.sdk.Error>(
+            "/connections", mapOf(), body
+        )
     }
 
     /**
@@ -1777,9 +1891,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun connection(
         connection_name: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<DBConnection, com.looker.sdk.Error> {
         val path_connection_name = encodeParam(connection_name)
-        return this.get<DBConnection>(
+        return this.get<DBConnection, com.looker.sdk.Error>(
             "/connections/$path_connection_name",
             mapOf("fields" to fields)
         )
@@ -1796,9 +1910,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     fun update_connection(
         connection_name: String,
         body: WriteDBConnection
-    ): SDKResponse {
+    ): SdkResult<DBConnection, com.looker.sdk.Error> {
         val path_connection_name = encodeParam(connection_name)
-        return this.patch<DBConnection>("/connections/$path_connection_name", mapOf(), body)
+        return this.patch<DBConnection, com.looker.sdk.Error>(
+            "/connections/$path_connection_name", mapOf(), body
+        )
     }
 
     /**
@@ -1810,9 +1926,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_connection(
         connection_name: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_connection_name = encodeParam(connection_name)
-        return this.delete<String>("/connections/$path_connection_name", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/connections/$path_connection_name", mapOf()
+        )
     }
 
     /**
@@ -1826,10 +1944,12 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     fun delete_connection_override(
         connection_name: String,
         override_context: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_connection_name = encodeParam(connection_name)
         val path_override_context = encodeParam(override_context)
-        return this.delete<String>("/connections/$path_connection_name/connection_override/$path_override_context", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/connections/$path_connection_name/connection_override/$path_override_context", mapOf()
+        )
     }
 
     /**
@@ -1850,9 +1970,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun test_connection(
         connection_name: String,
         tests: DelimArray<String>? = null
-    ): SDKResponse {
+    ): SdkResult<Array<DBConnectionTestResult>, com.looker.sdk.Error> {
         val path_connection_name = encodeParam(connection_name)
-        return this.put<Array<DBConnectionTestResult>>(
+        return this.put<Array<DBConnectionTestResult>, com.looker.sdk.Error>(
             "/connections/$path_connection_name/test",
             mapOf("tests" to tests)
         )
@@ -1876,8 +1996,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun test_connection_config(
         body: WriteDBConnection,
         tests: DelimArray<String>? = null
-    ): SDKResponse {
-        return this.put<Array<DBConnectionTestResult>>(
+    ): SdkResult<Array<DBConnectionTestResult>, com.looker.sdk.Error> {
+        return this.put<Array<DBConnectionTestResult>, com.looker.sdk.Error>(
             "/connections/test",
             mapOf("tests" to tests), body
         )
@@ -1892,8 +2012,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_dialect_infos(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<DialectInfo>>(
+    ): SdkResult<Array<DialectInfo>, com.looker.sdk.Error> {
+        return this.get<Array<DialectInfo>, com.looker.sdk.Error>(
             "/dialect_info",
             mapOf("fields" to fields)
         )
@@ -1908,8 +2028,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_ssh_servers(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<SshServer>>(
+    ): SdkResult<Array<SshServer>, com.looker.sdk.Error> {
+        return this.get<Array<SshServer>, com.looker.sdk.Error>(
             "/ssh_servers",
             mapOf("fields" to fields)
         )
@@ -1924,8 +2044,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_ssh_server(
         body: WriteSshServer
-    ): SDKResponse {
-        return this.post<SshServer>("/ssh_servers", mapOf(), body)
+    ): SdkResult<SshServer, com.looker.sdk.Error> {
+        return this.post<SshServer, com.looker.sdk.Error>(
+            "/ssh_servers", mapOf(), body
+        )
     }
 
     /**
@@ -1937,9 +2059,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun ssh_server(
         ssh_server_id: String
-    ): SDKResponse {
+    ): SdkResult<SshServer, com.looker.sdk.Error> {
         val path_ssh_server_id = encodeParam(ssh_server_id)
-        return this.get<SshServer>("/ssh_server/$path_ssh_server_id", mapOf())
+        return this.get<SshServer, com.looker.sdk.Error>(
+            "/ssh_server/$path_ssh_server_id", mapOf()
+        )
     }
 
     /**
@@ -1953,9 +2077,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     fun update_ssh_server(
         ssh_server_id: String,
         body: WriteSshServer
-    ): SDKResponse {
+    ): SdkResult<SshServer, com.looker.sdk.Error> {
         val path_ssh_server_id = encodeParam(ssh_server_id)
-        return this.patch<SshServer>("/ssh_server/$path_ssh_server_id", mapOf(), body)
+        return this.patch<SshServer, com.looker.sdk.Error>(
+            "/ssh_server/$path_ssh_server_id", mapOf(), body
+        )
     }
 
     /**
@@ -1967,9 +2093,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_ssh_server(
         ssh_server_id: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_ssh_server_id = encodeParam(ssh_server_id)
-        return this.delete<String>("/ssh_server/$path_ssh_server_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/ssh_server/$path_ssh_server_id", mapOf()
+        )
     }
 
     /**
@@ -1981,9 +2109,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun test_ssh_server(
         ssh_server_id: String
-    ): SDKResponse {
+    ): SdkResult<SshServer, com.looker.sdk.Error> {
         val path_ssh_server_id = encodeParam(ssh_server_id)
-        return this.get<SshServer>("/ssh_server/$path_ssh_server_id/test", mapOf())
+        return this.get<SshServer, com.looker.sdk.Error>(
+            "/ssh_server/$path_ssh_server_id/test", mapOf()
+        )
     }
 
     /**
@@ -1995,8 +2125,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_ssh_tunnels(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<SshTunnel>>(
+    ): SdkResult<Array<SshTunnel>, com.looker.sdk.Error> {
+        return this.get<Array<SshTunnel>, com.looker.sdk.Error>(
             "/ssh_tunnels",
             mapOf("fields" to fields)
         )
@@ -2011,8 +2141,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_ssh_tunnel(
         body: WriteSshTunnel
-    ): SDKResponse {
-        return this.post<SshTunnel>("/ssh_tunnels", mapOf(), body)
+    ): SdkResult<SshTunnel, com.looker.sdk.Error> {
+        return this.post<SshTunnel, com.looker.sdk.Error>(
+            "/ssh_tunnels", mapOf(), body
+        )
     }
 
     /**
@@ -2024,9 +2156,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun ssh_tunnel(
         ssh_tunnel_id: String
-    ): SDKResponse {
+    ): SdkResult<SshTunnel, com.looker.sdk.Error> {
         val path_ssh_tunnel_id = encodeParam(ssh_tunnel_id)
-        return this.get<SshTunnel>("/ssh_tunnel/$path_ssh_tunnel_id", mapOf())
+        return this.get<SshTunnel, com.looker.sdk.Error>(
+            "/ssh_tunnel/$path_ssh_tunnel_id", mapOf()
+        )
     }
 
     /**
@@ -2040,9 +2174,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     fun update_ssh_tunnel(
         ssh_tunnel_id: String,
         body: WriteSshTunnel
-    ): SDKResponse {
+    ): SdkResult<SshTunnel, com.looker.sdk.Error> {
         val path_ssh_tunnel_id = encodeParam(ssh_tunnel_id)
-        return this.patch<SshTunnel>("/ssh_tunnel/$path_ssh_tunnel_id", mapOf(), body)
+        return this.patch<SshTunnel, com.looker.sdk.Error>(
+            "/ssh_tunnel/$path_ssh_tunnel_id", mapOf(), body
+        )
     }
 
     /**
@@ -2054,9 +2190,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_ssh_tunnel(
         ssh_tunnel_id: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_ssh_tunnel_id = encodeParam(ssh_tunnel_id)
-        return this.delete<String>("/ssh_tunnel/$path_ssh_tunnel_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/ssh_tunnel/$path_ssh_tunnel_id", mapOf()
+        )
     }
 
     /**
@@ -2068,9 +2206,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun test_ssh_tunnel(
         ssh_tunnel_id: String
-    ): SDKResponse {
+    ): SdkResult<SshTunnel, com.looker.sdk.Error> {
         val path_ssh_tunnel_id = encodeParam(ssh_tunnel_id)
-        return this.get<SshTunnel>("/ssh_tunnel/$path_ssh_tunnel_id/test", mapOf())
+        return this.get<SshTunnel, com.looker.sdk.Error>(
+            "/ssh_tunnel/$path_ssh_tunnel_id/test", mapOf()
+        )
     }
 
     /**
@@ -2080,8 +2220,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /ssh_public_key -> SshPublicKey
      */
-    fun ssh_public_key(): SDKResponse {
-        return this.get<SshPublicKey>("/ssh_public_key", mapOf())
+    fun ssh_public_key(): SdkResult<SshPublicKey, com.looker.sdk.Error> {
+        return this.get<SshPublicKey, com.looker.sdk.Error>(
+            "/ssh_public_key", mapOf()
+        )
     }
 
     //endregion Connection: Manage Database Connections
@@ -2138,8 +2280,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         sorts: String? = null,
         fields: String? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<Array<ContentFavorite>>(
+    ): SdkResult<Array<ContentFavorite>, com.looker.sdk.Error> {
+        return this.get<Array<ContentFavorite>, com.looker.sdk.Error>(
             "/content_favorite/search",
             mapOf(
                 "id" to id,
@@ -2168,9 +2310,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun content_favorite(
         content_favorite_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ContentFavorite, com.looker.sdk.Error> {
         val path_content_favorite_id = encodeParam(content_favorite_id)
-        return this.get<ContentFavorite>(
+        return this.get<ContentFavorite, com.looker.sdk.Error>(
             "/content_favorite/$path_content_favorite_id",
             mapOf("fields" to fields)
         )
@@ -2185,9 +2327,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_content_favorite(
         content_favorite_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_content_favorite_id = encodeParam(content_favorite_id)
-        return this.delete<String>("/content_favorite/$path_content_favorite_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/content_favorite/$path_content_favorite_id", mapOf()
+        )
     }
 
     /**
@@ -2199,8 +2343,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_content_favorite(
         body: WriteContentFavorite
-    ): SDKResponse {
-        return this.post<ContentFavorite>("/content_favorite", mapOf(), body)
+    ): SdkResult<ContentFavorite, com.looker.sdk.Error> {
+        return this.post<ContentFavorite, com.looker.sdk.Error>(
+            "/content_favorite", mapOf(), body
+        )
     }
 
     /**
@@ -2214,8 +2360,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_content_metadatas(
         parent_id: Long,
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<ContentMeta>>(
+    ): SdkResult<Array<ContentMeta>, com.looker.sdk.Error> {
+        return this.get<Array<ContentMeta>, com.looker.sdk.Error>(
             "/content_metadata",
             mapOf(
                 "parent_id" to parent_id,
@@ -2235,9 +2381,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun content_metadata(
         content_metadata_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ContentMeta, com.looker.sdk.Error> {
         val path_content_metadata_id = encodeParam(content_metadata_id)
-        return this.get<ContentMeta>(
+        return this.get<ContentMeta, com.looker.sdk.Error>(
             "/content_metadata/$path_content_metadata_id",
             mapOf("fields" to fields)
         )
@@ -2254,9 +2400,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     fun update_content_metadata(
         content_metadata_id: Long,
         body: WriteContentMeta
-    ): SDKResponse {
+    ): SdkResult<ContentMeta, com.looker.sdk.Error> {
         val path_content_metadata_id = encodeParam(content_metadata_id)
-        return this.patch<ContentMeta>("/content_metadata/$path_content_metadata_id", mapOf(), body)
+        return this.patch<ContentMeta, com.looker.sdk.Error>(
+            "/content_metadata/$path_content_metadata_id", mapOf(), body
+        )
     }
 
     /**
@@ -2270,8 +2418,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_content_metadata_accesses(
         content_metadata_id: Long,
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<ContentMetaGroupUser>>(
+    ): SdkResult<Array<ContentMetaGroupUser>, com.looker.sdk.Error> {
+        return this.get<Array<ContentMetaGroupUser>, com.looker.sdk.Error>(
             "/content_metadata_access",
             mapOf(
                 "content_metadata_id" to content_metadata_id,
@@ -2291,8 +2439,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_content_metadata_access(
         body: ContentMetaGroupUser,
         send_boards_notification_email: Boolean? = null
-    ): SDKResponse {
-        return this.post<ContentMetaGroupUser>(
+    ): SdkResult<ContentMetaGroupUser, com.looker.sdk.Error> {
+        return this.post<ContentMetaGroupUser, com.looker.sdk.Error>(
             "/content_metadata_access",
             mapOf("send_boards_notification_email" to send_boards_notification_email), body
         )
@@ -2309,9 +2457,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     fun update_content_metadata_access(
         content_metadata_access_id: String,
         body: ContentMetaGroupUser
-    ): SDKResponse {
+    ): SdkResult<ContentMetaGroupUser, com.looker.sdk.Error> {
         val path_content_metadata_access_id = encodeParam(content_metadata_access_id)
-        return this.put<ContentMetaGroupUser>("/content_metadata_access/$path_content_metadata_access_id", mapOf(), body)
+        return this.put<ContentMetaGroupUser, com.looker.sdk.Error>(
+            "/content_metadata_access/$path_content_metadata_access_id", mapOf(), body
+        )
     }
 
     /**
@@ -2323,9 +2473,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_content_metadata_access(
         content_metadata_access_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_content_metadata_access_id = encodeParam(content_metadata_access_id)
-        return this.delete<String>("/content_metadata_access/$path_content_metadata_access_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/content_metadata_access/$path_content_metadata_access_id", mapOf()
+        )
     }
 
     /**
@@ -2352,10 +2504,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         format: String? = null,
         width: Long? = null,
         height: Long? = null
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_type = encodeParam(type)
         val path_resource_id = encodeParam(resource_id)
-        return this.get<String>(
+        return this.get<String, com.looker.sdk.Error>(
             "/content_thumbnail/$path_type/$path_resource_id",
             mapOf(
                 "reload" to reload,
@@ -2378,8 +2530,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun content_validation(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ContentValidation>(
+    ): SdkResult<ContentValidation, com.looker.sdk.Error> {
+        return this.get<ContentValidation, com.looker.sdk.Error>(
             "/content_validation",
             mapOf("fields" to fields)
         )
@@ -2439,8 +2591,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         offset: Long? = null,
         sorts: String? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<Array<ContentView>>(
+    ): SdkResult<Array<ContentView>, com.looker.sdk.Error> {
+        return this.get<Array<ContentView>, com.looker.sdk.Error>(
             "/content_view/search",
             mapOf(
                 "view_count" to view_count,
@@ -2478,10 +2630,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         type: String,
         resource_id: String,
         reload: String? = null
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_type = encodeParam(type)
         val path_resource_id = encodeParam(resource_id)
-        return this.get<String>(
+        return this.get<String, com.looker.sdk.Error>(
             "/vector_thumbnail/$path_type/$path_resource_id",
             mapOf("reload" to reload)
         )
@@ -2506,8 +2658,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_dashboards(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<DashboardBase>>(
+    ): SdkResult<Array<DashboardBase>, com.looker.sdk.Error> {
+        return this.get<Array<DashboardBase>, com.looker.sdk.Error>(
             "/dashboards",
             mapOf("fields" to fields)
         )
@@ -2535,8 +2687,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_dashboard(
         body: WriteDashboard
-    ): SDKResponse {
-        return this.post<Dashboard>("/dashboards", mapOf(), body)
+    ): SdkResult<Dashboard, com.looker.sdk.Error> {
+        return this.post<Dashboard, com.looker.sdk.Error>(
+            "/dashboards", mapOf(), body
+        )
     }
 
     /**
@@ -2612,8 +2766,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         offset: Long? = null,
         sorts: String? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<Array<Dashboard>>(
+    ): SdkResult<Array<Dashboard>, com.looker.sdk.Error> {
+        return this.get<Array<Dashboard>, com.looker.sdk.Error>(
             "/dashboards/search",
             mapOf(
                 "id" to id,
@@ -2665,10 +2819,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         space_id: String,
         body: WriteDashboard? = null,
         raw_locale: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<Dashboard, com.looker.sdk.Error> {
         val path_lookml_dashboard_id = encodeParam(lookml_dashboard_id)
         val path_space_id = encodeParam(space_id)
-        return this.post<Dashboard>(
+        return this.post<Dashboard, com.looker.sdk.Error>(
             "/dashboards/$path_lookml_dashboard_id/import/$path_space_id",
             mapOf("raw_locale" to raw_locale), body
         )
@@ -2695,9 +2849,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         lookml_dashboard_id: String,
         body: WriteDashboard,
         raw_locale: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<Array<Long>, com.looker.sdk.Error> {
         val path_lookml_dashboard_id = encodeParam(lookml_dashboard_id)
-        return this.patch<Array<Long>>(
+        return this.patch<Array<Long>, com.looker.sdk.Error>(
             "/dashboards/$path_lookml_dashboard_id/sync",
             mapOf("raw_locale" to raw_locale), body
         )
@@ -2720,9 +2874,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun dashboard(
         dashboard_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Dashboard, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
-        return this.get<Dashboard>(
+        return this.get<Dashboard, com.looker.sdk.Error>(
             "/dashboards/$path_dashboard_id",
             mapOf("fields" to fields)
         )
@@ -2748,9 +2902,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     fun update_dashboard(
         dashboard_id: String,
         body: WriteDashboard
-    ): SDKResponse {
+    ): SdkResult<Dashboard, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
-        return this.patch<Dashboard>("/dashboards/$path_dashboard_id", mapOf(), body)
+        return this.patch<Dashboard, com.looker.sdk.Error>(
+            "/dashboards/$path_dashboard_id", mapOf(), body
+        )
     }
 
     /**
@@ -2768,9 +2924,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_dashboard(
         dashboard_id: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
-        return this.delete<String>("/dashboards/$path_dashboard_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/dashboards/$path_dashboard_id", mapOf()
+        )
     }
 
     /**
@@ -2784,9 +2942,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun dashboard_aggregate_table_lookml(
         dashboard_id: String
-    ): SDKResponse {
+    ): SdkResult<DashboardAggregateTableLookml, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
-        return this.get<DashboardAggregateTableLookml>("/dashboards/aggregate_table_lookml/$path_dashboard_id", mapOf())
+        return this.get<DashboardAggregateTableLookml, com.looker.sdk.Error>(
+            "/dashboards/aggregate_table_lookml/$path_dashboard_id", mapOf()
+        )
     }
 
     /**
@@ -2800,9 +2960,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun dashboard_lookml(
         dashboard_id: String
-    ): SDKResponse {
+    ): SdkResult<DashboardLookml, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
-        return this.get<DashboardLookml>("/dashboards/lookml/$path_dashboard_id", mapOf())
+        return this.get<DashboardLookml, com.looker.sdk.Error>(
+            "/dashboards/lookml/$path_dashboard_id", mapOf()
+        )
     }
 
     /**
@@ -2849,8 +3011,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         fields: String? = null,
         filter_or: Boolean? = null,
         sorts: String? = null
-    ): SDKResponse {
-        return this.get<Array<DashboardElement>>(
+    ): SdkResult<Array<DashboardElement>, com.looker.sdk.Error> {
+        return this.get<Array<DashboardElement>, com.looker.sdk.Error>(
             "/dashboard_elements/search",
             mapOf(
                 "dashboard_id" to dashboard_id,
@@ -2875,9 +3037,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun dashboard_element(
         dashboard_element_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<DashboardElement, com.looker.sdk.Error> {
         val path_dashboard_element_id = encodeParam(dashboard_element_id)
-        return this.get<DashboardElement>(
+        return this.get<DashboardElement, com.looker.sdk.Error>(
             "/dashboard_elements/$path_dashboard_element_id",
             mapOf("fields" to fields)
         )
@@ -2896,9 +3058,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         dashboard_element_id: String,
         body: WriteDashboardElement,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<DashboardElement, com.looker.sdk.Error> {
         val path_dashboard_element_id = encodeParam(dashboard_element_id)
-        return this.patch<DashboardElement>(
+        return this.patch<DashboardElement, com.looker.sdk.Error>(
             "/dashboard_elements/$path_dashboard_element_id",
             mapOf("fields" to fields), body
         )
@@ -2913,9 +3075,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_dashboard_element(
         dashboard_element_id: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_dashboard_element_id = encodeParam(dashboard_element_id)
-        return this.delete<String>("/dashboard_elements/$path_dashboard_element_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/dashboard_elements/$path_dashboard_element_id", mapOf()
+        )
     }
 
     /**
@@ -2929,9 +3093,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun dashboard_dashboard_elements(
         dashboard_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<DashboardElement>, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
-        return this.get<Array<DashboardElement>>(
+        return this.get<Array<DashboardElement>, com.looker.sdk.Error>(
             "/dashboards/$path_dashboard_id/dashboard_elements",
             mapOf("fields" to fields)
         )
@@ -2948,8 +3112,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_dashboard_element(
         body: WriteDashboardElement,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<DashboardElement>(
+    ): SdkResult<DashboardElement, com.looker.sdk.Error> {
+        return this.post<DashboardElement, com.looker.sdk.Error>(
             "/dashboard_elements",
             mapOf("fields" to fields), body
         )
@@ -2966,9 +3130,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun dashboard_filter(
         dashboard_filter_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<DashboardFilter, com.looker.sdk.Error> {
         val path_dashboard_filter_id = encodeParam(dashboard_filter_id)
-        return this.get<DashboardFilter>(
+        return this.get<DashboardFilter, com.looker.sdk.Error>(
             "/dashboard_filters/$path_dashboard_filter_id",
             mapOf("fields" to fields)
         )
@@ -2987,9 +3151,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         dashboard_filter_id: String,
         body: WriteDashboardFilter,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<DashboardFilter, com.looker.sdk.Error> {
         val path_dashboard_filter_id = encodeParam(dashboard_filter_id)
-        return this.patch<DashboardFilter>(
+        return this.patch<DashboardFilter, com.looker.sdk.Error>(
             "/dashboard_filters/$path_dashboard_filter_id",
             mapOf("fields" to fields), body
         )
@@ -3004,9 +3168,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_dashboard_filter(
         dashboard_filter_id: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_dashboard_filter_id = encodeParam(dashboard_filter_id)
-        return this.delete<String>("/dashboard_filters/$path_dashboard_filter_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/dashboard_filters/$path_dashboard_filter_id", mapOf()
+        )
     }
 
     /**
@@ -3020,9 +3186,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun dashboard_dashboard_filters(
         dashboard_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<DashboardFilter>, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
-        return this.get<Array<DashboardFilter>>(
+        return this.get<Array<DashboardFilter>, com.looker.sdk.Error>(
             "/dashboards/$path_dashboard_id/dashboard_filters",
             mapOf("fields" to fields)
         )
@@ -3039,8 +3205,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_dashboard_filter(
         body: WriteCreateDashboardFilter,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<DashboardFilter>(
+    ): SdkResult<DashboardFilter, com.looker.sdk.Error> {
+        return this.post<DashboardFilter, com.looker.sdk.Error>(
             "/dashboard_filters",
             mapOf("fields" to fields), body
         )
@@ -3057,9 +3223,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun dashboard_layout_component(
         dashboard_layout_component_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<DashboardLayoutComponent, com.looker.sdk.Error> {
         val path_dashboard_layout_component_id = encodeParam(dashboard_layout_component_id)
-        return this.get<DashboardLayoutComponent>(
+        return this.get<DashboardLayoutComponent, com.looker.sdk.Error>(
             "/dashboard_layout_components/$path_dashboard_layout_component_id",
             mapOf("fields" to fields)
         )
@@ -3078,9 +3244,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         dashboard_layout_component_id: String,
         body: WriteDashboardLayoutComponent,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<DashboardLayoutComponent, com.looker.sdk.Error> {
         val path_dashboard_layout_component_id = encodeParam(dashboard_layout_component_id)
-        return this.patch<DashboardLayoutComponent>(
+        return this.patch<DashboardLayoutComponent, com.looker.sdk.Error>(
             "/dashboard_layout_components/$path_dashboard_layout_component_id",
             mapOf("fields" to fields), body
         )
@@ -3097,9 +3263,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun dashboard_layout_dashboard_layout_components(
         dashboard_layout_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<DashboardLayoutComponent>, com.looker.sdk.Error> {
         val path_dashboard_layout_id = encodeParam(dashboard_layout_id)
-        return this.get<Array<DashboardLayoutComponent>>(
+        return this.get<Array<DashboardLayoutComponent>, com.looker.sdk.Error>(
             "/dashboard_layouts/$path_dashboard_layout_id/dashboard_layout_components",
             mapOf("fields" to fields)
         )
@@ -3116,9 +3282,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun dashboard_layout(
         dashboard_layout_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<DashboardLayout, com.looker.sdk.Error> {
         val path_dashboard_layout_id = encodeParam(dashboard_layout_id)
-        return this.get<DashboardLayout>(
+        return this.get<DashboardLayout, com.looker.sdk.Error>(
             "/dashboard_layouts/$path_dashboard_layout_id",
             mapOf("fields" to fields)
         )
@@ -3137,9 +3303,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         dashboard_layout_id: String,
         body: WriteDashboardLayout,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<DashboardLayout, com.looker.sdk.Error> {
         val path_dashboard_layout_id = encodeParam(dashboard_layout_id)
-        return this.patch<DashboardLayout>(
+        return this.patch<DashboardLayout, com.looker.sdk.Error>(
             "/dashboard_layouts/$path_dashboard_layout_id",
             mapOf("fields" to fields), body
         )
@@ -3154,9 +3320,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_dashboard_layout(
         dashboard_layout_id: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_dashboard_layout_id = encodeParam(dashboard_layout_id)
-        return this.delete<String>("/dashboard_layouts/$path_dashboard_layout_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/dashboard_layouts/$path_dashboard_layout_id", mapOf()
+        )
     }
 
     /**
@@ -3170,9 +3338,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun dashboard_dashboard_layouts(
         dashboard_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<DashboardLayout>, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
-        return this.get<Array<DashboardLayout>>(
+        return this.get<Array<DashboardLayout>, com.looker.sdk.Error>(
             "/dashboards/$path_dashboard_id/dashboard_layouts",
             mapOf("fields" to fields)
         )
@@ -3189,8 +3357,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_dashboard_layout(
         body: WriteDashboardLayout,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<DashboardLayout>(
+    ): SdkResult<DashboardLayout, com.looker.sdk.Error> {
+        return this.post<DashboardLayout, com.looker.sdk.Error>(
             "/dashboard_layouts",
             mapOf("fields" to fields), body
         )
@@ -3209,8 +3377,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun perform_data_action(
         body: DataActionRequest
-    ): SDKResponse {
-        return this.post<DataActionResponse>("/data_actions", mapOf(), body)
+    ): SdkResult<DataActionResponse, com.looker.sdk.Error> {
+        return this.post<DataActionResponse, com.looker.sdk.Error>(
+            "/data_actions", mapOf(), body
+        )
     }
 
     /**
@@ -3222,8 +3392,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun fetch_remote_data_action_form(
         body: Map<String, Any>
-    ): SDKResponse {
-        return this.post<DataActionForm>("/data_actions/form", mapOf(), body)
+    ): SdkResult<DataActionForm, com.looker.sdk.Error> {
+        return this.post<DataActionForm, com.looker.sdk.Error>(
+            "/data_actions/form", mapOf(), body
+        )
     }
 
     //endregion DataAction: Run Data Actions
@@ -3235,8 +3407,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /datagroups -> Array<Datagroup>
      */
-    fun all_datagroups(): SDKResponse {
-        return this.get<Array<Datagroup>>("/datagroups", mapOf())
+    fun all_datagroups(): SdkResult<Array<Datagroup>, com.looker.sdk.Error> {
+        return this.get<Array<Datagroup>, com.looker.sdk.Error>(
+            "/datagroups", mapOf()
+        )
     }
 
     /**
@@ -3248,9 +3422,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun datagroup(
         datagroup_id: Long
-    ): SDKResponse {
+    ): SdkResult<Datagroup, com.looker.sdk.Error> {
         val path_datagroup_id = encodeParam(datagroup_id)
-        return this.get<Datagroup>("/datagroups/$path_datagroup_id", mapOf())
+        return this.get<Datagroup, com.looker.sdk.Error>(
+            "/datagroups/$path_datagroup_id", mapOf()
+        )
     }
 
     /**
@@ -3264,9 +3440,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     fun update_datagroup(
         datagroup_id: Long,
         body: WriteDatagroup
-    ): SDKResponse {
+    ): SdkResult<Datagroup, com.looker.sdk.Error> {
         val path_datagroup_id = encodeParam(datagroup_id)
-        return this.patch<Datagroup>("/datagroups/$path_datagroup_id", mapOf(), body)
+        return this.patch<Datagroup, com.looker.sdk.Error>(
+            "/datagroups/$path_datagroup_id", mapOf(), body
+        )
     }
 
     //endregion Datagroup: Manage Datagroups
@@ -3302,8 +3480,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         parent_id: String? = null,
         creator_id: String? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<Array<Folder>>(
+    ): SdkResult<Array<Folder>, com.looker.sdk.Error> {
+        return this.get<Array<Folder>, com.looker.sdk.Error>(
             "/folders/search",
             mapOf(
                 "fields" to fields,
@@ -3332,9 +3510,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun folder(
         folder_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Folder, com.looker.sdk.Error> {
         val path_folder_id = encodeParam(folder_id)
-        return this.get<Folder>(
+        return this.get<Folder, com.looker.sdk.Error>(
             "/folders/$path_folder_id",
             mapOf("fields" to fields)
         )
@@ -3351,9 +3529,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     fun update_folder(
         folder_id: String,
         body: UpdateFolder
-    ): SDKResponse {
+    ): SdkResult<Folder, com.looker.sdk.Error> {
         val path_folder_id = encodeParam(folder_id)
-        return this.patch<Folder>("/folders/$path_folder_id", mapOf(), body)
+        return this.patch<Folder, com.looker.sdk.Error>(
+            "/folders/$path_folder_id", mapOf(), body
+        )
     }
 
     /**
@@ -3366,9 +3546,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_folder(
         folder_id: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_folder_id = encodeParam(folder_id)
-        return this.delete<String>("/folders/$path_folder_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/folders/$path_folder_id", mapOf()
+        )
     }
 
     /**
@@ -3380,8 +3562,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_folders(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<Folder>>(
+    ): SdkResult<Array<Folder>, com.looker.sdk.Error> {
+        return this.get<Array<Folder>, com.looker.sdk.Error>(
             "/folders",
             mapOf("fields" to fields)
         )
@@ -3399,8 +3581,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_folder(
         body: CreateFolder
-    ): SDKResponse {
-        return this.post<Folder>("/folders", mapOf(), body)
+    ): SdkResult<Folder, com.looker.sdk.Error> {
+        return this.post<Folder, com.looker.sdk.Error>(
+            "/folders", mapOf(), body
+        )
     }
 
     /**
@@ -3420,9 +3604,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         page: Long? = null,
         per_page: Long? = null,
         sorts: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<Folder>, com.looker.sdk.Error> {
         val path_folder_id = encodeParam(folder_id)
-        return this.get<Array<Folder>>(
+        return this.get<Array<Folder>, com.looker.sdk.Error>(
             "/folders/$path_folder_id/children",
             mapOf(
                 "fields" to fields,
@@ -3448,9 +3632,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         fields: String? = null,
         sorts: String? = null,
         name: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<Folder>, com.looker.sdk.Error> {
         val path_folder_id = encodeParam(folder_id)
-        return this.get<Array<Folder>>(
+        return this.get<Array<Folder>, com.looker.sdk.Error>(
             "/folders/$path_folder_id/children/search",
             mapOf(
                 "fields" to fields,
@@ -3471,9 +3655,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun folder_parent(
         folder_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Folder, com.looker.sdk.Error> {
         val path_folder_id = encodeParam(folder_id)
-        return this.get<Folder>(
+        return this.get<Folder, com.looker.sdk.Error>(
             "/folders/$path_folder_id/parent",
             mapOf("fields" to fields)
         )
@@ -3490,9 +3674,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun folder_ancestors(
         folder_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<Folder>, com.looker.sdk.Error> {
         val path_folder_id = encodeParam(folder_id)
-        return this.get<Array<Folder>>(
+        return this.get<Array<Folder>, com.looker.sdk.Error>(
             "/folders/$path_folder_id/ancestors",
             mapOf("fields" to fields)
         )
@@ -3509,9 +3693,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun folder_looks(
         folder_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<LookWithQuery>, com.looker.sdk.Error> {
         val path_folder_id = encodeParam(folder_id)
-        return this.get<Array<LookWithQuery>>(
+        return this.get<Array<LookWithQuery>, com.looker.sdk.Error>(
             "/folders/$path_folder_id/looks",
             mapOf("fields" to fields)
         )
@@ -3528,9 +3712,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun folder_dashboards(
         folder_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<Dashboard>, com.looker.sdk.Error> {
         val path_folder_id = encodeParam(folder_id)
-        return this.get<Array<Dashboard>>(
+        return this.get<Array<Dashboard>, com.looker.sdk.Error>(
             "/folders/$path_folder_id/dashboards",
             mapOf("fields" to fields)
         )
@@ -3561,8 +3745,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         ids: DelimArray<Long>? = null,
         content_metadata_id: Long? = null,
         can_add_to_content_metadata: Boolean? = null
-    ): SDKResponse {
-        return this.get<Array<Group>>(
+    ): SdkResult<Array<Group>, com.looker.sdk.Error> {
+        return this.get<Array<Group>, com.looker.sdk.Error>(
             "/groups",
             mapOf(
                 "fields" to fields,
@@ -3587,8 +3771,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_group(
         body: WriteGroup,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<Group>(
+    ): SdkResult<Group, com.looker.sdk.Error> {
+        return this.post<Group, com.looker.sdk.Error>(
             "/groups",
             mapOf("fields" to fields), body
         )
@@ -3644,8 +3828,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         external_group_id: String? = null,
         externally_managed: Boolean? = null,
         externally_orphaned: Boolean? = null
-    ): SDKResponse {
-        return this.get<Array<Group>>(
+    ): SdkResult<Array<Group>, com.looker.sdk.Error> {
+        return this.get<Array<Group>, com.looker.sdk.Error>(
             "/groups/search",
             mapOf(
                 "fields" to fields,
@@ -3712,8 +3896,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         external_group_id: String? = null,
         externally_managed: Boolean? = null,
         externally_orphaned: Boolean? = null
-    ): SDKResponse {
-        return this.get<Array<GroupSearch>>(
+    ): SdkResult<Array<GroupSearch>, com.looker.sdk.Error> {
+        return this.get<Array<GroupSearch>, com.looker.sdk.Error>(
             "/groups/search/with_roles",
             mapOf(
                 "fields" to fields,
@@ -3781,8 +3965,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         external_group_id: String? = null,
         externally_managed: Boolean? = null,
         externally_orphaned: Boolean? = null
-    ): SDKResponse {
-        return this.get<Array<GroupHierarchy>>(
+    ): SdkResult<Array<GroupHierarchy>, com.looker.sdk.Error> {
+        return this.get<Array<GroupHierarchy>, com.looker.sdk.Error>(
             "/groups/search/with_hierarchy",
             mapOf(
                 "fields" to fields,
@@ -3810,9 +3994,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun group(
         group_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Group, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
-        return this.get<Group>(
+        return this.get<Group, com.looker.sdk.Error>(
             "/groups/$path_group_id",
             mapOf("fields" to fields)
         )
@@ -3831,9 +4015,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         group_id: Long,
         body: WriteGroup,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Group, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
-        return this.patch<Group>(
+        return this.patch<Group, com.looker.sdk.Error>(
             "/groups/$path_group_id",
             mapOf("fields" to fields), body
         )
@@ -3848,9 +4032,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_group(
         group_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
-        return this.delete<String>("/groups/$path_group_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/groups/$path_group_id", mapOf()
+        )
     }
 
     /**
@@ -3864,9 +4050,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_group_groups(
         group_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<Group>, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
-        return this.get<Array<Group>>(
+        return this.get<Array<Group>, com.looker.sdk.Error>(
             "/groups/$path_group_id/groups",
             mapOf("fields" to fields)
         )
@@ -3883,9 +4069,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     fun add_group_group(
         group_id: Long,
         body: GroupIdForGroupInclusion
-    ): SDKResponse {
+    ): SdkResult<Group, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
-        return this.post<Group>("/groups/$path_group_id/groups", mapOf(), body)
+        return this.post<Group, com.looker.sdk.Error>(
+            "/groups/$path_group_id/groups", mapOf(), body
+        )
     }
 
     /**
@@ -3905,9 +4093,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         page: Long? = null,
         per_page: Long? = null,
         sorts: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<User>, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
-        return this.get<Array<User>>(
+        return this.get<Array<User>, com.looker.sdk.Error>(
             "/groups/$path_group_id/users",
             mapOf(
                 "fields" to fields,
@@ -3929,9 +4117,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     fun add_group_user(
         group_id: Long,
         body: GroupIdForGroupUserInclusion
-    ): SDKResponse {
+    ): SdkResult<User, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
-        return this.post<User>("/groups/$path_group_id/users", mapOf(), body)
+        return this.post<User, com.looker.sdk.Error>(
+            "/groups/$path_group_id/users", mapOf(), body
+        )
     }
 
     /**
@@ -3945,10 +4135,12 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     fun delete_group_user(
         group_id: Long,
         user_id: Long
-    ): SDKResponse {
+    ): SdkResult<Void, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
         val path_user_id = encodeParam(user_id)
-        return this.delete<Void>("/groups/$path_group_id/users/$path_user_id", mapOf())
+        return this.delete<Void, com.looker.sdk.Error>(
+            "/groups/$path_group_id/users/$path_user_id", mapOf()
+        )
     }
 
     /**
@@ -3962,10 +4154,12 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     fun delete_group_from_group(
         group_id: Long,
         deleting_group_id: Long
-    ): SDKResponse {
+    ): SdkResult<Void, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
         val path_deleting_group_id = encodeParam(deleting_group_id)
-        return this.delete<Void>("/groups/$path_group_id/groups/$path_deleting_group_id", mapOf())
+        return this.delete<Void, com.looker.sdk.Error>(
+            "/groups/$path_group_id/groups/$path_deleting_group_id", mapOf()
+        )
     }
 
     /**
@@ -3983,10 +4177,12 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         group_id: Long,
         user_attribute_id: Long,
         body: UserAttributeGroupValue
-    ): SDKResponse {
+    ): SdkResult<UserAttributeGroupValue, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
         val path_user_attribute_id = encodeParam(user_attribute_id)
-        return this.patch<UserAttributeGroupValue>("/groups/$path_group_id/attribute_values/$path_user_attribute_id", mapOf(), body)
+        return this.patch<UserAttributeGroupValue, com.looker.sdk.Error>(
+            "/groups/$path_group_id/attribute_values/$path_user_attribute_id", mapOf(), body
+        )
     }
 
     /**
@@ -4000,10 +4196,12 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     fun delete_user_attribute_group_value(
         group_id: Long,
         user_attribute_id: Long
-    ): SDKResponse {
+    ): SdkResult<Void, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
         val path_user_attribute_id = encodeParam(user_attribute_id)
-        return this.delete<Void>("/groups/$path_group_id/attribute_values/$path_user_attribute_id", mapOf())
+        return this.delete<Void, com.looker.sdk.Error>(
+            "/groups/$path_group_id/attribute_values/$path_user_attribute_id", mapOf()
+        )
     }
 
     //endregion Group: Manage Groups
@@ -4019,8 +4217,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_primary_homepage_sections(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<HomepageSection>>(
+    ): SdkResult<Array<HomepageSection>, com.looker.sdk.Error> {
+        return this.get<Array<HomepageSection>, com.looker.sdk.Error>(
             "/primary_homepage_sections",
             mapOf("fields" to fields)
         )
@@ -4039,8 +4237,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_integration_hubs(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<IntegrationHub>>(
+    ): SdkResult<Array<IntegrationHub>, com.looker.sdk.Error> {
+        return this.get<Array<IntegrationHub>, com.looker.sdk.Error>(
             "/integration_hubs",
             mapOf("fields" to fields)
         )
@@ -4059,8 +4257,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_integration_hub(
         body: WriteIntegrationHub,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<IntegrationHub>(
+    ): SdkResult<IntegrationHub, com.looker.sdk.Error> {
+        return this.post<IntegrationHub, com.looker.sdk.Error>(
             "/integration_hubs",
             mapOf("fields" to fields), body
         )
@@ -4077,9 +4275,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun integration_hub(
         integration_hub_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<IntegrationHub, com.looker.sdk.Error> {
         val path_integration_hub_id = encodeParam(integration_hub_id)
-        return this.get<IntegrationHub>(
+        return this.get<IntegrationHub, com.looker.sdk.Error>(
             "/integration_hubs/$path_integration_hub_id",
             mapOf("fields" to fields)
         )
@@ -4100,9 +4298,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         integration_hub_id: Long,
         body: WriteIntegrationHub,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<IntegrationHub, com.looker.sdk.Error> {
         val path_integration_hub_id = encodeParam(integration_hub_id)
-        return this.patch<IntegrationHub>(
+        return this.patch<IntegrationHub, com.looker.sdk.Error>(
             "/integration_hubs/$path_integration_hub_id",
             mapOf("fields" to fields), body
         )
@@ -4117,9 +4315,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_integration_hub(
         integration_hub_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_integration_hub_id = encodeParam(integration_hub_id)
-        return this.delete<String>("/integration_hubs/$path_integration_hub_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/integration_hubs/$path_integration_hub_id", mapOf()
+        )
     }
 
     /**
@@ -4131,9 +4331,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun accept_integration_hub_legal_agreement(
         integration_hub_id: Long
-    ): SDKResponse {
+    ): SdkResult<IntegrationHub, com.looker.sdk.Error> {
         val path_integration_hub_id = encodeParam(integration_hub_id)
-        return this.post<IntegrationHub>("/integration_hubs/$path_integration_hub_id/accept_legal_agreement", mapOf())
+        return this.post<IntegrationHub, com.looker.sdk.Error>(
+            "/integration_hubs/$path_integration_hub_id/accept_legal_agreement", mapOf()
+        )
     }
 
     /**
@@ -4147,8 +4349,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_integrations(
         fields: String? = null,
         integration_hub_id: String? = null
-    ): SDKResponse {
-        return this.get<Array<Integration>>(
+    ): SdkResult<Array<Integration>, com.looker.sdk.Error> {
+        return this.get<Array<Integration>, com.looker.sdk.Error>(
             "/integrations",
             mapOf(
                 "fields" to fields,
@@ -4168,9 +4370,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun integration(
         integration_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Integration, com.looker.sdk.Error> {
         val path_integration_id = encodeParam(integration_id)
-        return this.get<Integration>(
+        return this.get<Integration, com.looker.sdk.Error>(
             "/integrations/$path_integration_id",
             mapOf("fields" to fields)
         )
@@ -4189,9 +4391,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         integration_id: String,
         body: WriteIntegration,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Integration, com.looker.sdk.Error> {
         val path_integration_id = encodeParam(integration_id)
-        return this.patch<Integration>(
+        return this.patch<Integration, com.looker.sdk.Error>(
             "/integrations/$path_integration_id",
             mapOf("fields" to fields), body
         )
@@ -4208,9 +4410,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun fetch_integration_form(
         integration_id: String,
         body: Map<String, Any>? = null
-    ): SDKResponse {
+    ): SdkResult<DataActionForm, com.looker.sdk.Error> {
         val path_integration_id = encodeParam(integration_id)
-        return this.post<DataActionForm>("/integrations/$path_integration_id/form", mapOf(), body)
+        return this.post<DataActionForm, com.looker.sdk.Error>(
+            "/integrations/$path_integration_id/form", mapOf(), body
+        )
     }
 
     /**
@@ -4222,9 +4426,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun test_integration(
         integration_id: String
-    ): SDKResponse {
+    ): SdkResult<IntegrationTestResult, com.looker.sdk.Error> {
         val path_integration_id = encodeParam(integration_id)
-        return this.post<IntegrationTestResult>("/integrations/$path_integration_id/test", mapOf())
+        return this.post<IntegrationTestResult, com.looker.sdk.Error>(
+            "/integrations/$path_integration_id/test", mapOf()
+        )
     }
 
     //endregion Integration: Manage Integrations
@@ -4246,8 +4452,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_looks(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<Look>>(
+    ): SdkResult<Array<Look>, com.looker.sdk.Error> {
+        return this.get<Array<Look>, com.looker.sdk.Error>(
             "/looks",
             mapOf("fields" to fields)
         )
@@ -4270,8 +4476,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_look(
         body: WriteLookWithQuery,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<LookWithQuery>(
+    ): SdkResult<LookWithQuery, com.looker.sdk.Error> {
+        return this.post<LookWithQuery, com.looker.sdk.Error>(
             "/looks",
             mapOf("fields" to fields), body
         )
@@ -4346,8 +4552,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         offset: Long? = null,
         sorts: String? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<Array<Look>>(
+    ): SdkResult<Array<Look>, com.looker.sdk.Error> {
+        return this.get<Array<Look>, com.looker.sdk.Error>(
             "/looks/search",
             mapOf(
                 "id" to id,
@@ -4385,9 +4591,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun look(
         look_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<LookWithQuery, com.looker.sdk.Error> {
         val path_look_id = encodeParam(look_id)
-        return this.get<LookWithQuery>(
+        return this.get<LookWithQuery, com.looker.sdk.Error>(
             "/looks/$path_look_id",
             mapOf("fields" to fields)
         )
@@ -4425,9 +4631,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         look_id: Long,
         body: WriteLookWithQuery,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<LookWithQuery, com.looker.sdk.Error> {
         val path_look_id = encodeParam(look_id)
-        return this.patch<LookWithQuery>(
+        return this.patch<LookWithQuery, com.looker.sdk.Error>(
             "/looks/$path_look_id",
             mapOf("fields" to fields), body
         )
@@ -4448,9 +4654,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_look(
         look_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_look_id = encodeParam(look_id)
-        return this.delete<String>("/looks/$path_look_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/looks/$path_look_id", mapOf()
+        )
     }
 
     /**
@@ -4507,10 +4715,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         path_prefix: String? = null,
         rebuild_pdts: Boolean? = null,
         server_table_calcs: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_look_id = encodeParam(look_id)
         val path_result_format = encodeParam(result_format)
-        return this.get<String>(
+        return this.get<String, com.looker.sdk.Error>(
             "/looks/$path_look_id/run/$path_result_format",
             mapOf(
                 "limit" to limit,
@@ -4542,8 +4750,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_lookml_models(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<LookmlModel>>(
+    ): SdkResult<Array<LookmlModel>, com.looker.sdk.Error> {
+        return this.get<Array<LookmlModel>, com.looker.sdk.Error>(
             "/lookml_models",
             mapOf("fields" to fields)
         )
@@ -4558,8 +4766,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_lookml_model(
         body: WriteLookmlModel
-    ): SDKResponse {
-        return this.post<LookmlModel>("/lookml_models", mapOf(), body)
+    ): SdkResult<LookmlModel, com.looker.sdk.Error> {
+        return this.post<LookmlModel, com.looker.sdk.Error>(
+            "/lookml_models", mapOf(), body
+        )
     }
 
     /**
@@ -4573,9 +4783,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun lookml_model(
         lookml_model_name: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<LookmlModel, com.looker.sdk.Error> {
         val path_lookml_model_name = encodeParam(lookml_model_name)
-        return this.get<LookmlModel>(
+        return this.get<LookmlModel, com.looker.sdk.Error>(
             "/lookml_models/$path_lookml_model_name",
             mapOf("fields" to fields)
         )
@@ -4592,9 +4802,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     fun update_lookml_model(
         lookml_model_name: String,
         body: WriteLookmlModel
-    ): SDKResponse {
+    ): SdkResult<LookmlModel, com.looker.sdk.Error> {
         val path_lookml_model_name = encodeParam(lookml_model_name)
-        return this.patch<LookmlModel>("/lookml_models/$path_lookml_model_name", mapOf(), body)
+        return this.patch<LookmlModel, com.looker.sdk.Error>(
+            "/lookml_models/$path_lookml_model_name", mapOf(), body
+        )
     }
 
     /**
@@ -4606,9 +4818,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_lookml_model(
         lookml_model_name: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_lookml_model_name = encodeParam(lookml_model_name)
-        return this.delete<String>("/lookml_models/$path_lookml_model_name", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/lookml_models/$path_lookml_model_name", mapOf()
+        )
     }
 
     /**
@@ -4624,10 +4838,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         lookml_model_name: String,
         explore_name: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<LookmlModelExplore, com.looker.sdk.Error> {
         val path_lookml_model_name = encodeParam(lookml_model_name)
         val path_explore_name = encodeParam(explore_name)
-        return this.get<LookmlModelExplore>(
+        return this.get<LookmlModelExplore, com.looker.sdk.Error>(
             "/lookml_models/$path_lookml_model_name/explores/$path_explore_name",
             mapOf("fields" to fields)
         )
@@ -4654,11 +4868,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         field_name: String,
         term: String? = null,
         filters: String? = null
-    ): SDKResponse {
+    ): SdkResult<ModelFieldSuggestions, com.looker.sdk.Error> {
         val path_model_name = encodeParam(model_name)
         val path_view_name = encodeParam(view_name)
         val path_field_name = encodeParam(field_name)
-        return this.get<ModelFieldSuggestions>(
+        return this.get<ModelFieldSuggestions, com.looker.sdk.Error>(
             "/models/$path_model_name/views/$path_view_name/fields/$path_field_name/suggestions",
             mapOf(
                 "term" to term,
@@ -4684,9 +4898,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun connection_databases(
         connection_name: String
-    ): SDKResponse {
+    ): SdkResult<Array<String>, com.looker.sdk.Error> {
         val path_connection_name = encodeParam(connection_name)
-        return this.get<Array<String>>("/connections/$path_connection_name/databases", mapOf())
+        return this.get<Array<String>, com.looker.sdk.Error>(
+            "/connections/$path_connection_name/databases", mapOf()
+        )
     }
 
     /**
@@ -4702,9 +4918,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun connection_features(
         connection_name: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ConnectionFeatures, com.looker.sdk.Error> {
         val path_connection_name = encodeParam(connection_name)
-        return this.get<ConnectionFeatures>(
+        return this.get<ConnectionFeatures, com.looker.sdk.Error>(
             "/connections/$path_connection_name/features",
             mapOf("fields" to fields)
         )
@@ -4725,9 +4941,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         database: String? = null,
         cache: Boolean? = null,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<Schema>, com.looker.sdk.Error> {
         val path_connection_name = encodeParam(connection_name)
-        return this.get<Array<Schema>>(
+        return this.get<Array<Schema>, com.looker.sdk.Error>(
             "/connections/$path_connection_name/schemas",
             mapOf(
                 "database" to database,
@@ -4759,9 +4975,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         schema_name: String? = null,
         cache: Boolean? = null,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<SchemaTables>, com.looker.sdk.Error> {
         val path_connection_name = encodeParam(connection_name)
-        return this.get<Array<SchemaTables>>(
+        return this.get<Array<SchemaTables>, com.looker.sdk.Error>(
             "/connections/$path_connection_name/tables",
             mapOf(
                 "database" to database,
@@ -4793,9 +5009,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         table_limit: Long? = null,
         table_names: String? = null,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<SchemaColumns>, com.looker.sdk.Error> {
         val path_connection_name = encodeParam(connection_name)
-        return this.get<Array<SchemaColumns>>(
+        return this.get<Array<SchemaColumns>, com.looker.sdk.Error>(
             "/connections/$path_connection_name/columns",
             mapOf(
                 "database" to database,
@@ -4823,9 +5039,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         connection_name: String,
         column_name: String? = null,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<ColumnSearch>, com.looker.sdk.Error> {
         val path_connection_name = encodeParam(connection_name)
-        return this.get<Array<ColumnSearch>>(
+        return this.get<Array<ColumnSearch>, com.looker.sdk.Error>(
             "/connections/$path_connection_name/search_columns",
             mapOf(
                 "column_name" to column_name,
@@ -4851,9 +5067,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         connection_name: String,
         body: CreateCostEstimate,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<CostEstimate, com.looker.sdk.Error> {
         val path_connection_name = encodeParam(connection_name)
-        return this.post<CostEstimate>(
+        return this.post<CostEstimate, com.looker.sdk.Error>(
             "/connections/$path_connection_name/cost_estimate",
             mapOf("fields" to fields), body
         )
@@ -4880,9 +5096,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun lock_all(
         project_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.post<String>(
+        return this.post<String, com.looker.sdk.Error>(
             "/projects/$path_project_id/manifest/lock_all",
             mapOf("fields" to fields)
         )
@@ -4899,9 +5115,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun all_git_branches(
         project_id: String
-    ): SDKResponse {
+    ): SdkResult<Array<GitBranch>, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<Array<GitBranch>>("/projects/$path_project_id/git_branches", mapOf())
+        return this.get<Array<GitBranch>, com.looker.sdk.Error>(
+            "/projects/$path_project_id/git_branches", mapOf()
+        )
     }
 
     /**
@@ -4915,9 +5133,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun git_branch(
         project_id: String
-    ): SDKResponse {
+    ): SdkResult<GitBranch, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<GitBranch>("/projects/$path_project_id/git_branch", mapOf())
+        return this.get<GitBranch, com.looker.sdk.Error>(
+            "/projects/$path_project_id/git_branch", mapOf()
+        )
     }
 
     /**
@@ -4939,9 +5159,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     fun update_git_branch(
         project_id: String,
         body: WriteGitBranch
-    ): SDKResponse {
+    ): SdkResult<GitBranch, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.put<GitBranch>("/projects/$path_project_id/git_branch", mapOf(), body)
+        return this.put<GitBranch, com.looker.sdk.Error>(
+            "/projects/$path_project_id/git_branch", mapOf(), body
+        )
     }
 
     /**
@@ -4962,9 +5184,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     fun create_git_branch(
         project_id: String,
         body: WriteGitBranch
-    ): SDKResponse {
+    ): SdkResult<GitBranch, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.post<GitBranch>("/projects/$path_project_id/git_branch", mapOf(), body)
+        return this.post<GitBranch, com.looker.sdk.Error>(
+            "/projects/$path_project_id/git_branch", mapOf(), body
+        )
     }
 
     /**
@@ -4980,10 +5204,12 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     fun find_git_branch(
         project_id: String,
         branch_name: String
-    ): SDKResponse {
+    ): SdkResult<GitBranch, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
         val path_branch_name = encodeParam(branch_name)
-        return this.get<GitBranch>("/projects/$path_project_id/git_branch/$path_branch_name", mapOf())
+        return this.get<GitBranch, com.looker.sdk.Error>(
+            "/projects/$path_project_id/git_branch/$path_branch_name", mapOf()
+        )
     }
 
     /**
@@ -4999,10 +5225,12 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     fun delete_git_branch(
         project_id: String,
         branch_name: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
         val path_branch_name = encodeParam(branch_name)
-        return this.delete<String>("/projects/$path_project_id/git_branch/$path_branch_name", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/projects/$path_project_id/git_branch/$path_branch_name", mapOf()
+        )
     }
 
     /**
@@ -5026,9 +5254,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         project_id: String,
         branch: String? = null,
         ref: String? = null
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.post<String>(
+        return this.post<String, com.looker.sdk.Error>(
             "/projects/$path_project_id/deploy_ref_to_production",
             mapOf(
                 "branch" to branch,
@@ -5057,9 +5285,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun deploy_to_production(
         project_id: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.post<String>("/projects/$path_project_id/deploy_to_production", mapOf())
+        return this.post<String, com.looker.sdk.Error>(
+            "/projects/$path_project_id/deploy_to_production", mapOf()
+        )
     }
 
     /**
@@ -5073,9 +5303,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun reset_project_to_production(
         project_id: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.post<String>("/projects/$path_project_id/reset_to_production", mapOf())
+        return this.post<String, com.looker.sdk.Error>(
+            "/projects/$path_project_id/reset_to_production", mapOf()
+        )
     }
 
     /**
@@ -5089,9 +5321,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun reset_project_to_remote(
         project_id: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.post<String>("/projects/$path_project_id/reset_to_remote", mapOf())
+        return this.post<String, com.looker.sdk.Error>(
+            "/projects/$path_project_id/reset_to_remote", mapOf()
+        )
     }
 
     /**
@@ -5105,8 +5339,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_projects(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<Project>>(
+    ): SdkResult<Array<Project>, com.looker.sdk.Error> {
+        return this.get<Array<Project>, com.looker.sdk.Error>(
             "/projects",
             mapOf("fields" to fields)
         )
@@ -5127,8 +5361,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_project(
         body: WriteProject
-    ): SDKResponse {
-        return this.post<Project>("/projects", mapOf(), body)
+    ): SdkResult<Project, com.looker.sdk.Error> {
+        return this.post<Project, com.looker.sdk.Error>(
+            "/projects", mapOf(), body
+        )
     }
 
     /**
@@ -5144,9 +5380,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun project(
         project_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Project, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<Project>(
+        return this.get<Project, com.looker.sdk.Error>(
             "/projects/$path_project_id",
             mapOf("fields" to fields)
         )
@@ -5186,9 +5422,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         project_id: String,
         body: WriteProject,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Project, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.patch<Project>(
+        return this.patch<Project, com.looker.sdk.Error>(
             "/projects/$path_project_id",
             mapOf("fields" to fields), body
         )
@@ -5205,9 +5441,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun manifest(
         project_id: String
-    ): SDKResponse {
+    ): SdkResult<Manifest, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<Manifest>("/projects/$path_project_id/manifest", mapOf())
+        return this.get<Manifest, com.looker.sdk.Error>(
+            "/projects/$path_project_id/manifest", mapOf()
+        )
     }
 
     /**
@@ -5221,9 +5459,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun git_deploy_key(
         project_id: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<String>("/projects/$path_project_id/git/deploy_key", mapOf())
+        return this.get<String, com.looker.sdk.Error>(
+            "/projects/$path_project_id/git/deploy_key", mapOf()
+        )
     }
 
     /**
@@ -5243,9 +5483,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_git_deploy_key(
         project_id: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.post<String>("/projects/$path_project_id/git/deploy_key", mapOf())
+        return this.post<String, com.looker.sdk.Error>(
+            "/projects/$path_project_id/git/deploy_key", mapOf()
+        )
     }
 
     /**
@@ -5270,9 +5512,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun project_validation_results(
         project_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ProjectValidationCache, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<ProjectValidationCache>(
+        return this.get<ProjectValidationCache, com.looker.sdk.Error>(
             "/projects/$path_project_id/validate",
             mapOf("fields" to fields)
         )
@@ -5297,9 +5539,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun validate_project(
         project_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ProjectValidation, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.post<ProjectValidation>(
+        return this.post<ProjectValidation, com.looker.sdk.Error>(
             "/projects/$path_project_id/validate",
             mapOf("fields" to fields)
         )
@@ -5318,9 +5560,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun project_workspace(
         project_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ProjectWorkspace, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<ProjectWorkspace>(
+        return this.get<ProjectWorkspace, com.looker.sdk.Error>(
             "/projects/$path_project_id/current_workspace",
             mapOf("fields" to fields)
         )
@@ -5339,9 +5581,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_project_files(
         project_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<ProjectFile>, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<Array<ProjectFile>>(
+        return this.get<Array<ProjectFile>, com.looker.sdk.Error>(
             "/projects/$path_project_id/files",
             mapOf("fields" to fields)
         )
@@ -5362,9 +5604,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         project_id: String,
         file_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ProjectFile, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<ProjectFile>(
+        return this.get<ProjectFile, com.looker.sdk.Error>(
             "/projects/$path_project_id/files/file",
             mapOf(
                 "file_id" to file_id,
@@ -5393,9 +5635,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_git_connection_tests(
         project_id: String,
         remote_url: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<GitConnectionTest>, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<Array<GitConnectionTest>>(
+        return this.get<Array<GitConnectionTest>, com.looker.sdk.Error>(
             "/projects/$path_project_id/git_connection_tests",
             mapOf("remote_url" to remote_url)
         )
@@ -5420,10 +5662,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         project_id: String,
         test_id: String,
         remote_url: String? = null
-    ): SDKResponse {
+    ): SdkResult<GitConnectionTestResult, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
         val path_test_id = encodeParam(test_id)
-        return this.get<GitConnectionTestResult>(
+        return this.get<GitConnectionTestResult, com.looker.sdk.Error>(
             "/projects/$path_project_id/git_connection_tests/$path_test_id",
             mapOf("remote_url" to remote_url)
         )
@@ -5444,9 +5686,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_lookml_tests(
         project_id: String,
         file_id: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<LookmlTest>, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<Array<LookmlTest>>(
+        return this.get<Array<LookmlTest>, com.looker.sdk.Error>(
             "/projects/$path_project_id/lookml_tests",
             mapOf("file_id" to file_id)
         )
@@ -5469,9 +5711,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         file_id: String? = null,
         test: String? = null,
         model: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<LookmlTestResult>, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<Array<LookmlTestResult>>(
+        return this.get<Array<LookmlTestResult>, com.looker.sdk.Error>(
             "/projects/$path_project_id/lookml_tests/run",
             mapOf(
                 "file_id" to file_id,
@@ -5499,10 +5741,12 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         root_project_id: String,
         credential_id: String,
         body: WriteRepositoryCredential
-    ): SDKResponse {
+    ): SdkResult<RepositoryCredential, com.looker.sdk.Error> {
         val path_root_project_id = encodeParam(root_project_id)
         val path_credential_id = encodeParam(credential_id)
-        return this.put<RepositoryCredential>("/projects/$path_root_project_id/credential/$path_credential_id", mapOf(), body)
+        return this.put<RepositoryCredential, com.looker.sdk.Error>(
+            "/projects/$path_root_project_id/credential/$path_credential_id", mapOf(), body
+        )
     }
 
     /**
@@ -5521,10 +5765,12 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     fun delete_repository_credential(
         root_project_id: String,
         credential_id: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_root_project_id = encodeParam(root_project_id)
         val path_credential_id = encodeParam(credential_id)
-        return this.delete<String>("/projects/$path_root_project_id/credential/$path_credential_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/projects/$path_root_project_id/credential/$path_credential_id", mapOf()
+        )
     }
 
     /**
@@ -5538,9 +5784,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun get_all_repository_credentials(
         root_project_id: String
-    ): SDKResponse {
+    ): SdkResult<Array<RepositoryCredential>, com.looker.sdk.Error> {
         val path_root_project_id = encodeParam(root_project_id)
-        return this.get<Array<RepositoryCredential>>("/projects/$path_root_project_id/credentials", mapOf())
+        return this.get<Array<RepositoryCredential>, com.looker.sdk.Error>(
+            "/projects/$path_root_project_id/credentials", mapOf()
+        )
     }
 
     //endregion Project: Manage Projects
@@ -5587,8 +5835,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         rebuild_pdts: Boolean? = null,
         server_table_calcs: Boolean? = null,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<QueryTask>(
+    ): SdkResult<QueryTask, com.looker.sdk.Error> {
+        return this.post<QueryTask, com.looker.sdk.Error>(
             "/query_tasks",
             mapOf(
                 "limit" to limit,
@@ -5624,8 +5872,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun query_task_multi_results(
         query_task_ids: DelimArray<String>
-    ): SDKResponse {
-        return this.get<Map<String, Any>>(
+    ): SdkResult<Map<String, Any>, com.looker.sdk.Error> {
+        return this.get<Map<String, Any>, com.looker.sdk.Error>(
             "/query_tasks/multi_results",
             mapOf("query_task_ids" to query_task_ids)
         )
@@ -5648,9 +5896,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun query_task(
         query_task_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<QueryTask, com.looker.sdk.Error> {
         val path_query_task_id = encodeParam(query_task_id)
-        return this.get<QueryTask>(
+        return this.get<QueryTask, com.looker.sdk.Error>(
             "/query_tasks/$path_query_task_id",
             mapOf("fields" to fields)
         )
@@ -5687,9 +5935,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun query_task_results(
         query_task_id: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_query_task_id = encodeParam(query_task_id)
-        return this.get<String>("/query_tasks/$path_query_task_id/results", mapOf())
+        return this.get<String, com.looker.sdk.Error>(
+            "/query_tasks/$path_query_task_id/results", mapOf()
+        )
     }
 
     /**
@@ -5719,9 +5969,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun query(
         query_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Query, com.looker.sdk.Error> {
         val path_query_id = encodeParam(query_id)
-        return this.get<Query>(
+        return this.get<Query, com.looker.sdk.Error>(
             "/queries/$path_query_id",
             mapOf("fields" to fields)
         )
@@ -5754,9 +6004,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun query_for_slug(
         slug: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Query, com.looker.sdk.Error> {
         val path_slug = encodeParam(slug)
-        return this.get<Query>(
+        return this.get<Query, com.looker.sdk.Error>(
             "/queries/slug/$path_slug",
             mapOf("fields" to fields)
         )
@@ -5780,8 +6030,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_query(
         body: WriteQuery,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<Query>(
+    ): SdkResult<Query, com.looker.sdk.Error> {
+        return this.post<Query, com.looker.sdk.Error>(
             "/queries",
             mapOf("fields" to fields), body
         )
@@ -5844,10 +6094,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         path_prefix: String? = null,
         rebuild_pdts: Boolean? = null,
         server_table_calcs: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_query_id = encodeParam(query_id)
         val path_result_format = encodeParam(result_format)
-        return this.get<String>(
+        return this.get<String, com.looker.sdk.Error>(
             "/queries/$path_query_id/run/$path_result_format",
             mapOf(
                 "limit" to limit,
@@ -5952,9 +6202,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         path_prefix: String? = null,
         rebuild_pdts: Boolean? = null,
         server_table_calcs: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_result_format = encodeParam(result_format)
-        return this.post<String>(
+        return this.post<String, com.looker.sdk.Error>(
             "/queries/run/$path_result_format",
             mapOf(
                 "limit" to limit,
@@ -6040,11 +6290,13 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         model_name: String,
         view_name: String,
         result_format: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_model_name = encodeParam(model_name)
         val path_view_name = encodeParam(view_name)
         val path_result_format = encodeParam(result_format)
-        return this.get<String>("/queries/models/$path_model_name/views/$path_view_name/run/$path_result_format", mapOf())
+        return this.get<String, com.looker.sdk.Error>(
+            "/queries/models/$path_model_name/views/$path_view_name/run/$path_result_format", mapOf()
+        )
     }
 
     /**
@@ -6060,9 +6312,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun merge_query(
         merge_query_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<MergeQuery, com.looker.sdk.Error> {
         val path_merge_query_id = encodeParam(merge_query_id)
-        return this.get<MergeQuery>(
+        return this.get<MergeQuery, com.looker.sdk.Error>(
             "/merge_queries/$path_merge_query_id",
             mapOf("fields" to fields)
         )
@@ -6095,8 +6347,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_merge_query(
         body: WriteMergeQuery? = null,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<MergeQuery>(
+    ): SdkResult<MergeQuery, com.looker.sdk.Error> {
+        return this.post<MergeQuery, com.looker.sdk.Error>(
             "/merge_queries",
             mapOf("fields" to fields), body
         )
@@ -6107,8 +6359,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /running_queries -> Array<RunningQueries>
      */
-    fun all_running_queries(): SDKResponse {
-        return this.get<Array<RunningQueries>>("/running_queries", mapOf())
+    fun all_running_queries(): SdkResult<Array<RunningQueries>, com.looker.sdk.Error> {
+        return this.get<Array<RunningQueries>, com.looker.sdk.Error>(
+            "/running_queries", mapOf()
+        )
     }
 
     /**
@@ -6120,9 +6374,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun kill_query(
         query_task_id: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_query_task_id = encodeParam(query_task_id)
-        return this.delete<String>("/running_queries/$path_query_task_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/running_queries/$path_query_task_id", mapOf()
+        )
     }
 
     /**
@@ -6134,9 +6390,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun sql_query(
         slug: String
-    ): SDKResponse {
+    ): SdkResult<SqlQuery, com.looker.sdk.Error> {
         val path_slug = encodeParam(slug)
-        return this.get<SqlQuery>("/sql_queries/$path_slug", mapOf())
+        return this.get<SqlQuery, com.looker.sdk.Error>(
+            "/sql_queries/$path_slug", mapOf()
+        )
     }
 
     /**
@@ -6150,8 +6408,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_sql_query(
         body: SqlQueryCreate
-    ): SDKResponse {
-        return this.post<SqlQuery>("/sql_queries", mapOf(), body)
+    ): SdkResult<SqlQuery, com.looker.sdk.Error> {
+        return this.post<SqlQuery, com.looker.sdk.Error>(
+            "/sql_queries", mapOf(), body
+        )
     }
 
     /**
@@ -6169,10 +6429,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         slug: String,
         result_format: String,
         download: String? = null
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_slug = encodeParam(slug)
         val path_result_format = encodeParam(result_format)
-        return this.post<String>(
+        return this.post<String, com.looker.sdk.Error>(
             "/sql_queries/$path_slug/run/$path_result_format",
             mapOf("download" to download)
         )
@@ -6203,10 +6463,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         width: Long,
         height: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<RenderTask, com.looker.sdk.Error> {
         val path_look_id = encodeParam(look_id)
         val path_result_format = encodeParam(result_format)
-        return this.post<RenderTask>(
+        return this.post<RenderTask, com.looker.sdk.Error>(
             "/render_tasks/looks/$path_look_id/$path_result_format",
             mapOf(
                 "width" to width,
@@ -6237,10 +6497,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         width: Long,
         height: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<RenderTask, com.looker.sdk.Error> {
         val path_query_id = encodeParam(query_id)
         val path_result_format = encodeParam(result_format)
-        return this.post<RenderTask>(
+        return this.post<RenderTask, com.looker.sdk.Error>(
             "/render_tasks/queries/$path_query_id/$path_result_format",
             mapOf(
                 "width" to width,
@@ -6279,10 +6539,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         pdf_paper_size: String? = null,
         pdf_landscape: Boolean? = null,
         long_tables: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<RenderTask, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
         val path_result_format = encodeParam(result_format)
-        return this.post<RenderTask>(
+        return this.post<RenderTask, com.looker.sdk.Error>(
             "/render_tasks/dashboards/$path_dashboard_id/$path_result_format",
             mapOf(
                 "width" to width,
@@ -6311,9 +6571,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun render_task(
         render_task_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<RenderTask, com.looker.sdk.Error> {
         val path_render_task_id = encodeParam(render_task_id)
-        return this.get<RenderTask>(
+        return this.get<RenderTask, com.looker.sdk.Error>(
             "/render_tasks/$path_render_task_id",
             mapOf("fields" to fields)
         )
@@ -6346,9 +6606,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun render_task_results(
         render_task_id: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_render_task_id = encodeParam(render_task_id)
-        return this.get<String>("/render_tasks/$path_render_task_id/results", mapOf())
+        return this.get<String, com.looker.sdk.Error>(
+            "/render_tasks/$path_render_task_id/results", mapOf()
+        )
     }
 
     //endregion RenderTask: Manage Render Tasks
@@ -6401,8 +6663,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         all_access: Boolean? = null,
         built_in: Boolean? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<Array<ModelSet>>(
+    ): SdkResult<Array<ModelSet>, com.looker.sdk.Error> {
+        return this.get<Array<ModelSet>, com.looker.sdk.Error>(
             "/model_sets/search",
             mapOf(
                 "fields" to fields,
@@ -6429,9 +6691,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun model_set(
         model_set_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ModelSet, com.looker.sdk.Error> {
         val path_model_set_id = encodeParam(model_set_id)
-        return this.get<ModelSet>(
+        return this.get<ModelSet, com.looker.sdk.Error>(
             "/model_sets/$path_model_set_id",
             mapOf("fields" to fields)
         )
@@ -6448,9 +6710,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     fun update_model_set(
         model_set_id: Long,
         body: WriteModelSet
-    ): SDKResponse {
+    ): SdkResult<ModelSet, com.looker.sdk.Error> {
         val path_model_set_id = encodeParam(model_set_id)
-        return this.patch<ModelSet>("/model_sets/$path_model_set_id", mapOf(), body)
+        return this.patch<ModelSet, com.looker.sdk.Error>(
+            "/model_sets/$path_model_set_id", mapOf(), body
+        )
     }
 
     /**
@@ -6462,9 +6726,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_model_set(
         model_set_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_model_set_id = encodeParam(model_set_id)
-        return this.delete<String>("/model_sets/$path_model_set_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/model_sets/$path_model_set_id", mapOf()
+        )
     }
 
     /**
@@ -6476,8 +6742,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_model_sets(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<ModelSet>>(
+    ): SdkResult<Array<ModelSet>, com.looker.sdk.Error> {
+        return this.get<Array<ModelSet>, com.looker.sdk.Error>(
             "/model_sets",
             mapOf("fields" to fields)
         )
@@ -6492,8 +6758,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_model_set(
         body: WriteModelSet
-    ): SDKResponse {
-        return this.post<ModelSet>("/model_sets", mapOf(), body)
+    ): SdkResult<ModelSet, com.looker.sdk.Error> {
+        return this.post<ModelSet, com.looker.sdk.Error>(
+            "/model_sets", mapOf(), body
+        )
     }
 
     /**
@@ -6501,8 +6769,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /permissions -> Array<Permission>
      */
-    fun all_permissions(): SDKResponse {
-        return this.get<Array<Permission>>("/permissions", mapOf())
+    fun all_permissions(): SdkResult<Array<Permission>, com.looker.sdk.Error> {
+        return this.get<Array<Permission>, com.looker.sdk.Error>(
+            "/permissions", mapOf()
+        )
     }
 
     /**
@@ -6551,8 +6821,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         all_access: Boolean? = null,
         built_in: Boolean? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<Array<PermissionSet>>(
+    ): SdkResult<Array<PermissionSet>, com.looker.sdk.Error> {
+        return this.get<Array<PermissionSet>, com.looker.sdk.Error>(
             "/permission_sets/search",
             mapOf(
                 "fields" to fields,
@@ -6579,9 +6849,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun permission_set(
         permission_set_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<PermissionSet, com.looker.sdk.Error> {
         val path_permission_set_id = encodeParam(permission_set_id)
-        return this.get<PermissionSet>(
+        return this.get<PermissionSet, com.looker.sdk.Error>(
             "/permission_sets/$path_permission_set_id",
             mapOf("fields" to fields)
         )
@@ -6598,9 +6868,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     fun update_permission_set(
         permission_set_id: Long,
         body: WritePermissionSet
-    ): SDKResponse {
+    ): SdkResult<PermissionSet, com.looker.sdk.Error> {
         val path_permission_set_id = encodeParam(permission_set_id)
-        return this.patch<PermissionSet>("/permission_sets/$path_permission_set_id", mapOf(), body)
+        return this.patch<PermissionSet, com.looker.sdk.Error>(
+            "/permission_sets/$path_permission_set_id", mapOf(), body
+        )
     }
 
     /**
@@ -6612,9 +6884,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_permission_set(
         permission_set_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_permission_set_id = encodeParam(permission_set_id)
-        return this.delete<String>("/permission_sets/$path_permission_set_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/permission_sets/$path_permission_set_id", mapOf()
+        )
     }
 
     /**
@@ -6626,8 +6900,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_permission_sets(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<PermissionSet>>(
+    ): SdkResult<Array<PermissionSet>, com.looker.sdk.Error> {
+        return this.get<Array<PermissionSet>, com.looker.sdk.Error>(
             "/permission_sets",
             mapOf("fields" to fields)
         )
@@ -6642,8 +6916,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_permission_set(
         body: WritePermissionSet
-    ): SDKResponse {
-        return this.post<PermissionSet>("/permission_sets", mapOf(), body)
+    ): SdkResult<PermissionSet, com.looker.sdk.Error> {
+        return this.post<PermissionSet, com.looker.sdk.Error>(
+            "/permission_sets", mapOf(), body
+        )
     }
 
     /**
@@ -6657,8 +6933,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_roles(
         fields: String? = null,
         ids: DelimArray<Long>? = null
-    ): SDKResponse {
-        return this.get<Array<Role>>(
+    ): SdkResult<Array<Role>, com.looker.sdk.Error> {
+        return this.get<Array<Role>, com.looker.sdk.Error>(
             "/roles",
             mapOf(
                 "fields" to fields,
@@ -6676,8 +6952,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_role(
         body: WriteRole
-    ): SDKResponse {
-        return this.post<Role>("/roles", mapOf(), body)
+    ): SdkResult<Role, com.looker.sdk.Error> {
+        return this.post<Role, com.looker.sdk.Error>(
+            "/roles", mapOf(), body
+        )
     }
 
     /**
@@ -6726,8 +7004,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         name: String? = null,
         built_in: Boolean? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<Array<Role>>(
+    ): SdkResult<Array<Role>, com.looker.sdk.Error> {
+        return this.get<Array<Role>, com.looker.sdk.Error>(
             "/roles/search",
             mapOf(
                 "fields" to fields,
@@ -6751,9 +7029,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun role(
         role_id: Long
-    ): SDKResponse {
+    ): SdkResult<Role, com.looker.sdk.Error> {
         val path_role_id = encodeParam(role_id)
-        return this.get<Role>("/roles/$path_role_id", mapOf())
+        return this.get<Role, com.looker.sdk.Error>(
+            "/roles/$path_role_id", mapOf()
+        )
     }
 
     /**
@@ -6767,9 +7047,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     fun update_role(
         role_id: Long,
         body: WriteRole
-    ): SDKResponse {
+    ): SdkResult<Role, com.looker.sdk.Error> {
         val path_role_id = encodeParam(role_id)
-        return this.patch<Role>("/roles/$path_role_id", mapOf(), body)
+        return this.patch<Role, com.looker.sdk.Error>(
+            "/roles/$path_role_id", mapOf(), body
+        )
     }
 
     /**
@@ -6781,9 +7063,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_role(
         role_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_role_id = encodeParam(role_id)
-        return this.delete<String>("/roles/$path_role_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/roles/$path_role_id", mapOf()
+        )
     }
 
     /**
@@ -6797,9 +7081,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun role_groups(
         role_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<Group>, com.looker.sdk.Error> {
         val path_role_id = encodeParam(role_id)
-        return this.get<Array<Group>>(
+        return this.get<Array<Group>, com.looker.sdk.Error>(
             "/roles/$path_role_id/groups",
             mapOf("fields" to fields)
         )
@@ -6816,9 +7100,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     fun set_role_groups(
         role_id: Long,
         body: Array<Long>
-    ): SDKResponse {
+    ): SdkResult<Array<Group>, com.looker.sdk.Error> {
         val path_role_id = encodeParam(role_id)
-        return this.put<Array<Group>>("/roles/$path_role_id/groups", mapOf(), body)
+        return this.put<Array<Group>, com.looker.sdk.Error>(
+            "/roles/$path_role_id/groups", mapOf(), body
+        )
     }
 
     /**
@@ -6834,9 +7120,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         role_id: Long,
         fields: String? = null,
         direct_association_only: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<Array<User>, com.looker.sdk.Error> {
         val path_role_id = encodeParam(role_id)
-        return this.get<Array<User>>(
+        return this.get<Array<User>, com.looker.sdk.Error>(
             "/roles/$path_role_id/users",
             mapOf(
                 "fields" to fields,
@@ -6856,9 +7142,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     fun set_role_users(
         role_id: Long,
         body: Array<Long>
-    ): SDKResponse {
+    ): SdkResult<Array<User>, com.looker.sdk.Error> {
         val path_role_id = encodeParam(role_id)
-        return this.put<Array<User>>("/roles/$path_role_id/users", mapOf(), body)
+        return this.put<Array<User>, com.looker.sdk.Error>(
+            "/roles/$path_role_id/users", mapOf(), body
+        )
     }
 
     //endregion Role: Manage Roles
@@ -6878,9 +7166,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun scheduled_plans_for_space(
         space_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<ScheduledPlan>, com.looker.sdk.Error> {
         val path_space_id = encodeParam(space_id)
-        return this.get<Array<ScheduledPlan>>(
+        return this.get<Array<ScheduledPlan>, com.looker.sdk.Error>(
             "/scheduled_plans/space/$path_space_id",
             mapOf("fields" to fields)
         )
@@ -6899,9 +7187,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun scheduled_plan(
         scheduled_plan_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ScheduledPlan, com.looker.sdk.Error> {
         val path_scheduled_plan_id = encodeParam(scheduled_plan_id)
-        return this.get<ScheduledPlan>(
+        return this.get<ScheduledPlan, com.looker.sdk.Error>(
             "/scheduled_plans/$path_scheduled_plan_id",
             mapOf("fields" to fields)
         )
@@ -6959,9 +7247,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     fun update_scheduled_plan(
         scheduled_plan_id: Long,
         body: WriteScheduledPlan
-    ): SDKResponse {
+    ): SdkResult<ScheduledPlan, com.looker.sdk.Error> {
         val path_scheduled_plan_id = encodeParam(scheduled_plan_id)
-        return this.patch<ScheduledPlan>("/scheduled_plans/$path_scheduled_plan_id", mapOf(), body)
+        return this.patch<ScheduledPlan, com.looker.sdk.Error>(
+            "/scheduled_plans/$path_scheduled_plan_id", mapOf(), body
+        )
     }
 
     /**
@@ -6977,9 +7267,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_scheduled_plan(
         scheduled_plan_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_scheduled_plan_id = encodeParam(scheduled_plan_id)
-        return this.delete<String>("/scheduled_plans/$path_scheduled_plan_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/scheduled_plans/$path_scheduled_plan_id", mapOf()
+        )
     }
 
     /**
@@ -7005,8 +7297,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long? = null,
         fields: String? = null,
         all_users: Boolean? = null
-    ): SDKResponse {
-        return this.get<Array<ScheduledPlan>>(
+    ): SdkResult<Array<ScheduledPlan>, com.looker.sdk.Error> {
+        return this.get<Array<ScheduledPlan>, com.looker.sdk.Error>(
             "/scheduled_plans",
             mapOf(
                 "user_id" to user_id,
@@ -7082,8 +7374,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_scheduled_plan(
         body: WriteScheduledPlan
-    ): SDKResponse {
-        return this.post<ScheduledPlan>("/scheduled_plans", mapOf(), body)
+    ): SdkResult<ScheduledPlan, com.looker.sdk.Error> {
+        return this.post<ScheduledPlan, com.looker.sdk.Error>(
+            "/scheduled_plans", mapOf(), body
+        )
     }
 
     /**
@@ -7131,8 +7425,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun scheduled_plan_run_once(
         body: WriteScheduledPlan
-    ): SDKResponse {
-        return this.post<ScheduledPlan>("/scheduled_plans/run_once", mapOf(), body)
+    ): SdkResult<ScheduledPlan, com.looker.sdk.Error> {
+        return this.post<ScheduledPlan, com.looker.sdk.Error>(
+            "/scheduled_plans/run_once", mapOf(), body
+        )
     }
 
     /**
@@ -7160,9 +7456,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long? = null,
         fields: String? = null,
         all_users: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<Array<ScheduledPlan>, com.looker.sdk.Error> {
         val path_look_id = encodeParam(look_id)
-        return this.get<Array<ScheduledPlan>>(
+        return this.get<Array<ScheduledPlan>, com.looker.sdk.Error>(
             "/scheduled_plans/look/$path_look_id",
             mapOf(
                 "user_id" to user_id,
@@ -7197,9 +7493,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long? = null,
         all_users: Boolean? = null,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<ScheduledPlan>, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
-        return this.get<Array<ScheduledPlan>>(
+        return this.get<Array<ScheduledPlan>, com.looker.sdk.Error>(
             "/scheduled_plans/dashboard/$path_dashboard_id",
             mapOf(
                 "user_id" to user_id,
@@ -7234,9 +7530,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long? = null,
         fields: String? = null,
         all_users: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<Array<ScheduledPlan>, com.looker.sdk.Error> {
         val path_lookml_dashboard_id = encodeParam(lookml_dashboard_id)
-        return this.get<Array<ScheduledPlan>>(
+        return this.get<Array<ScheduledPlan>, com.looker.sdk.Error>(
             "/scheduled_plans/lookml_dashboard/$path_lookml_dashboard_id",
             mapOf(
                 "user_id" to user_id,
@@ -7303,9 +7599,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun scheduled_plan_run_once_by_id(
         scheduled_plan_id: Long,
         body: WriteScheduledPlan? = null
-    ): SDKResponse {
+    ): SdkResult<ScheduledPlan, com.looker.sdk.Error> {
         val path_scheduled_plan_id = encodeParam(scheduled_plan_id)
-        return this.post<ScheduledPlan>("/scheduled_plans/$path_scheduled_plan_id/run_once", mapOf(), body)
+        return this.post<ScheduledPlan, com.looker.sdk.Error>(
+            "/scheduled_plans/$path_scheduled_plan_id/run_once", mapOf(), body
+        )
     }
 
     //endregion ScheduledPlan: Manage Scheduled Plans
@@ -7319,8 +7617,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /session -> ApiSession
      */
-    fun session(): SDKResponse {
-        return this.get<ApiSession>("/session", mapOf())
+    fun session(): SdkResult<ApiSession, com.looker.sdk.Error> {
+        return this.get<ApiSession, com.looker.sdk.Error>(
+            "/session", mapOf()
+        )
     }
 
     /**
@@ -7351,8 +7651,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_session(
         body: WriteApiSession
-    ): SDKResponse {
-        return this.patch<ApiSession>("/session", mapOf(), body)
+    ): SdkResult<ApiSession, com.looker.sdk.Error> {
+        return this.patch<ApiSession, com.looker.sdk.Error>(
+            "/session", mapOf(), body
+        )
     }
 
     //endregion Session: Session Information
@@ -7374,8 +7676,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_themes(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<Theme>>(
+    ): SdkResult<Array<Theme>, com.looker.sdk.Error> {
+        return this.get<Array<Theme>, com.looker.sdk.Error>(
             "/themes",
             mapOf("fields" to fields)
         )
@@ -7404,8 +7706,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_theme(
         body: WriteTheme
-    ): SDKResponse {
-        return this.post<Theme>("/themes", mapOf(), body)
+    ): SdkResult<Theme, com.looker.sdk.Error> {
+        return this.post<Theme, com.looker.sdk.Error>(
+            "/themes", mapOf(), body
+        )
     }
 
     /**
@@ -7470,8 +7774,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         sorts: String? = null,
         fields: String? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<Array<Theme>>(
+    ): SdkResult<Array<Theme>, com.looker.sdk.Error> {
+        return this.get<Array<Theme>, com.looker.sdk.Error>(
             "/themes/search",
             mapOf(
                 "id" to id,
@@ -7502,8 +7806,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun default_theme(
         ts: Date? = null
-    ): SDKResponse {
-        return this.get<Theme>(
+    ): SdkResult<Theme, com.looker.sdk.Error> {
+        return this.get<Theme, com.looker.sdk.Error>(
             "/themes/default",
             mapOf("ts" to ts)
         )
@@ -7528,8 +7832,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun set_default_theme(
         name: String
-    ): SDKResponse {
-        return this.put<Theme>(
+    ): SdkResult<Theme, com.looker.sdk.Error> {
+        return this.put<Theme, com.looker.sdk.Error>(
             "/themes/default",
             mapOf("name" to name)
         )
@@ -7556,8 +7860,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         name: String? = null,
         ts: Date? = null,
         fields: String? = null
-    ): SDKResponse {
-        return this.get<Array<Theme>>(
+    ): SdkResult<Array<Theme>, com.looker.sdk.Error> {
+        return this.get<Array<Theme>, com.looker.sdk.Error>(
             "/themes/active",
             mapOf(
                 "name" to name,
@@ -7583,8 +7887,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun theme_or_default(
         name: String,
         ts: Date? = null
-    ): SDKResponse {
-        return this.get<Theme>(
+    ): SdkResult<Theme, com.looker.sdk.Error> {
+        return this.get<Theme, com.looker.sdk.Error>(
             "/themes/theme_or_default",
             mapOf(
                 "name" to name,
@@ -7608,8 +7912,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun validate_theme(
         body: WriteTheme
-    ): SDKResponse {
-        return this.post<ValidationError>("/themes/validate", mapOf(), body)
+    ): SdkResult<ValidationError, com.looker.sdk.Error> {
+        return this.post<ValidationError, com.looker.sdk.Error>(
+            "/themes/validate", mapOf(), body
+        )
     }
 
     /**
@@ -7627,9 +7933,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun theme(
         theme_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Theme, com.looker.sdk.Error> {
         val path_theme_id = encodeParam(theme_id)
-        return this.get<Theme>(
+        return this.get<Theme, com.looker.sdk.Error>(
             "/themes/$path_theme_id",
             mapOf("fields" to fields)
         )
@@ -7648,9 +7954,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     fun update_theme(
         theme_id: Long,
         body: WriteTheme
-    ): SDKResponse {
+    ): SdkResult<Theme, com.looker.sdk.Error> {
         val path_theme_id = encodeParam(theme_id)
-        return this.patch<Theme>("/themes/$path_theme_id", mapOf(), body)
+        return this.patch<Theme, com.looker.sdk.Error>(
+            "/themes/$path_theme_id", mapOf(), body
+        )
     }
 
     /**
@@ -7670,9 +7978,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_theme(
         theme_id: String
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_theme_id = encodeParam(theme_id)
-        return this.delete<String>("/themes/$path_theme_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/themes/$path_theme_id", mapOf()
+        )
     }
 
     //endregion Theme: Manage Themes
@@ -7688,8 +7998,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun me(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<User>(
+    ): SdkResult<User, com.looker.sdk.Error> {
+        return this.get<User, com.looker.sdk.Error>(
             "/user",
             mapOf("fields" to fields)
         )
@@ -7712,8 +8022,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         per_page: Long? = null,
         sorts: String? = null,
         ids: DelimArray<Long>? = null
-    ): SDKResponse {
-        return this.get<Array<User>>(
+    ): SdkResult<Array<User>, com.looker.sdk.Error> {
+        return this.get<Array<User>, com.looker.sdk.Error>(
             "/users",
             mapOf(
                 "fields" to fields,
@@ -7736,8 +8046,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_user(
         body: WriteUser? = null,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<User>(
+    ): SdkResult<User, com.looker.sdk.Error> {
+        return this.post<User, com.looker.sdk.Error>(
             "/users",
             mapOf("fields" to fields), body
         )
@@ -7805,8 +8115,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         filter_or: Boolean? = null,
         content_metadata_id: String? = null,
         group_id: String? = null
-    ): SDKResponse {
-        return this.get<Array<User>>(
+    ): SdkResult<Array<User>, com.looker.sdk.Error> {
+        return this.get<Array<User>, com.looker.sdk.Error>(
             "/users/search",
             mapOf(
                 "fields" to fields,
@@ -7860,9 +8170,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         verified_looker_employee: Boolean? = null,
         email: String? = null,
         is_disabled: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<Array<User>, com.looker.sdk.Error> {
         val path_pattern = encodeParam(pattern)
-        return this.get<Array<User>>(
+        return this.get<Array<User>, com.looker.sdk.Error>(
             "/users/search/names/$path_pattern",
             mapOf(
                 "fields" to fields,
@@ -7894,9 +8204,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun user(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<User, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<User>(
+        return this.get<User, com.looker.sdk.Error>(
             "/users/$path_user_id",
             mapOf("fields" to fields)
         )
@@ -7915,9 +8225,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         body: WriteUser,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<User, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.patch<User>(
+        return this.patch<User, com.looker.sdk.Error>(
             "/users/$path_user_id",
             mapOf("fields" to fields), body
         )
@@ -7934,9 +8244,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_user(
         user_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.delete<String>("/users/$path_user_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/users/$path_user_id", mapOf()
+        )
     }
 
     /**
@@ -7979,10 +8291,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         credential_type: String,
         credential_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<User, com.looker.sdk.Error> {
         val path_credential_type = encodeParam(credential_type)
         val path_credential_id = encodeParam(credential_id)
-        return this.get<User>(
+        return this.get<User, com.looker.sdk.Error>(
             "/users/credential/$path_credential_type/$path_credential_id",
             mapOf("fields" to fields)
         )
@@ -7999,9 +8311,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun user_credentials_email(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<CredentialsEmail, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<CredentialsEmail>(
+        return this.get<CredentialsEmail, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_email",
             mapOf("fields" to fields)
         )
@@ -8020,9 +8332,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         body: WriteCredentialsEmail,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<CredentialsEmail, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.post<CredentialsEmail>(
+        return this.post<CredentialsEmail, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_email",
             mapOf("fields" to fields), body
         )
@@ -8041,9 +8353,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         body: WriteCredentialsEmail,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<CredentialsEmail, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.patch<CredentialsEmail>(
+        return this.patch<CredentialsEmail, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_email",
             mapOf("fields" to fields), body
         )
@@ -8058,9 +8370,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_user_credentials_email(
         user_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.delete<String>("/users/$path_user_id/credentials_email", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/users/$path_user_id/credentials_email", mapOf()
+        )
     }
 
     /**
@@ -8074,9 +8388,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun user_credentials_totp(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<CredentialsTotp, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<CredentialsTotp>(
+        return this.get<CredentialsTotp, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_totp",
             mapOf("fields" to fields)
         )
@@ -8095,9 +8409,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         body: CredentialsTotp? = null,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<CredentialsTotp, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.post<CredentialsTotp>(
+        return this.post<CredentialsTotp, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_totp",
             mapOf("fields" to fields), body
         )
@@ -8112,9 +8426,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_user_credentials_totp(
         user_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.delete<String>("/users/$path_user_id/credentials_totp", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/users/$path_user_id/credentials_totp", mapOf()
+        )
     }
 
     /**
@@ -8128,9 +8444,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun user_credentials_ldap(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<CredentialsLDAP, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<CredentialsLDAP>(
+        return this.get<CredentialsLDAP, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_ldap",
             mapOf("fields" to fields)
         )
@@ -8145,9 +8461,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_user_credentials_ldap(
         user_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.delete<String>("/users/$path_user_id/credentials_ldap", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/users/$path_user_id/credentials_ldap", mapOf()
+        )
     }
 
     /**
@@ -8161,9 +8479,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun user_credentials_google(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<CredentialsGoogle, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<CredentialsGoogle>(
+        return this.get<CredentialsGoogle, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_google",
             mapOf("fields" to fields)
         )
@@ -8178,9 +8496,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_user_credentials_google(
         user_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.delete<String>("/users/$path_user_id/credentials_google", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/users/$path_user_id/credentials_google", mapOf()
+        )
     }
 
     /**
@@ -8194,9 +8514,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun user_credentials_saml(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<CredentialsSaml, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<CredentialsSaml>(
+        return this.get<CredentialsSaml, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_saml",
             mapOf("fields" to fields)
         )
@@ -8211,9 +8531,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_user_credentials_saml(
         user_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.delete<String>("/users/$path_user_id/credentials_saml", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/users/$path_user_id/credentials_saml", mapOf()
+        )
     }
 
     /**
@@ -8227,9 +8549,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun user_credentials_oidc(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<CredentialsOIDC, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<CredentialsOIDC>(
+        return this.get<CredentialsOIDC, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_oidc",
             mapOf("fields" to fields)
         )
@@ -8244,9 +8566,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_user_credentials_oidc(
         user_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.delete<String>("/users/$path_user_id/credentials_oidc", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/users/$path_user_id/credentials_oidc", mapOf()
+        )
     }
 
     /**
@@ -8262,10 +8586,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         credentials_api3_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<CredentialsApi3, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
         val path_credentials_api3_id = encodeParam(credentials_api3_id)
-        return this.get<CredentialsApi3>(
+        return this.get<CredentialsApi3, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_api3/$path_credentials_api3_id",
             mapOf("fields" to fields)
         )
@@ -8282,10 +8606,12 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     fun delete_user_credentials_api3(
         user_id: Long,
         credentials_api3_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
         val path_credentials_api3_id = encodeParam(credentials_api3_id)
-        return this.delete<String>("/users/$path_user_id/credentials_api3/$path_credentials_api3_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/users/$path_user_id/credentials_api3/$path_credentials_api3_id", mapOf()
+        )
     }
 
     /**
@@ -8299,9 +8625,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_user_credentials_api3s(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<CredentialsApi3>, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<Array<CredentialsApi3>>(
+        return this.get<Array<CredentialsApi3>, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_api3",
             mapOf("fields" to fields)
         )
@@ -8320,9 +8646,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         body: CredentialsApi3? = null,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<CredentialsApi3, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.post<CredentialsApi3>(
+        return this.post<CredentialsApi3, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_api3",
             mapOf("fields" to fields), body
         )
@@ -8341,10 +8667,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         credentials_embed_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<CredentialsEmbed, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
         val path_credentials_embed_id = encodeParam(credentials_embed_id)
-        return this.get<CredentialsEmbed>(
+        return this.get<CredentialsEmbed, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_embed/$path_credentials_embed_id",
             mapOf("fields" to fields)
         )
@@ -8361,10 +8687,12 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     fun delete_user_credentials_embed(
         user_id: Long,
         credentials_embed_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
         val path_credentials_embed_id = encodeParam(credentials_embed_id)
-        return this.delete<String>("/users/$path_user_id/credentials_embed/$path_credentials_embed_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/users/$path_user_id/credentials_embed/$path_credentials_embed_id", mapOf()
+        )
     }
 
     /**
@@ -8378,9 +8706,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_user_credentials_embeds(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<CredentialsEmbed>, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<Array<CredentialsEmbed>>(
+        return this.get<Array<CredentialsEmbed>, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_embed",
             mapOf("fields" to fields)
         )
@@ -8397,9 +8725,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun user_credentials_looker_openid(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<CredentialsLookerOpenid, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<CredentialsLookerOpenid>(
+        return this.get<CredentialsLookerOpenid, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_looker_openid",
             mapOf("fields" to fields)
         )
@@ -8414,9 +8742,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_user_credentials_looker_openid(
         user_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.delete<String>("/users/$path_user_id/credentials_looker_openid", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/users/$path_user_id/credentials_looker_openid", mapOf()
+        )
     }
 
     /**
@@ -8432,10 +8762,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         session_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Session, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
         val path_session_id = encodeParam(session_id)
-        return this.get<Session>(
+        return this.get<Session, com.looker.sdk.Error>(
             "/users/$path_user_id/sessions/$path_session_id",
             mapOf("fields" to fields)
         )
@@ -8452,10 +8782,12 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     fun delete_user_session(
         user_id: Long,
         session_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
         val path_session_id = encodeParam(session_id)
-        return this.delete<String>("/users/$path_user_id/sessions/$path_session_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/users/$path_user_id/sessions/$path_session_id", mapOf()
+        )
     }
 
     /**
@@ -8469,9 +8801,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_user_sessions(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<Session>, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<Array<Session>>(
+        return this.get<Array<Session>, com.looker.sdk.Error>(
             "/users/$path_user_id/sessions",
             mapOf("fields" to fields)
         )
@@ -8498,9 +8830,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         expires: Boolean? = null,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<CredentialsEmail, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.post<CredentialsEmail>(
+        return this.post<CredentialsEmail, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_email/password_reset",
             mapOf(
                 "expires" to expires,
@@ -8522,9 +8854,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         fields: String? = null,
         direct_association_only: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<Array<Role>, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<Array<Role>>(
+        return this.get<Array<Role>, com.looker.sdk.Error>(
             "/users/$path_user_id/roles",
             mapOf(
                 "fields" to fields,
@@ -8546,9 +8878,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         body: Array<Long>,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<Role>, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.put<Array<Role>>(
+        return this.put<Array<Role>, com.looker.sdk.Error>(
             "/users/$path_user_id/roles",
             mapOf("fields" to fields), body
         )
@@ -8586,9 +8918,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         user_attribute_ids: DelimArray<Long>? = null,
         all_values: Boolean? = null,
         include_unset: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<Array<UserAttributeWithValue>, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<Array<UserAttributeWithValue>>(
+        return this.get<Array<UserAttributeWithValue>, com.looker.sdk.Error>(
             "/users/$path_user_id/attribute_values",
             mapOf(
                 "fields" to fields,
@@ -8614,10 +8946,12 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         user_attribute_id: Long,
         body: WriteUserAttributeWithValue
-    ): SDKResponse {
+    ): SdkResult<UserAttributeWithValue, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
         val path_user_attribute_id = encodeParam(user_attribute_id)
-        return this.patch<UserAttributeWithValue>("/users/$path_user_id/attribute_values/$path_user_attribute_id", mapOf(), body)
+        return this.patch<UserAttributeWithValue, com.looker.sdk.Error>(
+            "/users/$path_user_id/attribute_values/$path_user_attribute_id", mapOf(), body
+        )
     }
 
     /**
@@ -8636,10 +8970,12 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     fun delete_user_attribute_user_value(
         user_id: Long,
         user_attribute_id: Long
-    ): SDKResponse {
+    ): SdkResult<Void, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
         val path_user_attribute_id = encodeParam(user_attribute_id)
-        return this.delete<Void>("/users/$path_user_id/attribute_values/$path_user_attribute_id", mapOf())
+        return this.delete<Void, com.looker.sdk.Error>(
+            "/users/$path_user_id/attribute_values/$path_user_attribute_id", mapOf()
+        )
     }
 
     /**
@@ -8659,9 +8995,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun send_user_credentials_email_password_reset(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<CredentialsEmail, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.post<CredentialsEmail>(
+        return this.post<CredentialsEmail, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_email/send_password_reset",
             mapOf("fields" to fields)
         )
@@ -8682,8 +9018,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_user_attributes(
         fields: String? = null,
         sorts: String? = null
-    ): SDKResponse {
-        return this.get<Array<UserAttribute>>(
+    ): SdkResult<Array<UserAttribute>, com.looker.sdk.Error> {
+        return this.get<Array<UserAttribute>, com.looker.sdk.Error>(
             "/user_attributes",
             mapOf(
                 "fields" to fields,
@@ -8712,8 +9048,8 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_user_attribute(
         body: WriteUserAttribute,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<UserAttribute>(
+    ): SdkResult<UserAttribute, com.looker.sdk.Error> {
+        return this.post<UserAttribute, com.looker.sdk.Error>(
             "/user_attributes",
             mapOf("fields" to fields), body
         )
@@ -8730,9 +9066,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun user_attribute(
         user_attribute_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<UserAttribute, com.looker.sdk.Error> {
         val path_user_attribute_id = encodeParam(user_attribute_id)
-        return this.get<UserAttribute>(
+        return this.get<UserAttribute, com.looker.sdk.Error>(
             "/user_attributes/$path_user_attribute_id",
             mapOf("fields" to fields)
         )
@@ -8751,9 +9087,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
         user_attribute_id: Long,
         body: WriteUserAttribute,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<UserAttribute, com.looker.sdk.Error> {
         val path_user_attribute_id = encodeParam(user_attribute_id)
-        return this.patch<UserAttribute>(
+        return this.patch<UserAttribute, com.looker.sdk.Error>(
             "/user_attributes/$path_user_attribute_id",
             mapOf("fields" to fields), body
         )
@@ -8768,9 +9104,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_user_attribute(
         user_attribute_id: Long
-    ): SDKResponse {
+    ): SdkResult<String, com.looker.sdk.Error> {
         val path_user_attribute_id = encodeParam(user_attribute_id)
-        return this.delete<String>("/user_attributes/$path_user_attribute_id", mapOf())
+        return this.delete<String, com.looker.sdk.Error>(
+            "/user_attributes/$path_user_attribute_id", mapOf()
+        )
     }
 
     /**
@@ -8790,9 +9128,9 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_user_attribute_group_values(
         user_attribute_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<Array<UserAttributeGroupValue>, com.looker.sdk.Error> {
         val path_user_attribute_id = encodeParam(user_attribute_id)
-        return this.get<Array<UserAttributeGroupValue>>(
+        return this.get<Array<UserAttributeGroupValue>, com.looker.sdk.Error>(
             "/user_attributes/$path_user_attribute_id/group_values",
             mapOf("fields" to fields)
         )
@@ -8828,9 +9166,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
     fun set_user_attribute_group_values(
         user_attribute_id: Long,
         body: Array<UserAttributeGroupValue>
-    ): SDKResponse {
+    ): SdkResult<Array<UserAttributeGroupValue>, com.looker.sdk.Error> {
         val path_user_attribute_id = encodeParam(user_attribute_id)
-        return this.post<Array<UserAttributeGroupValue>>("/user_attributes/$path_user_attribute_id/group_values", mapOf(), body)
+        return this.post<Array<UserAttributeGroupValue>, com.looker.sdk.Error>(
+            "/user_attributes/$path_user_attribute_id/group_values", mapOf(), body
+        )
     }
 
     //endregion UserAttribute: Manage User Attributes
@@ -8844,8 +9184,10 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /workspaces -> Array<Workspace>
      */
-    fun all_workspaces(): SDKResponse {
-        return this.get<Array<Workspace>>("/workspaces", mapOf())
+    fun all_workspaces(): SdkResult<Array<Workspace>, com.looker.sdk.Error> {
+        return this.get<Array<Workspace>, com.looker.sdk.Error>(
+            "/workspaces", mapOf()
+        )
     }
 
     /**
@@ -8885,9 +9227,11 @@ class LookerSDK(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun workspace(
         workspace_id: String
-    ): SDKResponse {
+    ): SdkResult<Workspace, com.looker.sdk.Error> {
         val path_workspace_id = encodeParam(workspace_id)
-        return this.get<Workspace>("/workspaces/$path_workspace_id", mapOf())
+        return this.get<Workspace, com.looker.sdk.Error>(
+            "/workspaces/$path_workspace_id", mapOf()
+        )
     }
 
     //endregion Workspace: Manage Workspaces

--- a/kotlin/src/main/com/looker/sdk/4.0/streams.kt
+++ b/kotlin/src/main/com/looker/sdk/4.0/streams.kt
@@ -76,8 +76,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun login(
         client_id: String? = null,
         client_secret: String? = null
-    ): SDKResponse {
-        return this.post<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/login",
             mapOf(
                 "client_id" to client_id,
@@ -112,9 +112,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun login_user(
         user_id: Long,
         associative: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.post<ByteArray>(
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/login/$path_user_id",
             mapOf("associative" to associative)
         )
@@ -125,8 +125,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * DELETE /logout -> ByteArray
      */
-    fun logout(): SDKResponse {
-        return this.delete<ByteArray>("/logout", mapOf())
+    fun logout(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/logout", mapOf()
+        )
     }
 
     //endregion ApiAuth: API Authentication
@@ -175,8 +177,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_sso_embed_url(
         body: EmbedSsoParams
-    ): SDKResponse {
-        return this.post<ByteArray>("/embed/sso_url", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/embed/sso_url", mapOf(), body
+        )
     }
 
     /**
@@ -206,8 +210,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_embed_url_as_me(
         body: EmbedParams
-    ): SDKResponse {
-        return this.post<ByteArray>("/embed/token_url/me", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/embed/token_url/me", mapOf(), body
+        )
     }
 
     /**
@@ -230,8 +236,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /ldap_config -> ByteArray
      */
-    fun ldap_config(): SDKResponse {
-        return this.get<ByteArray>("/ldap_config", mapOf())
+    fun ldap_config(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/ldap_config", mapOf()
+        )
     }
 
     /**
@@ -253,8 +261,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_ldap_config(
         body: WriteLDAPConfig
-    ): SDKResponse {
-        return this.patch<ByteArray>("/ldap_config", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/ldap_config", mapOf(), body
+        )
     }
 
     /**
@@ -283,8 +293,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun test_ldap_config_connection(
         body: WriteLDAPConfig
-    ): SDKResponse {
-        return this.put<ByteArray>("/ldap_config/test_connection", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.put<ByteArray, com.looker.sdk.Error>(
+            "/ldap_config/test_connection", mapOf(), body
+        )
     }
 
     /**
@@ -315,8 +327,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun test_ldap_config_auth(
         body: WriteLDAPConfig
-    ): SDKResponse {
-        return this.put<ByteArray>("/ldap_config/test_auth", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.put<ByteArray, com.looker.sdk.Error>(
+            "/ldap_config/test_auth", mapOf(), body
+        )
     }
 
     /**
@@ -336,8 +350,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun test_ldap_config_user_info(
         body: WriteLDAPConfig
-    ): SDKResponse {
-        return this.put<ByteArray>("/ldap_config/test_user_info", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.put<ByteArray, com.looker.sdk.Error>(
+            "/ldap_config/test_user_info", mapOf(), body
+        )
     }
 
     /**
@@ -357,8 +373,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun test_ldap_config_user_auth(
         body: WriteLDAPConfig
-    ): SDKResponse {
-        return this.put<ByteArray>("/ldap_config/test_user_auth", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.put<ByteArray, com.looker.sdk.Error>(
+            "/ldap_config/test_user_auth", mapOf(), body
+        )
     }
 
     /**
@@ -376,8 +394,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_oauth_client_apps(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/oauth_client_apps",
             mapOf("fields" to fields)
         )
@@ -396,9 +414,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun oauth_client_app(
         client_guid: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_client_guid = encodeParam(client_guid)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/oauth_client_apps/$path_client_guid",
             mapOf("fields" to fields)
         )
@@ -422,9 +440,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         client_guid: String,
         body: WriteOauthClientApp,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_client_guid = encodeParam(client_guid)
-        return this.post<ByteArray>(
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/oauth_client_apps/$path_client_guid",
             mapOf("fields" to fields), body
         )
@@ -445,9 +463,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         client_guid: String,
         body: WriteOauthClientApp,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_client_guid = encodeParam(client_guid)
-        return this.patch<ByteArray>(
+        return this.patch<ByteArray, com.looker.sdk.Error>(
             "/oauth_client_apps/$path_client_guid",
             mapOf("fields" to fields), body
         )
@@ -467,9 +485,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_oauth_client_app(
         client_guid: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_client_guid = encodeParam(client_guid)
-        return this.delete<ByteArray>("/oauth_client_apps/$path_client_guid", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/oauth_client_apps/$path_client_guid", mapOf()
+        )
     }
 
     /**
@@ -484,9 +504,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun invalidate_tokens(
         client_guid: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_client_guid = encodeParam(client_guid)
-        return this.delete<ByteArray>("/oauth_client_apps/$path_client_guid/tokens", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/oauth_client_apps/$path_client_guid/tokens", mapOf()
+        )
     }
 
     /**
@@ -508,10 +530,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         client_guid: String,
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_client_guid = encodeParam(client_guid)
         val path_user_id = encodeParam(user_id)
-        return this.post<ByteArray>(
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/oauth_client_apps/$path_client_guid/users/$path_user_id",
             mapOf("fields" to fields)
         )
@@ -539,10 +561,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         client_guid: String,
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_client_guid = encodeParam(client_guid)
         val path_user_id = encodeParam(user_id)
-        return this.delete<ByteArray>(
+        return this.delete<ByteArray, com.looker.sdk.Error>(
             "/oauth_client_apps/$path_client_guid/users/$path_user_id",
             mapOf("fields" to fields)
         )
@@ -564,8 +586,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /oidc_config -> ByteArray
      */
-    fun oidc_config(): SDKResponse {
-        return this.get<ByteArray>("/oidc_config", mapOf())
+    fun oidc_config(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/oidc_config", mapOf()
+        )
     }
 
     /**
@@ -585,8 +609,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_oidc_config(
         body: WriteOIDCConfig
-    ): SDKResponse {
-        return this.patch<ByteArray>("/oidc_config", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/oidc_config", mapOf(), body
+        )
     }
 
     /**
@@ -598,9 +624,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun oidc_test_config(
         test_slug: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_test_slug = encodeParam(test_slug)
-        return this.get<ByteArray>("/oidc_test_configs/$path_test_slug", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/oidc_test_configs/$path_test_slug", mapOf()
+        )
     }
 
     /**
@@ -612,9 +640,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_oidc_test_config(
         test_slug: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_test_slug = encodeParam(test_slug)
-        return this.delete<ByteArray>("/oidc_test_configs/$path_test_slug", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/oidc_test_configs/$path_test_slug", mapOf()
+        )
     }
 
     /**
@@ -626,8 +656,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_oidc_test_config(
         body: WriteOIDCConfig
-    ): SDKResponse {
-        return this.post<ByteArray>("/oidc_test_configs", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/oidc_test_configs", mapOf(), body
+        )
     }
 
     /**
@@ -635,8 +667,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /password_config -> ByteArray
      */
-    fun password_config(): SDKResponse {
-        return this.get<ByteArray>("/password_config", mapOf())
+    fun password_config(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/password_config", mapOf()
+        )
     }
 
     /**
@@ -648,8 +682,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_password_config(
         body: WritePasswordConfig
-    ): SDKResponse {
-        return this.patch<ByteArray>("/password_config", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/password_config", mapOf(), body
+        )
     }
 
     /**
@@ -657,8 +693,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * PUT /password_config/force_password_reset_at_next_login_for_all_users -> ByteArray
      */
-    fun force_password_reset_at_next_login_for_all_users(): SDKResponse {
-        return this.put<ByteArray>("/password_config/force_password_reset_at_next_login_for_all_users", mapOf())
+    fun force_password_reset_at_next_login_for_all_users(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.put<ByteArray, com.looker.sdk.Error>(
+            "/password_config/force_password_reset_at_next_login_for_all_users", mapOf()
+        )
     }
 
     /**
@@ -677,8 +715,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /saml_config -> ByteArray
      */
-    fun saml_config(): SDKResponse {
-        return this.get<ByteArray>("/saml_config", mapOf())
+    fun saml_config(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/saml_config", mapOf()
+        )
     }
 
     /**
@@ -698,8 +738,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_saml_config(
         body: WriteSamlConfig
-    ): SDKResponse {
-        return this.patch<ByteArray>("/saml_config", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/saml_config", mapOf(), body
+        )
     }
 
     /**
@@ -711,9 +753,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun saml_test_config(
         test_slug: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_test_slug = encodeParam(test_slug)
-        return this.get<ByteArray>("/saml_test_configs/$path_test_slug", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/saml_test_configs/$path_test_slug", mapOf()
+        )
     }
 
     /**
@@ -725,9 +769,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_saml_test_config(
         test_slug: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_test_slug = encodeParam(test_slug)
-        return this.delete<ByteArray>("/saml_test_configs/$path_test_slug", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/saml_test_configs/$path_test_slug", mapOf()
+        )
     }
 
     /**
@@ -739,8 +785,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_saml_test_config(
         body: WriteSamlConfig
-    ): SDKResponse {
-        return this.post<ByteArray>("/saml_test_configs", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/saml_test_configs", mapOf(), body
+        )
     }
 
     /**
@@ -752,8 +800,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun parse_saml_idp_metadata(
         body: String
-    ): SDKResponse {
-        return this.post<ByteArray>("/parse_saml_idp_metadata", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/parse_saml_idp_metadata", mapOf(), body
+        )
     }
 
     /**
@@ -767,8 +817,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun fetch_and_parse_saml_idp_metadata(
         body: String
-    ): SDKResponse {
-        return this.post<ByteArray>("/fetch_and_parse_saml_idp_metadata", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/fetch_and_parse_saml_idp_metadata", mapOf(), body
+        )
     }
 
     /**
@@ -776,8 +828,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /session_config -> ByteArray
      */
-    fun session_config(): SDKResponse {
-        return this.get<ByteArray>("/session_config", mapOf())
+    fun session_config(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/session_config", mapOf()
+        )
     }
 
     /**
@@ -789,8 +843,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_session_config(
         body: WriteSessionConfig
-    ): SDKResponse {
-        return this.patch<ByteArray>("/session_config", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/session_config", mapOf(), body
+        )
     }
 
     /**
@@ -802,8 +858,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_user_login_lockouts(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/user_login_lockouts",
             mapOf("fields" to fields)
         )
@@ -834,8 +890,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         email: String? = null,
         remote_id: String? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/user_login_lockouts/search",
             mapOf(
                 "fields" to fields,
@@ -860,9 +916,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_user_login_lockout(
         key: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_key = encodeParam(key)
-        return this.delete<ByteArray>("/user_login_lockout/$path_key", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/user_login_lockout/$path_key", mapOf()
+        )
     }
 
     //endregion Auth: Manage User Authentication Configuration
@@ -878,8 +936,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_boards(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/boards",
             mapOf("fields" to fields)
         )
@@ -896,8 +954,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_board(
         body: WriteBoard,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/boards",
             mapOf("fields" to fields), body
         )
@@ -957,8 +1015,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         offset: Long? = null,
         limit: Long? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/boards/search",
             mapOf(
                 "title" to title,
@@ -989,9 +1047,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun board(
         board_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_board_id = encodeParam(board_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/boards/$path_board_id",
             mapOf("fields" to fields)
         )
@@ -1010,9 +1068,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         board_id: Long,
         body: WriteBoard,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_board_id = encodeParam(board_id)
-        return this.patch<ByteArray>(
+        return this.patch<ByteArray, com.looker.sdk.Error>(
             "/boards/$path_board_id",
             mapOf("fields" to fields), body
         )
@@ -1027,9 +1085,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_board(
         board_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_board_id = encodeParam(board_id)
-        return this.delete<ByteArray>("/boards/$path_board_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/boards/$path_board_id", mapOf()
+        )
     }
 
     /**
@@ -1045,8 +1105,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         fields: String? = null,
         sorts: String? = null,
         board_section_id: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/board_items",
             mapOf(
                 "fields" to fields,
@@ -1067,8 +1127,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_board_item(
         body: WriteBoardItem,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/board_items",
             mapOf("fields" to fields), body
         )
@@ -1085,9 +1145,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun board_item(
         board_item_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_board_item_id = encodeParam(board_item_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/board_items/$path_board_item_id",
             mapOf("fields" to fields)
         )
@@ -1106,9 +1166,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         board_item_id: Long,
         body: WriteBoardItem,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_board_item_id = encodeParam(board_item_id)
-        return this.patch<ByteArray>(
+        return this.patch<ByteArray, com.looker.sdk.Error>(
             "/board_items/$path_board_item_id",
             mapOf("fields" to fields), body
         )
@@ -1123,9 +1183,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_board_item(
         board_item_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_board_item_id = encodeParam(board_item_id)
-        return this.delete<ByteArray>("/board_items/$path_board_item_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/board_items/$path_board_item_id", mapOf()
+        )
     }
 
     /**
@@ -1139,8 +1201,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_board_sections(
         fields: String? = null,
         sorts: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/board_sections",
             mapOf(
                 "fields" to fields,
@@ -1160,8 +1222,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_board_section(
         body: WriteBoardSection,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/board_sections",
             mapOf("fields" to fields), body
         )
@@ -1178,9 +1240,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun board_section(
         board_section_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_board_section_id = encodeParam(board_section_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/board_sections/$path_board_section_id",
             mapOf("fields" to fields)
         )
@@ -1199,9 +1261,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         board_section_id: Long,
         body: WriteBoardSection,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_board_section_id = encodeParam(board_section_id)
-        return this.patch<ByteArray>(
+        return this.patch<ByteArray, com.looker.sdk.Error>(
             "/board_sections/$path_board_section_id",
             mapOf("fields" to fields), body
         )
@@ -1216,9 +1278,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_board_section(
         board_section_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_board_section_id = encodeParam(board_section_id)
-        return this.delete<ByteArray>("/board_sections/$path_board_section_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/board_sections/$path_board_section_id", mapOf()
+        )
     }
 
     //endregion Board: Manage Boards
@@ -1241,8 +1305,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_color_collections(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/color_collections",
             mapOf("fields" to fields)
         )
@@ -1265,8 +1329,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_color_collection(
         body: WriteColorCollection
-    ): SDKResponse {
-        return this.post<ByteArray>("/color_collections", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/color_collections", mapOf(), body
+        )
     }
 
     /**
@@ -1283,8 +1349,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun color_collections_custom(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/color_collections/custom",
             mapOf("fields" to fields)
         )
@@ -1304,8 +1370,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun color_collections_standard(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/color_collections/standard",
             mapOf("fields" to fields)
         )
@@ -1320,8 +1386,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /color_collections/default -> ByteArray
      */
-    fun default_color_collection(): SDKResponse {
-        return this.get<ByteArray>("/color_collections/default", mapOf())
+    fun default_color_collection(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/color_collections/default", mapOf()
+        )
     }
 
     /**
@@ -1336,8 +1404,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun set_default_color_collection(
         collection_id: String
-    ): SDKResponse {
-        return this.put<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.put<ByteArray, com.looker.sdk.Error>(
             "/color_collections/default",
             mapOf("collection_id" to collection_id)
         )
@@ -1363,9 +1431,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun color_collection(
         collection_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_collection_id = encodeParam(collection_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/color_collections/$path_collection_id",
             mapOf("fields" to fields)
         )
@@ -1383,9 +1451,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun update_color_collection(
         collection_id: String,
         body: WriteColorCollection
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_collection_id = encodeParam(collection_id)
-        return this.patch<ByteArray>("/color_collections/$path_collection_id", mapOf(), body)
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/color_collections/$path_collection_id", mapOf(), body
+        )
     }
 
     /**
@@ -1404,9 +1474,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_color_collection(
         collection_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_collection_id = encodeParam(collection_id)
-        return this.delete<ByteArray>("/color_collections/$path_collection_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/color_collections/$path_collection_id", mapOf()
+        )
     }
 
     //endregion ColorCollection: Manage Color Collections
@@ -1426,8 +1498,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         content_id: String? = null,
         content_type: String? = null,
         limit: Long? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/commands",
             mapOf(
                 "content_id" to content_id,
@@ -1449,8 +1521,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_command(
         body: WriteCommand
-    ): SDKResponse {
-        return this.post<ByteArray>("/commands", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/commands", mapOf(), body
+        )
     }
 
     /**
@@ -1466,9 +1540,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun update_command(
         command_id: Long,
         body: UpdateCommand
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_command_id = encodeParam(command_id)
-        return this.patch<ByteArray>("/commands/$path_command_id", mapOf(), body)
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/commands/$path_command_id", mapOf(), body
+        )
     }
 
     /**
@@ -1480,9 +1556,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_command(
         command_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_command_id = encodeParam(command_id)
-        return this.delete<ByteArray>("/commands/$path_command_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/commands/$path_command_id", mapOf()
+        )
     }
 
     //endregion Command: Manage Commands
@@ -1494,8 +1572,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /cloud_storage -> ByteArray
      */
-    fun cloud_storage_configuration(): SDKResponse {
-        return this.get<ByteArray>("/cloud_storage", mapOf())
+    fun cloud_storage_configuration(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/cloud_storage", mapOf()
+        )
     }
 
     /**
@@ -1507,8 +1587,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_cloud_storage_configuration(
         body: WriteBackupConfiguration
-    ): SDKResponse {
-        return this.patch<ByteArray>("/cloud_storage", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/cloud_storage", mapOf(), body
+        )
     }
 
     /**
@@ -1516,8 +1598,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /custom_welcome_email -> ByteArray
      */
-    fun custom_welcome_email(): SDKResponse {
-        return this.get<ByteArray>("/custom_welcome_email", mapOf())
+    fun custom_welcome_email(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/custom_welcome_email", mapOf()
+        )
     }
 
     /**
@@ -1531,8 +1615,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun update_custom_welcome_email(
         body: WriteCustomWelcomeEmail,
         send_test_welcome_email: Boolean? = null
-    ): SDKResponse {
-        return this.patch<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.patch<ByteArray, com.looker.sdk.Error>(
             "/custom_welcome_email",
             mapOf("send_test_welcome_email" to send_test_welcome_email), body
         )
@@ -1547,8 +1631,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_custom_welcome_email_test(
         body: WelcomeEmailTest
-    ): SDKResponse {
-        return this.put<ByteArray>("/custom_welcome_email_test", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.put<ByteArray, com.looker.sdk.Error>(
+            "/custom_welcome_email_test", mapOf(), body
+        )
     }
 
     /**
@@ -1556,8 +1642,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /digest_emails_enabled -> ByteArray
      */
-    fun digest_emails_enabled(): SDKResponse {
-        return this.get<ByteArray>("/digest_emails_enabled", mapOf())
+    fun digest_emails_enabled(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/digest_emails_enabled", mapOf()
+        )
     }
 
     /**
@@ -1569,8 +1657,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_digest_emails_enabled(
         body: DigestEmails
-    ): SDKResponse {
-        return this.patch<ByteArray>("/digest_emails_enabled", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/digest_emails_enabled", mapOf(), body
+        )
     }
 
     /**
@@ -1580,8 +1670,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * POST /digest_email_send -> ByteArray
      */
-    fun create_digest_email_send(): SDKResponse {
-        return this.post<ByteArray>("/digest_email_send", mapOf())
+    fun create_digest_email_send(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/digest_email_send", mapOf()
+        )
     }
 
     /**
@@ -1589,8 +1681,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /internal_help_resources_content -> ByteArray
      */
-    fun internal_help_resources_content(): SDKResponse {
-        return this.get<ByteArray>("/internal_help_resources_content", mapOf())
+    fun internal_help_resources_content(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/internal_help_resources_content", mapOf()
+        )
     }
 
     /**
@@ -1602,8 +1696,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_internal_help_resources_content(
         body: WriteInternalHelpResourcesContent
-    ): SDKResponse {
-        return this.patch<ByteArray>("/internal_help_resources_content", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/internal_help_resources_content", mapOf(), body
+        )
     }
 
     /**
@@ -1611,8 +1707,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /internal_help_resources_enabled -> ByteArray
      */
-    fun internal_help_resources(): SDKResponse {
-        return this.get<ByteArray>("/internal_help_resources_enabled", mapOf())
+    fun internal_help_resources(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/internal_help_resources_enabled", mapOf()
+        )
     }
 
     /**
@@ -1624,8 +1722,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_internal_help_resources(
         body: WriteInternalHelpResources
-    ): SDKResponse {
-        return this.patch<ByteArray>("/internal_help_resources", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/internal_help_resources", mapOf(), body
+        )
     }
 
     /**
@@ -1633,8 +1733,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /legacy_features -> ByteArray
      */
-    fun all_legacy_features(): SDKResponse {
-        return this.get<ByteArray>("/legacy_features", mapOf())
+    fun all_legacy_features(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/legacy_features", mapOf()
+        )
     }
 
     /**
@@ -1646,9 +1748,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun legacy_feature(
         legacy_feature_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_legacy_feature_id = encodeParam(legacy_feature_id)
-        return this.get<ByteArray>("/legacy_features/$path_legacy_feature_id", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/legacy_features/$path_legacy_feature_id", mapOf()
+        )
     }
 
     /**
@@ -1662,9 +1766,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun update_legacy_feature(
         legacy_feature_id: String,
         body: WriteLegacyFeature
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_legacy_feature_id = encodeParam(legacy_feature_id)
-        return this.patch<ByteArray>("/legacy_features/$path_legacy_feature_id", mapOf(), body)
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/legacy_features/$path_legacy_feature_id", mapOf(), body
+        )
     }
 
     /**
@@ -1672,8 +1778,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /locales -> ByteArray
      */
-    fun all_locales(): SDKResponse {
-        return this.get<ByteArray>("/locales", mapOf())
+    fun all_locales(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/locales", mapOf()
+        )
     }
 
     /**
@@ -1681,8 +1789,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /timezones -> ByteArray
      */
-    fun all_timezones(): SDKResponse {
-        return this.get<ByteArray>("/timezones", mapOf())
+    fun all_timezones(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/timezones", mapOf()
+        )
     }
 
     /**
@@ -1694,8 +1804,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun versions(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/versions",
             mapOf("fields" to fields)
         )
@@ -1711,8 +1821,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun whitelabel_configuration(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/whitelabel_configuration",
             mapOf("fields" to fields)
         )
@@ -1727,8 +1837,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_whitelabel_configuration(
         body: WriteWhitelabelConfiguration
-    ): SDKResponse {
-        return this.put<ByteArray>("/whitelabel_configuration", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.put<ByteArray, com.looker.sdk.Error>(
+            "/whitelabel_configuration", mapOf(), body
+        )
     }
 
     //endregion Config: Manage General Configuration
@@ -1744,8 +1856,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_connections(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/connections",
             mapOf("fields" to fields)
         )
@@ -1760,8 +1872,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_connection(
         body: WriteDBConnection
-    ): SDKResponse {
-        return this.post<ByteArray>("/connections", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/connections", mapOf(), body
+        )
     }
 
     /**
@@ -1775,9 +1889,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun connection(
         connection_name: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_connection_name = encodeParam(connection_name)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/connections/$path_connection_name",
             mapOf("fields" to fields)
         )
@@ -1794,9 +1908,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun update_connection(
         connection_name: String,
         body: WriteDBConnection
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_connection_name = encodeParam(connection_name)
-        return this.patch<ByteArray>("/connections/$path_connection_name", mapOf(), body)
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/connections/$path_connection_name", mapOf(), body
+        )
     }
 
     /**
@@ -1808,9 +1924,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_connection(
         connection_name: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_connection_name = encodeParam(connection_name)
-        return this.delete<ByteArray>("/connections/$path_connection_name", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/connections/$path_connection_name", mapOf()
+        )
     }
 
     /**
@@ -1824,10 +1942,12 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun delete_connection_override(
         connection_name: String,
         override_context: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_connection_name = encodeParam(connection_name)
         val path_override_context = encodeParam(override_context)
-        return this.delete<ByteArray>("/connections/$path_connection_name/connection_override/$path_override_context", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/connections/$path_connection_name/connection_override/$path_override_context", mapOf()
+        )
     }
 
     /**
@@ -1848,9 +1968,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun test_connection(
         connection_name: String,
         tests: DelimArray<String>? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_connection_name = encodeParam(connection_name)
-        return this.put<ByteArray>(
+        return this.put<ByteArray, com.looker.sdk.Error>(
             "/connections/$path_connection_name/test",
             mapOf("tests" to tests)
         )
@@ -1874,8 +1994,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun test_connection_config(
         body: WriteDBConnection,
         tests: DelimArray<String>? = null
-    ): SDKResponse {
-        return this.put<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.put<ByteArray, com.looker.sdk.Error>(
             "/connections/test",
             mapOf("tests" to tests), body
         )
@@ -1890,8 +2010,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_dialect_infos(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/dialect_info",
             mapOf("fields" to fields)
         )
@@ -1906,8 +2026,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_ssh_servers(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/ssh_servers",
             mapOf("fields" to fields)
         )
@@ -1922,8 +2042,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_ssh_server(
         body: WriteSshServer
-    ): SDKResponse {
-        return this.post<ByteArray>("/ssh_servers", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/ssh_servers", mapOf(), body
+        )
     }
 
     /**
@@ -1935,9 +2057,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun ssh_server(
         ssh_server_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_ssh_server_id = encodeParam(ssh_server_id)
-        return this.get<ByteArray>("/ssh_server/$path_ssh_server_id", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/ssh_server/$path_ssh_server_id", mapOf()
+        )
     }
 
     /**
@@ -1951,9 +2075,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun update_ssh_server(
         ssh_server_id: String,
         body: WriteSshServer
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_ssh_server_id = encodeParam(ssh_server_id)
-        return this.patch<ByteArray>("/ssh_server/$path_ssh_server_id", mapOf(), body)
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/ssh_server/$path_ssh_server_id", mapOf(), body
+        )
     }
 
     /**
@@ -1965,9 +2091,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_ssh_server(
         ssh_server_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_ssh_server_id = encodeParam(ssh_server_id)
-        return this.delete<ByteArray>("/ssh_server/$path_ssh_server_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/ssh_server/$path_ssh_server_id", mapOf()
+        )
     }
 
     /**
@@ -1979,9 +2107,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun test_ssh_server(
         ssh_server_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_ssh_server_id = encodeParam(ssh_server_id)
-        return this.get<ByteArray>("/ssh_server/$path_ssh_server_id/test", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/ssh_server/$path_ssh_server_id/test", mapOf()
+        )
     }
 
     /**
@@ -1993,8 +2123,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_ssh_tunnels(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/ssh_tunnels",
             mapOf("fields" to fields)
         )
@@ -2009,8 +2139,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_ssh_tunnel(
         body: WriteSshTunnel
-    ): SDKResponse {
-        return this.post<ByteArray>("/ssh_tunnels", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/ssh_tunnels", mapOf(), body
+        )
     }
 
     /**
@@ -2022,9 +2154,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun ssh_tunnel(
         ssh_tunnel_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_ssh_tunnel_id = encodeParam(ssh_tunnel_id)
-        return this.get<ByteArray>("/ssh_tunnel/$path_ssh_tunnel_id", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/ssh_tunnel/$path_ssh_tunnel_id", mapOf()
+        )
     }
 
     /**
@@ -2038,9 +2172,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun update_ssh_tunnel(
         ssh_tunnel_id: String,
         body: WriteSshTunnel
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_ssh_tunnel_id = encodeParam(ssh_tunnel_id)
-        return this.patch<ByteArray>("/ssh_tunnel/$path_ssh_tunnel_id", mapOf(), body)
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/ssh_tunnel/$path_ssh_tunnel_id", mapOf(), body
+        )
     }
 
     /**
@@ -2052,9 +2188,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_ssh_tunnel(
         ssh_tunnel_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_ssh_tunnel_id = encodeParam(ssh_tunnel_id)
-        return this.delete<ByteArray>("/ssh_tunnel/$path_ssh_tunnel_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/ssh_tunnel/$path_ssh_tunnel_id", mapOf()
+        )
     }
 
     /**
@@ -2066,9 +2204,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun test_ssh_tunnel(
         ssh_tunnel_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_ssh_tunnel_id = encodeParam(ssh_tunnel_id)
-        return this.get<ByteArray>("/ssh_tunnel/$path_ssh_tunnel_id/test", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/ssh_tunnel/$path_ssh_tunnel_id/test", mapOf()
+        )
     }
 
     /**
@@ -2078,8 +2218,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /ssh_public_key -> ByteArray
      */
-    fun ssh_public_key(): SDKResponse {
-        return this.get<ByteArray>("/ssh_public_key", mapOf())
+    fun ssh_public_key(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/ssh_public_key", mapOf()
+        )
     }
 
     //endregion Connection: Manage Database Connections
@@ -2136,8 +2278,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         sorts: String? = null,
         fields: String? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/content_favorite/search",
             mapOf(
                 "id" to id,
@@ -2166,9 +2308,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun content_favorite(
         content_favorite_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_content_favorite_id = encodeParam(content_favorite_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/content_favorite/$path_content_favorite_id",
             mapOf("fields" to fields)
         )
@@ -2183,9 +2325,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_content_favorite(
         content_favorite_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_content_favorite_id = encodeParam(content_favorite_id)
-        return this.delete<ByteArray>("/content_favorite/$path_content_favorite_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/content_favorite/$path_content_favorite_id", mapOf()
+        )
     }
 
     /**
@@ -2197,8 +2341,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_content_favorite(
         body: WriteContentFavorite
-    ): SDKResponse {
-        return this.post<ByteArray>("/content_favorite", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/content_favorite", mapOf(), body
+        )
     }
 
     /**
@@ -2212,8 +2358,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_content_metadatas(
         parent_id: Long,
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/content_metadata",
             mapOf(
                 "parent_id" to parent_id,
@@ -2233,9 +2379,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun content_metadata(
         content_metadata_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_content_metadata_id = encodeParam(content_metadata_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/content_metadata/$path_content_metadata_id",
             mapOf("fields" to fields)
         )
@@ -2252,9 +2398,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun update_content_metadata(
         content_metadata_id: Long,
         body: WriteContentMeta
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_content_metadata_id = encodeParam(content_metadata_id)
-        return this.patch<ByteArray>("/content_metadata/$path_content_metadata_id", mapOf(), body)
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/content_metadata/$path_content_metadata_id", mapOf(), body
+        )
     }
 
     /**
@@ -2268,8 +2416,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_content_metadata_accesses(
         content_metadata_id: Long,
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/content_metadata_access",
             mapOf(
                 "content_metadata_id" to content_metadata_id,
@@ -2289,8 +2437,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_content_metadata_access(
         body: ContentMetaGroupUser,
         send_boards_notification_email: Boolean? = null
-    ): SDKResponse {
-        return this.post<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/content_metadata_access",
             mapOf("send_boards_notification_email" to send_boards_notification_email), body
         )
@@ -2307,9 +2455,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun update_content_metadata_access(
         content_metadata_access_id: String,
         body: ContentMetaGroupUser
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_content_metadata_access_id = encodeParam(content_metadata_access_id)
-        return this.put<ByteArray>("/content_metadata_access/$path_content_metadata_access_id", mapOf(), body)
+        return this.put<ByteArray, com.looker.sdk.Error>(
+            "/content_metadata_access/$path_content_metadata_access_id", mapOf(), body
+        )
     }
 
     /**
@@ -2321,9 +2471,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_content_metadata_access(
         content_metadata_access_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_content_metadata_access_id = encodeParam(content_metadata_access_id)
-        return this.delete<ByteArray>("/content_metadata_access/$path_content_metadata_access_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/content_metadata_access/$path_content_metadata_access_id", mapOf()
+        )
     }
 
     /**
@@ -2350,10 +2502,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         format: String? = null,
         width: Long? = null,
         height: Long? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_type = encodeParam(type)
         val path_resource_id = encodeParam(resource_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/content_thumbnail/$path_type/$path_resource_id",
             mapOf(
                 "reload" to reload,
@@ -2376,8 +2528,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun content_validation(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/content_validation",
             mapOf("fields" to fields)
         )
@@ -2437,8 +2589,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         offset: Long? = null,
         sorts: String? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/content_view/search",
             mapOf(
                 "view_count" to view_count,
@@ -2476,10 +2628,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         type: String,
         resource_id: String,
         reload: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_type = encodeParam(type)
         val path_resource_id = encodeParam(resource_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/vector_thumbnail/$path_type/$path_resource_id",
             mapOf("reload" to reload)
         )
@@ -2504,8 +2656,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_dashboards(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/dashboards",
             mapOf("fields" to fields)
         )
@@ -2533,8 +2685,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_dashboard(
         body: WriteDashboard
-    ): SDKResponse {
-        return this.post<ByteArray>("/dashboards", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/dashboards", mapOf(), body
+        )
     }
 
     /**
@@ -2610,8 +2764,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         offset: Long? = null,
         sorts: String? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/dashboards/search",
             mapOf(
                 "id" to id,
@@ -2663,10 +2817,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         space_id: String,
         body: WriteDashboard? = null,
         raw_locale: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_lookml_dashboard_id = encodeParam(lookml_dashboard_id)
         val path_space_id = encodeParam(space_id)
-        return this.post<ByteArray>(
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/dashboards/$path_lookml_dashboard_id/import/$path_space_id",
             mapOf("raw_locale" to raw_locale), body
         )
@@ -2693,9 +2847,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         lookml_dashboard_id: String,
         body: WriteDashboard,
         raw_locale: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_lookml_dashboard_id = encodeParam(lookml_dashboard_id)
-        return this.patch<ByteArray>(
+        return this.patch<ByteArray, com.looker.sdk.Error>(
             "/dashboards/$path_lookml_dashboard_id/sync",
             mapOf("raw_locale" to raw_locale), body
         )
@@ -2718,9 +2872,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun dashboard(
         dashboard_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/dashboards/$path_dashboard_id",
             mapOf("fields" to fields)
         )
@@ -2746,9 +2900,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun update_dashboard(
         dashboard_id: String,
         body: WriteDashboard
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
-        return this.patch<ByteArray>("/dashboards/$path_dashboard_id", mapOf(), body)
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/dashboards/$path_dashboard_id", mapOf(), body
+        )
     }
 
     /**
@@ -2766,9 +2922,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_dashboard(
         dashboard_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
-        return this.delete<ByteArray>("/dashboards/$path_dashboard_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/dashboards/$path_dashboard_id", mapOf()
+        )
     }
 
     /**
@@ -2782,9 +2940,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun dashboard_aggregate_table_lookml(
         dashboard_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
-        return this.get<ByteArray>("/dashboards/aggregate_table_lookml/$path_dashboard_id", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/dashboards/aggregate_table_lookml/$path_dashboard_id", mapOf()
+        )
     }
 
     /**
@@ -2798,9 +2958,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun dashboard_lookml(
         dashboard_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
-        return this.get<ByteArray>("/dashboards/lookml/$path_dashboard_id", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/dashboards/lookml/$path_dashboard_id", mapOf()
+        )
     }
 
     /**
@@ -2847,8 +3009,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         fields: String? = null,
         filter_or: Boolean? = null,
         sorts: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/dashboard_elements/search",
             mapOf(
                 "dashboard_id" to dashboard_id,
@@ -2873,9 +3035,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun dashboard_element(
         dashboard_element_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_element_id = encodeParam(dashboard_element_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/dashboard_elements/$path_dashboard_element_id",
             mapOf("fields" to fields)
         )
@@ -2894,9 +3056,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         dashboard_element_id: String,
         body: WriteDashboardElement,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_element_id = encodeParam(dashboard_element_id)
-        return this.patch<ByteArray>(
+        return this.patch<ByteArray, com.looker.sdk.Error>(
             "/dashboard_elements/$path_dashboard_element_id",
             mapOf("fields" to fields), body
         )
@@ -2911,9 +3073,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_dashboard_element(
         dashboard_element_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_element_id = encodeParam(dashboard_element_id)
-        return this.delete<ByteArray>("/dashboard_elements/$path_dashboard_element_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/dashboard_elements/$path_dashboard_element_id", mapOf()
+        )
     }
 
     /**
@@ -2927,9 +3091,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun dashboard_dashboard_elements(
         dashboard_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/dashboards/$path_dashboard_id/dashboard_elements",
             mapOf("fields" to fields)
         )
@@ -2946,8 +3110,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_dashboard_element(
         body: WriteDashboardElement,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/dashboard_elements",
             mapOf("fields" to fields), body
         )
@@ -2964,9 +3128,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun dashboard_filter(
         dashboard_filter_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_filter_id = encodeParam(dashboard_filter_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/dashboard_filters/$path_dashboard_filter_id",
             mapOf("fields" to fields)
         )
@@ -2985,9 +3149,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         dashboard_filter_id: String,
         body: WriteDashboardFilter,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_filter_id = encodeParam(dashboard_filter_id)
-        return this.patch<ByteArray>(
+        return this.patch<ByteArray, com.looker.sdk.Error>(
             "/dashboard_filters/$path_dashboard_filter_id",
             mapOf("fields" to fields), body
         )
@@ -3002,9 +3166,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_dashboard_filter(
         dashboard_filter_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_filter_id = encodeParam(dashboard_filter_id)
-        return this.delete<ByteArray>("/dashboard_filters/$path_dashboard_filter_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/dashboard_filters/$path_dashboard_filter_id", mapOf()
+        )
     }
 
     /**
@@ -3018,9 +3184,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun dashboard_dashboard_filters(
         dashboard_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/dashboards/$path_dashboard_id/dashboard_filters",
             mapOf("fields" to fields)
         )
@@ -3037,8 +3203,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_dashboard_filter(
         body: WriteCreateDashboardFilter,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/dashboard_filters",
             mapOf("fields" to fields), body
         )
@@ -3055,9 +3221,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun dashboard_layout_component(
         dashboard_layout_component_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_layout_component_id = encodeParam(dashboard_layout_component_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/dashboard_layout_components/$path_dashboard_layout_component_id",
             mapOf("fields" to fields)
         )
@@ -3076,9 +3242,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         dashboard_layout_component_id: String,
         body: WriteDashboardLayoutComponent,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_layout_component_id = encodeParam(dashboard_layout_component_id)
-        return this.patch<ByteArray>(
+        return this.patch<ByteArray, com.looker.sdk.Error>(
             "/dashboard_layout_components/$path_dashboard_layout_component_id",
             mapOf("fields" to fields), body
         )
@@ -3095,9 +3261,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun dashboard_layout_dashboard_layout_components(
         dashboard_layout_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_layout_id = encodeParam(dashboard_layout_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/dashboard_layouts/$path_dashboard_layout_id/dashboard_layout_components",
             mapOf("fields" to fields)
         )
@@ -3114,9 +3280,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun dashboard_layout(
         dashboard_layout_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_layout_id = encodeParam(dashboard_layout_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/dashboard_layouts/$path_dashboard_layout_id",
             mapOf("fields" to fields)
         )
@@ -3135,9 +3301,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         dashboard_layout_id: String,
         body: WriteDashboardLayout,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_layout_id = encodeParam(dashboard_layout_id)
-        return this.patch<ByteArray>(
+        return this.patch<ByteArray, com.looker.sdk.Error>(
             "/dashboard_layouts/$path_dashboard_layout_id",
             mapOf("fields" to fields), body
         )
@@ -3152,9 +3318,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_dashboard_layout(
         dashboard_layout_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_layout_id = encodeParam(dashboard_layout_id)
-        return this.delete<ByteArray>("/dashboard_layouts/$path_dashboard_layout_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/dashboard_layouts/$path_dashboard_layout_id", mapOf()
+        )
     }
 
     /**
@@ -3168,9 +3336,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun dashboard_dashboard_layouts(
         dashboard_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/dashboards/$path_dashboard_id/dashboard_layouts",
             mapOf("fields" to fields)
         )
@@ -3187,8 +3355,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_dashboard_layout(
         body: WriteDashboardLayout,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/dashboard_layouts",
             mapOf("fields" to fields), body
         )
@@ -3207,8 +3375,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun perform_data_action(
         body: DataActionRequest
-    ): SDKResponse {
-        return this.post<ByteArray>("/data_actions", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/data_actions", mapOf(), body
+        )
     }
 
     /**
@@ -3220,8 +3390,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun fetch_remote_data_action_form(
         body: Map<String, Any>
-    ): SDKResponse {
-        return this.post<ByteArray>("/data_actions/form", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/data_actions/form", mapOf(), body
+        )
     }
 
     //endregion DataAction: Run Data Actions
@@ -3233,8 +3405,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /datagroups -> ByteArray
      */
-    fun all_datagroups(): SDKResponse {
-        return this.get<ByteArray>("/datagroups", mapOf())
+    fun all_datagroups(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/datagroups", mapOf()
+        )
     }
 
     /**
@@ -3246,9 +3420,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun datagroup(
         datagroup_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_datagroup_id = encodeParam(datagroup_id)
-        return this.get<ByteArray>("/datagroups/$path_datagroup_id", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/datagroups/$path_datagroup_id", mapOf()
+        )
     }
 
     /**
@@ -3262,9 +3438,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun update_datagroup(
         datagroup_id: Long,
         body: WriteDatagroup
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_datagroup_id = encodeParam(datagroup_id)
-        return this.patch<ByteArray>("/datagroups/$path_datagroup_id", mapOf(), body)
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/datagroups/$path_datagroup_id", mapOf(), body
+        )
     }
 
     //endregion Datagroup: Manage Datagroups
@@ -3300,8 +3478,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         parent_id: String? = null,
         creator_id: String? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/folders/search",
             mapOf(
                 "fields" to fields,
@@ -3330,9 +3508,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun folder(
         folder_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_folder_id = encodeParam(folder_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/folders/$path_folder_id",
             mapOf("fields" to fields)
         )
@@ -3349,9 +3527,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun update_folder(
         folder_id: String,
         body: UpdateFolder
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_folder_id = encodeParam(folder_id)
-        return this.patch<ByteArray>("/folders/$path_folder_id", mapOf(), body)
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/folders/$path_folder_id", mapOf(), body
+        )
     }
 
     /**
@@ -3364,9 +3544,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_folder(
         folder_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_folder_id = encodeParam(folder_id)
-        return this.delete<ByteArray>("/folders/$path_folder_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/folders/$path_folder_id", mapOf()
+        )
     }
 
     /**
@@ -3378,8 +3560,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_folders(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/folders",
             mapOf("fields" to fields)
         )
@@ -3397,8 +3579,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_folder(
         body: CreateFolder
-    ): SDKResponse {
-        return this.post<ByteArray>("/folders", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/folders", mapOf(), body
+        )
     }
 
     /**
@@ -3418,9 +3602,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         page: Long? = null,
         per_page: Long? = null,
         sorts: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_folder_id = encodeParam(folder_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/folders/$path_folder_id/children",
             mapOf(
                 "fields" to fields,
@@ -3446,9 +3630,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         fields: String? = null,
         sorts: String? = null,
         name: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_folder_id = encodeParam(folder_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/folders/$path_folder_id/children/search",
             mapOf(
                 "fields" to fields,
@@ -3469,9 +3653,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun folder_parent(
         folder_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_folder_id = encodeParam(folder_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/folders/$path_folder_id/parent",
             mapOf("fields" to fields)
         )
@@ -3488,9 +3672,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun folder_ancestors(
         folder_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_folder_id = encodeParam(folder_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/folders/$path_folder_id/ancestors",
             mapOf("fields" to fields)
         )
@@ -3507,9 +3691,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun folder_looks(
         folder_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_folder_id = encodeParam(folder_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/folders/$path_folder_id/looks",
             mapOf("fields" to fields)
         )
@@ -3526,9 +3710,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun folder_dashboards(
         folder_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_folder_id = encodeParam(folder_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/folders/$path_folder_id/dashboards",
             mapOf("fields" to fields)
         )
@@ -3559,8 +3743,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         ids: DelimArray<Long>? = null,
         content_metadata_id: Long? = null,
         can_add_to_content_metadata: Boolean? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/groups",
             mapOf(
                 "fields" to fields,
@@ -3585,8 +3769,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_group(
         body: WriteGroup,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/groups",
             mapOf("fields" to fields), body
         )
@@ -3642,8 +3826,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         external_group_id: String? = null,
         externally_managed: Boolean? = null,
         externally_orphaned: Boolean? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/groups/search",
             mapOf(
                 "fields" to fields,
@@ -3710,8 +3894,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         external_group_id: String? = null,
         externally_managed: Boolean? = null,
         externally_orphaned: Boolean? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/groups/search/with_roles",
             mapOf(
                 "fields" to fields,
@@ -3779,8 +3963,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         external_group_id: String? = null,
         externally_managed: Boolean? = null,
         externally_orphaned: Boolean? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/groups/search/with_hierarchy",
             mapOf(
                 "fields" to fields,
@@ -3808,9 +3992,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun group(
         group_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/groups/$path_group_id",
             mapOf("fields" to fields)
         )
@@ -3829,9 +4013,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         group_id: Long,
         body: WriteGroup,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
-        return this.patch<ByteArray>(
+        return this.patch<ByteArray, com.looker.sdk.Error>(
             "/groups/$path_group_id",
             mapOf("fields" to fields), body
         )
@@ -3846,9 +4030,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_group(
         group_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
-        return this.delete<ByteArray>("/groups/$path_group_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/groups/$path_group_id", mapOf()
+        )
     }
 
     /**
@@ -3862,9 +4048,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_group_groups(
         group_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/groups/$path_group_id/groups",
             mapOf("fields" to fields)
         )
@@ -3881,9 +4067,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun add_group_group(
         group_id: Long,
         body: GroupIdForGroupInclusion
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
-        return this.post<ByteArray>("/groups/$path_group_id/groups", mapOf(), body)
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/groups/$path_group_id/groups", mapOf(), body
+        )
     }
 
     /**
@@ -3903,9 +4091,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         page: Long? = null,
         per_page: Long? = null,
         sorts: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/groups/$path_group_id/users",
             mapOf(
                 "fields" to fields,
@@ -3927,9 +4115,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun add_group_user(
         group_id: Long,
         body: GroupIdForGroupUserInclusion
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
-        return this.post<ByteArray>("/groups/$path_group_id/users", mapOf(), body)
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/groups/$path_group_id/users", mapOf(), body
+        )
     }
 
     /**
@@ -3943,10 +4133,12 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun delete_group_user(
         group_id: Long,
         user_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
         val path_user_id = encodeParam(user_id)
-        return this.delete<ByteArray>("/groups/$path_group_id/users/$path_user_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/groups/$path_group_id/users/$path_user_id", mapOf()
+        )
     }
 
     /**
@@ -3960,10 +4152,12 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun delete_group_from_group(
         group_id: Long,
         deleting_group_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
         val path_deleting_group_id = encodeParam(deleting_group_id)
-        return this.delete<ByteArray>("/groups/$path_group_id/groups/$path_deleting_group_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/groups/$path_group_id/groups/$path_deleting_group_id", mapOf()
+        )
     }
 
     /**
@@ -3981,10 +4175,12 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         group_id: Long,
         user_attribute_id: Long,
         body: UserAttributeGroupValue
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
         val path_user_attribute_id = encodeParam(user_attribute_id)
-        return this.patch<ByteArray>("/groups/$path_group_id/attribute_values/$path_user_attribute_id", mapOf(), body)
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/groups/$path_group_id/attribute_values/$path_user_attribute_id", mapOf(), body
+        )
     }
 
     /**
@@ -3998,10 +4194,12 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun delete_user_attribute_group_value(
         group_id: Long,
         user_attribute_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_group_id = encodeParam(group_id)
         val path_user_attribute_id = encodeParam(user_attribute_id)
-        return this.delete<ByteArray>("/groups/$path_group_id/attribute_values/$path_user_attribute_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/groups/$path_group_id/attribute_values/$path_user_attribute_id", mapOf()
+        )
     }
 
     //endregion Group: Manage Groups
@@ -4017,8 +4215,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_primary_homepage_sections(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/primary_homepage_sections",
             mapOf("fields" to fields)
         )
@@ -4037,8 +4235,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_integration_hubs(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/integration_hubs",
             mapOf("fields" to fields)
         )
@@ -4057,8 +4255,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_integration_hub(
         body: WriteIntegrationHub,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/integration_hubs",
             mapOf("fields" to fields), body
         )
@@ -4075,9 +4273,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun integration_hub(
         integration_hub_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_integration_hub_id = encodeParam(integration_hub_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/integration_hubs/$path_integration_hub_id",
             mapOf("fields" to fields)
         )
@@ -4098,9 +4296,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         integration_hub_id: Long,
         body: WriteIntegrationHub,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_integration_hub_id = encodeParam(integration_hub_id)
-        return this.patch<ByteArray>(
+        return this.patch<ByteArray, com.looker.sdk.Error>(
             "/integration_hubs/$path_integration_hub_id",
             mapOf("fields" to fields), body
         )
@@ -4115,9 +4313,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_integration_hub(
         integration_hub_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_integration_hub_id = encodeParam(integration_hub_id)
-        return this.delete<ByteArray>("/integration_hubs/$path_integration_hub_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/integration_hubs/$path_integration_hub_id", mapOf()
+        )
     }
 
     /**
@@ -4129,9 +4329,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun accept_integration_hub_legal_agreement(
         integration_hub_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_integration_hub_id = encodeParam(integration_hub_id)
-        return this.post<ByteArray>("/integration_hubs/$path_integration_hub_id/accept_legal_agreement", mapOf())
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/integration_hubs/$path_integration_hub_id/accept_legal_agreement", mapOf()
+        )
     }
 
     /**
@@ -4145,8 +4347,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_integrations(
         fields: String? = null,
         integration_hub_id: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/integrations",
             mapOf(
                 "fields" to fields,
@@ -4166,9 +4368,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun integration(
         integration_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_integration_id = encodeParam(integration_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/integrations/$path_integration_id",
             mapOf("fields" to fields)
         )
@@ -4187,9 +4389,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         integration_id: String,
         body: WriteIntegration,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_integration_id = encodeParam(integration_id)
-        return this.patch<ByteArray>(
+        return this.patch<ByteArray, com.looker.sdk.Error>(
             "/integrations/$path_integration_id",
             mapOf("fields" to fields), body
         )
@@ -4206,9 +4408,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun fetch_integration_form(
         integration_id: String,
         body: Map<String, Any>? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_integration_id = encodeParam(integration_id)
-        return this.post<ByteArray>("/integrations/$path_integration_id/form", mapOf(), body)
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/integrations/$path_integration_id/form", mapOf(), body
+        )
     }
 
     /**
@@ -4220,9 +4424,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun test_integration(
         integration_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_integration_id = encodeParam(integration_id)
-        return this.post<ByteArray>("/integrations/$path_integration_id/test", mapOf())
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/integrations/$path_integration_id/test", mapOf()
+        )
     }
 
     //endregion Integration: Manage Integrations
@@ -4244,8 +4450,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_looks(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/looks",
             mapOf("fields" to fields)
         )
@@ -4268,8 +4474,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_look(
         body: WriteLookWithQuery,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/looks",
             mapOf("fields" to fields), body
         )
@@ -4344,8 +4550,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         offset: Long? = null,
         sorts: String? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/looks/search",
             mapOf(
                 "id" to id,
@@ -4383,9 +4589,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun look(
         look_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_look_id = encodeParam(look_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/looks/$path_look_id",
             mapOf("fields" to fields)
         )
@@ -4423,9 +4629,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         look_id: Long,
         body: WriteLookWithQuery,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_look_id = encodeParam(look_id)
-        return this.patch<ByteArray>(
+        return this.patch<ByteArray, com.looker.sdk.Error>(
             "/looks/$path_look_id",
             mapOf("fields" to fields), body
         )
@@ -4446,9 +4652,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_look(
         look_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_look_id = encodeParam(look_id)
-        return this.delete<ByteArray>("/looks/$path_look_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/looks/$path_look_id", mapOf()
+        )
     }
 
     /**
@@ -4505,10 +4713,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         path_prefix: String? = null,
         rebuild_pdts: Boolean? = null,
         server_table_calcs: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_look_id = encodeParam(look_id)
         val path_result_format = encodeParam(result_format)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/looks/$path_look_id/run/$path_result_format",
             mapOf(
                 "limit" to limit,
@@ -4540,8 +4748,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_lookml_models(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/lookml_models",
             mapOf("fields" to fields)
         )
@@ -4556,8 +4764,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_lookml_model(
         body: WriteLookmlModel
-    ): SDKResponse {
-        return this.post<ByteArray>("/lookml_models", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/lookml_models", mapOf(), body
+        )
     }
 
     /**
@@ -4571,9 +4781,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun lookml_model(
         lookml_model_name: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_lookml_model_name = encodeParam(lookml_model_name)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/lookml_models/$path_lookml_model_name",
             mapOf("fields" to fields)
         )
@@ -4590,9 +4800,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun update_lookml_model(
         lookml_model_name: String,
         body: WriteLookmlModel
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_lookml_model_name = encodeParam(lookml_model_name)
-        return this.patch<ByteArray>("/lookml_models/$path_lookml_model_name", mapOf(), body)
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/lookml_models/$path_lookml_model_name", mapOf(), body
+        )
     }
 
     /**
@@ -4604,9 +4816,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_lookml_model(
         lookml_model_name: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_lookml_model_name = encodeParam(lookml_model_name)
-        return this.delete<ByteArray>("/lookml_models/$path_lookml_model_name", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/lookml_models/$path_lookml_model_name", mapOf()
+        )
     }
 
     /**
@@ -4622,10 +4836,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         lookml_model_name: String,
         explore_name: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_lookml_model_name = encodeParam(lookml_model_name)
         val path_explore_name = encodeParam(explore_name)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/lookml_models/$path_lookml_model_name/explores/$path_explore_name",
             mapOf("fields" to fields)
         )
@@ -4652,11 +4866,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         field_name: String,
         term: String? = null,
         filters: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_model_name = encodeParam(model_name)
         val path_view_name = encodeParam(view_name)
         val path_field_name = encodeParam(field_name)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/models/$path_model_name/views/$path_view_name/fields/$path_field_name/suggestions",
             mapOf(
                 "term" to term,
@@ -4682,9 +4896,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun connection_databases(
         connection_name: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_connection_name = encodeParam(connection_name)
-        return this.get<ByteArray>("/connections/$path_connection_name/databases", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/connections/$path_connection_name/databases", mapOf()
+        )
     }
 
     /**
@@ -4700,9 +4916,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun connection_features(
         connection_name: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_connection_name = encodeParam(connection_name)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/connections/$path_connection_name/features",
             mapOf("fields" to fields)
         )
@@ -4723,9 +4939,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         database: String? = null,
         cache: Boolean? = null,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_connection_name = encodeParam(connection_name)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/connections/$path_connection_name/schemas",
             mapOf(
                 "database" to database,
@@ -4757,9 +4973,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         schema_name: String? = null,
         cache: Boolean? = null,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_connection_name = encodeParam(connection_name)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/connections/$path_connection_name/tables",
             mapOf(
                 "database" to database,
@@ -4791,9 +5007,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         table_limit: Long? = null,
         table_names: String? = null,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_connection_name = encodeParam(connection_name)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/connections/$path_connection_name/columns",
             mapOf(
                 "database" to database,
@@ -4821,9 +5037,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         connection_name: String,
         column_name: String? = null,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_connection_name = encodeParam(connection_name)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/connections/$path_connection_name/search_columns",
             mapOf(
                 "column_name" to column_name,
@@ -4849,9 +5065,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         connection_name: String,
         body: CreateCostEstimate,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_connection_name = encodeParam(connection_name)
-        return this.post<ByteArray>(
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/connections/$path_connection_name/cost_estimate",
             mapOf("fields" to fields), body
         )
@@ -4878,9 +5094,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun lock_all(
         project_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.post<ByteArray>(
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/projects/$path_project_id/manifest/lock_all",
             mapOf("fields" to fields)
         )
@@ -4897,9 +5113,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun all_git_branches(
         project_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<ByteArray>("/projects/$path_project_id/git_branches", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/projects/$path_project_id/git_branches", mapOf()
+        )
     }
 
     /**
@@ -4913,9 +5131,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun git_branch(
         project_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<ByteArray>("/projects/$path_project_id/git_branch", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/projects/$path_project_id/git_branch", mapOf()
+        )
     }
 
     /**
@@ -4937,9 +5157,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun update_git_branch(
         project_id: String,
         body: WriteGitBranch
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.put<ByteArray>("/projects/$path_project_id/git_branch", mapOf(), body)
+        return this.put<ByteArray, com.looker.sdk.Error>(
+            "/projects/$path_project_id/git_branch", mapOf(), body
+        )
     }
 
     /**
@@ -4960,9 +5182,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun create_git_branch(
         project_id: String,
         body: WriteGitBranch
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.post<ByteArray>("/projects/$path_project_id/git_branch", mapOf(), body)
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/projects/$path_project_id/git_branch", mapOf(), body
+        )
     }
 
     /**
@@ -4978,10 +5202,12 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun find_git_branch(
         project_id: String,
         branch_name: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
         val path_branch_name = encodeParam(branch_name)
-        return this.get<ByteArray>("/projects/$path_project_id/git_branch/$path_branch_name", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/projects/$path_project_id/git_branch/$path_branch_name", mapOf()
+        )
     }
 
     /**
@@ -4997,10 +5223,12 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun delete_git_branch(
         project_id: String,
         branch_name: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
         val path_branch_name = encodeParam(branch_name)
-        return this.delete<ByteArray>("/projects/$path_project_id/git_branch/$path_branch_name", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/projects/$path_project_id/git_branch/$path_branch_name", mapOf()
+        )
     }
 
     /**
@@ -5024,9 +5252,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         project_id: String,
         branch: String? = null,
         ref: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.post<ByteArray>(
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/projects/$path_project_id/deploy_ref_to_production",
             mapOf(
                 "branch" to branch,
@@ -5055,9 +5283,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun deploy_to_production(
         project_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.post<ByteArray>("/projects/$path_project_id/deploy_to_production", mapOf())
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/projects/$path_project_id/deploy_to_production", mapOf()
+        )
     }
 
     /**
@@ -5071,9 +5301,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun reset_project_to_production(
         project_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.post<ByteArray>("/projects/$path_project_id/reset_to_production", mapOf())
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/projects/$path_project_id/reset_to_production", mapOf()
+        )
     }
 
     /**
@@ -5087,9 +5319,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun reset_project_to_remote(
         project_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.post<ByteArray>("/projects/$path_project_id/reset_to_remote", mapOf())
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/projects/$path_project_id/reset_to_remote", mapOf()
+        )
     }
 
     /**
@@ -5103,8 +5337,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_projects(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/projects",
             mapOf("fields" to fields)
         )
@@ -5125,8 +5359,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_project(
         body: WriteProject
-    ): SDKResponse {
-        return this.post<ByteArray>("/projects", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/projects", mapOf(), body
+        )
     }
 
     /**
@@ -5142,9 +5378,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun project(
         project_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/projects/$path_project_id",
             mapOf("fields" to fields)
         )
@@ -5184,9 +5420,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         project_id: String,
         body: WriteProject,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.patch<ByteArray>(
+        return this.patch<ByteArray, com.looker.sdk.Error>(
             "/projects/$path_project_id",
             mapOf("fields" to fields), body
         )
@@ -5203,9 +5439,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun manifest(
         project_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<ByteArray>("/projects/$path_project_id/manifest", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/projects/$path_project_id/manifest", mapOf()
+        )
     }
 
     /**
@@ -5219,9 +5457,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun git_deploy_key(
         project_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<ByteArray>("/projects/$path_project_id/git/deploy_key", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/projects/$path_project_id/git/deploy_key", mapOf()
+        )
     }
 
     /**
@@ -5241,9 +5481,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_git_deploy_key(
         project_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.post<ByteArray>("/projects/$path_project_id/git/deploy_key", mapOf())
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/projects/$path_project_id/git/deploy_key", mapOf()
+        )
     }
 
     /**
@@ -5268,9 +5510,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun project_validation_results(
         project_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/projects/$path_project_id/validate",
             mapOf("fields" to fields)
         )
@@ -5295,9 +5537,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun validate_project(
         project_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.post<ByteArray>(
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/projects/$path_project_id/validate",
             mapOf("fields" to fields)
         )
@@ -5316,9 +5558,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun project_workspace(
         project_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/projects/$path_project_id/current_workspace",
             mapOf("fields" to fields)
         )
@@ -5337,9 +5579,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_project_files(
         project_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/projects/$path_project_id/files",
             mapOf("fields" to fields)
         )
@@ -5360,9 +5602,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         project_id: String,
         file_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/projects/$path_project_id/files/file",
             mapOf(
                 "file_id" to file_id,
@@ -5391,9 +5633,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_git_connection_tests(
         project_id: String,
         remote_url: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/projects/$path_project_id/git_connection_tests",
             mapOf("remote_url" to remote_url)
         )
@@ -5418,10 +5660,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         project_id: String,
         test_id: String,
         remote_url: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
         val path_test_id = encodeParam(test_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/projects/$path_project_id/git_connection_tests/$path_test_id",
             mapOf("remote_url" to remote_url)
         )
@@ -5442,9 +5684,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_lookml_tests(
         project_id: String,
         file_id: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/projects/$path_project_id/lookml_tests",
             mapOf("file_id" to file_id)
         )
@@ -5467,9 +5709,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         file_id: String? = null,
         test: String? = null,
         model: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_project_id = encodeParam(project_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/projects/$path_project_id/lookml_tests/run",
             mapOf(
                 "file_id" to file_id,
@@ -5497,10 +5739,12 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         root_project_id: String,
         credential_id: String,
         body: WriteRepositoryCredential
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_root_project_id = encodeParam(root_project_id)
         val path_credential_id = encodeParam(credential_id)
-        return this.put<ByteArray>("/projects/$path_root_project_id/credential/$path_credential_id", mapOf(), body)
+        return this.put<ByteArray, com.looker.sdk.Error>(
+            "/projects/$path_root_project_id/credential/$path_credential_id", mapOf(), body
+        )
     }
 
     /**
@@ -5519,10 +5763,12 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun delete_repository_credential(
         root_project_id: String,
         credential_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_root_project_id = encodeParam(root_project_id)
         val path_credential_id = encodeParam(credential_id)
-        return this.delete<ByteArray>("/projects/$path_root_project_id/credential/$path_credential_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/projects/$path_root_project_id/credential/$path_credential_id", mapOf()
+        )
     }
 
     /**
@@ -5536,9 +5782,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun get_all_repository_credentials(
         root_project_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_root_project_id = encodeParam(root_project_id)
-        return this.get<ByteArray>("/projects/$path_root_project_id/credentials", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/projects/$path_root_project_id/credentials", mapOf()
+        )
     }
 
     //endregion Project: Manage Projects
@@ -5585,8 +5833,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         rebuild_pdts: Boolean? = null,
         server_table_calcs: Boolean? = null,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/query_tasks",
             mapOf(
                 "limit" to limit,
@@ -5622,8 +5870,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun query_task_multi_results(
         query_task_ids: DelimArray<String>
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/query_tasks/multi_results",
             mapOf("query_task_ids" to query_task_ids)
         )
@@ -5646,9 +5894,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun query_task(
         query_task_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_query_task_id = encodeParam(query_task_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/query_tasks/$path_query_task_id",
             mapOf("fields" to fields)
         )
@@ -5685,9 +5933,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun query_task_results(
         query_task_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_query_task_id = encodeParam(query_task_id)
-        return this.get<ByteArray>("/query_tasks/$path_query_task_id/results", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/query_tasks/$path_query_task_id/results", mapOf()
+        )
     }
 
     /**
@@ -5717,9 +5967,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun query(
         query_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_query_id = encodeParam(query_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/queries/$path_query_id",
             mapOf("fields" to fields)
         )
@@ -5752,9 +6002,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun query_for_slug(
         slug: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_slug = encodeParam(slug)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/queries/slug/$path_slug",
             mapOf("fields" to fields)
         )
@@ -5778,8 +6028,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_query(
         body: WriteQuery,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/queries",
             mapOf("fields" to fields), body
         )
@@ -5842,10 +6092,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         path_prefix: String? = null,
         rebuild_pdts: Boolean? = null,
         server_table_calcs: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_query_id = encodeParam(query_id)
         val path_result_format = encodeParam(result_format)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/queries/$path_query_id/run/$path_result_format",
             mapOf(
                 "limit" to limit,
@@ -5950,9 +6200,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         path_prefix: String? = null,
         rebuild_pdts: Boolean? = null,
         server_table_calcs: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_result_format = encodeParam(result_format)
-        return this.post<ByteArray>(
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/queries/run/$path_result_format",
             mapOf(
                 "limit" to limit,
@@ -6038,11 +6288,13 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         model_name: String,
         view_name: String,
         result_format: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_model_name = encodeParam(model_name)
         val path_view_name = encodeParam(view_name)
         val path_result_format = encodeParam(result_format)
-        return this.get<ByteArray>("/queries/models/$path_model_name/views/$path_view_name/run/$path_result_format", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/queries/models/$path_model_name/views/$path_view_name/run/$path_result_format", mapOf()
+        )
     }
 
     /**
@@ -6058,9 +6310,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun merge_query(
         merge_query_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_merge_query_id = encodeParam(merge_query_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/merge_queries/$path_merge_query_id",
             mapOf("fields" to fields)
         )
@@ -6093,8 +6345,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_merge_query(
         body: WriteMergeQuery? = null,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/merge_queries",
             mapOf("fields" to fields), body
         )
@@ -6105,8 +6357,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /running_queries -> ByteArray
      */
-    fun all_running_queries(): SDKResponse {
-        return this.get<ByteArray>("/running_queries", mapOf())
+    fun all_running_queries(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/running_queries", mapOf()
+        )
     }
 
     /**
@@ -6118,9 +6372,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun kill_query(
         query_task_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_query_task_id = encodeParam(query_task_id)
-        return this.delete<ByteArray>("/running_queries/$path_query_task_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/running_queries/$path_query_task_id", mapOf()
+        )
     }
 
     /**
@@ -6132,9 +6388,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun sql_query(
         slug: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_slug = encodeParam(slug)
-        return this.get<ByteArray>("/sql_queries/$path_slug", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/sql_queries/$path_slug", mapOf()
+        )
     }
 
     /**
@@ -6148,8 +6406,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_sql_query(
         body: SqlQueryCreate
-    ): SDKResponse {
-        return this.post<ByteArray>("/sql_queries", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/sql_queries", mapOf(), body
+        )
     }
 
     /**
@@ -6167,10 +6427,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         slug: String,
         result_format: String,
         download: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_slug = encodeParam(slug)
         val path_result_format = encodeParam(result_format)
-        return this.post<ByteArray>(
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/sql_queries/$path_slug/run/$path_result_format",
             mapOf("download" to download)
         )
@@ -6201,10 +6461,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         width: Long,
         height: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_look_id = encodeParam(look_id)
         val path_result_format = encodeParam(result_format)
-        return this.post<ByteArray>(
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/render_tasks/looks/$path_look_id/$path_result_format",
             mapOf(
                 "width" to width,
@@ -6235,10 +6495,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         width: Long,
         height: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_query_id = encodeParam(query_id)
         val path_result_format = encodeParam(result_format)
-        return this.post<ByteArray>(
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/render_tasks/queries/$path_query_id/$path_result_format",
             mapOf(
                 "width" to width,
@@ -6277,10 +6537,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         pdf_paper_size: String? = null,
         pdf_landscape: Boolean? = null,
         long_tables: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
         val path_result_format = encodeParam(result_format)
-        return this.post<ByteArray>(
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/render_tasks/dashboards/$path_dashboard_id/$path_result_format",
             mapOf(
                 "width" to width,
@@ -6309,9 +6569,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun render_task(
         render_task_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_render_task_id = encodeParam(render_task_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/render_tasks/$path_render_task_id",
             mapOf("fields" to fields)
         )
@@ -6344,9 +6604,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun render_task_results(
         render_task_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_render_task_id = encodeParam(render_task_id)
-        return this.get<ByteArray>("/render_tasks/$path_render_task_id/results", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/render_tasks/$path_render_task_id/results", mapOf()
+        )
     }
 
     //endregion RenderTask: Manage Render Tasks
@@ -6399,8 +6661,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         all_access: Boolean? = null,
         built_in: Boolean? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/model_sets/search",
             mapOf(
                 "fields" to fields,
@@ -6427,9 +6689,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun model_set(
         model_set_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_model_set_id = encodeParam(model_set_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/model_sets/$path_model_set_id",
             mapOf("fields" to fields)
         )
@@ -6446,9 +6708,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun update_model_set(
         model_set_id: Long,
         body: WriteModelSet
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_model_set_id = encodeParam(model_set_id)
-        return this.patch<ByteArray>("/model_sets/$path_model_set_id", mapOf(), body)
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/model_sets/$path_model_set_id", mapOf(), body
+        )
     }
 
     /**
@@ -6460,9 +6724,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_model_set(
         model_set_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_model_set_id = encodeParam(model_set_id)
-        return this.delete<ByteArray>("/model_sets/$path_model_set_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/model_sets/$path_model_set_id", mapOf()
+        )
     }
 
     /**
@@ -6474,8 +6740,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_model_sets(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/model_sets",
             mapOf("fields" to fields)
         )
@@ -6490,8 +6756,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_model_set(
         body: WriteModelSet
-    ): SDKResponse {
-        return this.post<ByteArray>("/model_sets", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/model_sets", mapOf(), body
+        )
     }
 
     /**
@@ -6499,8 +6767,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /permissions -> ByteArray
      */
-    fun all_permissions(): SDKResponse {
-        return this.get<ByteArray>("/permissions", mapOf())
+    fun all_permissions(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/permissions", mapOf()
+        )
     }
 
     /**
@@ -6549,8 +6819,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         all_access: Boolean? = null,
         built_in: Boolean? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/permission_sets/search",
             mapOf(
                 "fields" to fields,
@@ -6577,9 +6847,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun permission_set(
         permission_set_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_permission_set_id = encodeParam(permission_set_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/permission_sets/$path_permission_set_id",
             mapOf("fields" to fields)
         )
@@ -6596,9 +6866,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun update_permission_set(
         permission_set_id: Long,
         body: WritePermissionSet
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_permission_set_id = encodeParam(permission_set_id)
-        return this.patch<ByteArray>("/permission_sets/$path_permission_set_id", mapOf(), body)
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/permission_sets/$path_permission_set_id", mapOf(), body
+        )
     }
 
     /**
@@ -6610,9 +6882,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_permission_set(
         permission_set_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_permission_set_id = encodeParam(permission_set_id)
-        return this.delete<ByteArray>("/permission_sets/$path_permission_set_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/permission_sets/$path_permission_set_id", mapOf()
+        )
     }
 
     /**
@@ -6624,8 +6898,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_permission_sets(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/permission_sets",
             mapOf("fields" to fields)
         )
@@ -6640,8 +6914,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_permission_set(
         body: WritePermissionSet
-    ): SDKResponse {
-        return this.post<ByteArray>("/permission_sets", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/permission_sets", mapOf(), body
+        )
     }
 
     /**
@@ -6655,8 +6931,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_roles(
         fields: String? = null,
         ids: DelimArray<Long>? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/roles",
             mapOf(
                 "fields" to fields,
@@ -6674,8 +6950,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_role(
         body: WriteRole
-    ): SDKResponse {
-        return this.post<ByteArray>("/roles", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/roles", mapOf(), body
+        )
     }
 
     /**
@@ -6724,8 +7002,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         name: String? = null,
         built_in: Boolean? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/roles/search",
             mapOf(
                 "fields" to fields,
@@ -6749,9 +7027,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun role(
         role_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_role_id = encodeParam(role_id)
-        return this.get<ByteArray>("/roles/$path_role_id", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/roles/$path_role_id", mapOf()
+        )
     }
 
     /**
@@ -6765,9 +7045,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun update_role(
         role_id: Long,
         body: WriteRole
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_role_id = encodeParam(role_id)
-        return this.patch<ByteArray>("/roles/$path_role_id", mapOf(), body)
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/roles/$path_role_id", mapOf(), body
+        )
     }
 
     /**
@@ -6779,9 +7061,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_role(
         role_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_role_id = encodeParam(role_id)
-        return this.delete<ByteArray>("/roles/$path_role_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/roles/$path_role_id", mapOf()
+        )
     }
 
     /**
@@ -6795,9 +7079,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun role_groups(
         role_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_role_id = encodeParam(role_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/roles/$path_role_id/groups",
             mapOf("fields" to fields)
         )
@@ -6814,9 +7098,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun set_role_groups(
         role_id: Long,
         body: Array<Long>
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_role_id = encodeParam(role_id)
-        return this.put<ByteArray>("/roles/$path_role_id/groups", mapOf(), body)
+        return this.put<ByteArray, com.looker.sdk.Error>(
+            "/roles/$path_role_id/groups", mapOf(), body
+        )
     }
 
     /**
@@ -6832,9 +7118,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         role_id: Long,
         fields: String? = null,
         direct_association_only: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_role_id = encodeParam(role_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/roles/$path_role_id/users",
             mapOf(
                 "fields" to fields,
@@ -6854,9 +7140,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun set_role_users(
         role_id: Long,
         body: Array<Long>
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_role_id = encodeParam(role_id)
-        return this.put<ByteArray>("/roles/$path_role_id/users", mapOf(), body)
+        return this.put<ByteArray, com.looker.sdk.Error>(
+            "/roles/$path_role_id/users", mapOf(), body
+        )
     }
 
     //endregion Role: Manage Roles
@@ -6876,9 +7164,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun scheduled_plans_for_space(
         space_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_space_id = encodeParam(space_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/scheduled_plans/space/$path_space_id",
             mapOf("fields" to fields)
         )
@@ -6897,9 +7185,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun scheduled_plan(
         scheduled_plan_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_scheduled_plan_id = encodeParam(scheduled_plan_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/scheduled_plans/$path_scheduled_plan_id",
             mapOf("fields" to fields)
         )
@@ -6957,9 +7245,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun update_scheduled_plan(
         scheduled_plan_id: Long,
         body: WriteScheduledPlan
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_scheduled_plan_id = encodeParam(scheduled_plan_id)
-        return this.patch<ByteArray>("/scheduled_plans/$path_scheduled_plan_id", mapOf(), body)
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/scheduled_plans/$path_scheduled_plan_id", mapOf(), body
+        )
     }
 
     /**
@@ -6975,9 +7265,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_scheduled_plan(
         scheduled_plan_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_scheduled_plan_id = encodeParam(scheduled_plan_id)
-        return this.delete<ByteArray>("/scheduled_plans/$path_scheduled_plan_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/scheduled_plans/$path_scheduled_plan_id", mapOf()
+        )
     }
 
     /**
@@ -7003,8 +7295,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long? = null,
         fields: String? = null,
         all_users: Boolean? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/scheduled_plans",
             mapOf(
                 "user_id" to user_id,
@@ -7080,8 +7372,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_scheduled_plan(
         body: WriteScheduledPlan
-    ): SDKResponse {
-        return this.post<ByteArray>("/scheduled_plans", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/scheduled_plans", mapOf(), body
+        )
     }
 
     /**
@@ -7129,8 +7423,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun scheduled_plan_run_once(
         body: WriteScheduledPlan
-    ): SDKResponse {
-        return this.post<ByteArray>("/scheduled_plans/run_once", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/scheduled_plans/run_once", mapOf(), body
+        )
     }
 
     /**
@@ -7158,9 +7454,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long? = null,
         fields: String? = null,
         all_users: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_look_id = encodeParam(look_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/scheduled_plans/look/$path_look_id",
             mapOf(
                 "user_id" to user_id,
@@ -7195,9 +7491,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long? = null,
         all_users: Boolean? = null,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_dashboard_id = encodeParam(dashboard_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/scheduled_plans/dashboard/$path_dashboard_id",
             mapOf(
                 "user_id" to user_id,
@@ -7232,9 +7528,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long? = null,
         fields: String? = null,
         all_users: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_lookml_dashboard_id = encodeParam(lookml_dashboard_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/scheduled_plans/lookml_dashboard/$path_lookml_dashboard_id",
             mapOf(
                 "user_id" to user_id,
@@ -7301,9 +7597,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun scheduled_plan_run_once_by_id(
         scheduled_plan_id: Long,
         body: WriteScheduledPlan? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_scheduled_plan_id = encodeParam(scheduled_plan_id)
-        return this.post<ByteArray>("/scheduled_plans/$path_scheduled_plan_id/run_once", mapOf(), body)
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/scheduled_plans/$path_scheduled_plan_id/run_once", mapOf(), body
+        )
     }
 
     //endregion ScheduledPlan: Manage Scheduled Plans
@@ -7317,8 +7615,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /session -> ByteArray
      */
-    fun session(): SDKResponse {
-        return this.get<ByteArray>("/session", mapOf())
+    fun session(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/session", mapOf()
+        )
     }
 
     /**
@@ -7349,8 +7649,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun update_session(
         body: WriteApiSession
-    ): SDKResponse {
-        return this.patch<ByteArray>("/session", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/session", mapOf(), body
+        )
     }
 
     //endregion Session: Session Information
@@ -7372,8 +7674,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun all_themes(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/themes",
             mapOf("fields" to fields)
         )
@@ -7402,8 +7704,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun create_theme(
         body: WriteTheme
-    ): SDKResponse {
-        return this.post<ByteArray>("/themes", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/themes", mapOf(), body
+        )
     }
 
     /**
@@ -7468,8 +7772,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         sorts: String? = null,
         fields: String? = null,
         filter_or: Boolean? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/themes/search",
             mapOf(
                 "id" to id,
@@ -7500,8 +7804,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun default_theme(
         ts: Date? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/themes/default",
             mapOf("ts" to ts)
         )
@@ -7526,8 +7830,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun set_default_theme(
         name: String
-    ): SDKResponse {
-        return this.put<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.put<ByteArray, com.looker.sdk.Error>(
             "/themes/default",
             mapOf("name" to name)
         )
@@ -7554,8 +7858,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         name: String? = null,
         ts: Date? = null,
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/themes/active",
             mapOf(
                 "name" to name,
@@ -7581,8 +7885,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun theme_or_default(
         name: String,
         ts: Date? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/themes/theme_or_default",
             mapOf(
                 "name" to name,
@@ -7606,8 +7910,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun validate_theme(
         body: WriteTheme
-    ): SDKResponse {
-        return this.post<ByteArray>("/themes/validate", mapOf(), body)
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/themes/validate", mapOf(), body
+        )
     }
 
     /**
@@ -7625,9 +7931,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun theme(
         theme_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_theme_id = encodeParam(theme_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/themes/$path_theme_id",
             mapOf("fields" to fields)
         )
@@ -7646,9 +7952,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun update_theme(
         theme_id: Long,
         body: WriteTheme
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_theme_id = encodeParam(theme_id)
-        return this.patch<ByteArray>("/themes/$path_theme_id", mapOf(), body)
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/themes/$path_theme_id", mapOf(), body
+        )
     }
 
     /**
@@ -7668,9 +7976,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_theme(
         theme_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_theme_id = encodeParam(theme_id)
-        return this.delete<ByteArray>("/themes/$path_theme_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/themes/$path_theme_id", mapOf()
+        )
     }
 
     //endregion Theme: Manage Themes
@@ -7686,8 +7996,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     @JvmOverloads fun me(
         fields: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/user",
             mapOf("fields" to fields)
         )
@@ -7710,8 +8020,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         per_page: Long? = null,
         sorts: String? = null,
         ids: DelimArray<Long>? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/users",
             mapOf(
                 "fields" to fields,
@@ -7734,8 +8044,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_user(
         body: WriteUser? = null,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/users",
             mapOf("fields" to fields), body
         )
@@ -7803,8 +8113,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         filter_or: Boolean? = null,
         content_metadata_id: String? = null,
         group_id: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/users/search",
             mapOf(
                 "fields" to fields,
@@ -7858,9 +8168,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         verified_looker_employee: Boolean? = null,
         email: String? = null,
         is_disabled: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_pattern = encodeParam(pattern)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/users/search/names/$path_pattern",
             mapOf(
                 "fields" to fields,
@@ -7892,9 +8202,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun user(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id",
             mapOf("fields" to fields)
         )
@@ -7913,9 +8223,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         body: WriteUser,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.patch<ByteArray>(
+        return this.patch<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id",
             mapOf("fields" to fields), body
         )
@@ -7932,9 +8242,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_user(
         user_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.delete<ByteArray>("/users/$path_user_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/users/$path_user_id", mapOf()
+        )
     }
 
     /**
@@ -7977,10 +8289,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         credential_type: String,
         credential_id: String,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_credential_type = encodeParam(credential_type)
         val path_credential_id = encodeParam(credential_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/users/credential/$path_credential_type/$path_credential_id",
             mapOf("fields" to fields)
         )
@@ -7997,9 +8309,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun user_credentials_email(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_email",
             mapOf("fields" to fields)
         )
@@ -8018,9 +8330,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         body: WriteCredentialsEmail,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.post<ByteArray>(
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_email",
             mapOf("fields" to fields), body
         )
@@ -8039,9 +8351,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         body: WriteCredentialsEmail,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.patch<ByteArray>(
+        return this.patch<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_email",
             mapOf("fields" to fields), body
         )
@@ -8056,9 +8368,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_user_credentials_email(
         user_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.delete<ByteArray>("/users/$path_user_id/credentials_email", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/users/$path_user_id/credentials_email", mapOf()
+        )
     }
 
     /**
@@ -8072,9 +8386,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun user_credentials_totp(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_totp",
             mapOf("fields" to fields)
         )
@@ -8093,9 +8407,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         body: CredentialsTotp? = null,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.post<ByteArray>(
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_totp",
             mapOf("fields" to fields), body
         )
@@ -8110,9 +8424,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_user_credentials_totp(
         user_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.delete<ByteArray>("/users/$path_user_id/credentials_totp", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/users/$path_user_id/credentials_totp", mapOf()
+        )
     }
 
     /**
@@ -8126,9 +8442,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun user_credentials_ldap(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_ldap",
             mapOf("fields" to fields)
         )
@@ -8143,9 +8459,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_user_credentials_ldap(
         user_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.delete<ByteArray>("/users/$path_user_id/credentials_ldap", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/users/$path_user_id/credentials_ldap", mapOf()
+        )
     }
 
     /**
@@ -8159,9 +8477,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun user_credentials_google(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_google",
             mapOf("fields" to fields)
         )
@@ -8176,9 +8494,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_user_credentials_google(
         user_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.delete<ByteArray>("/users/$path_user_id/credentials_google", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/users/$path_user_id/credentials_google", mapOf()
+        )
     }
 
     /**
@@ -8192,9 +8512,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun user_credentials_saml(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_saml",
             mapOf("fields" to fields)
         )
@@ -8209,9 +8529,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_user_credentials_saml(
         user_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.delete<ByteArray>("/users/$path_user_id/credentials_saml", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/users/$path_user_id/credentials_saml", mapOf()
+        )
     }
 
     /**
@@ -8225,9 +8547,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun user_credentials_oidc(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_oidc",
             mapOf("fields" to fields)
         )
@@ -8242,9 +8564,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_user_credentials_oidc(
         user_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.delete<ByteArray>("/users/$path_user_id/credentials_oidc", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/users/$path_user_id/credentials_oidc", mapOf()
+        )
     }
 
     /**
@@ -8260,10 +8584,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         credentials_api3_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
         val path_credentials_api3_id = encodeParam(credentials_api3_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_api3/$path_credentials_api3_id",
             mapOf("fields" to fields)
         )
@@ -8280,10 +8604,12 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun delete_user_credentials_api3(
         user_id: Long,
         credentials_api3_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
         val path_credentials_api3_id = encodeParam(credentials_api3_id)
-        return this.delete<ByteArray>("/users/$path_user_id/credentials_api3/$path_credentials_api3_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/users/$path_user_id/credentials_api3/$path_credentials_api3_id", mapOf()
+        )
     }
 
     /**
@@ -8297,9 +8623,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_user_credentials_api3s(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_api3",
             mapOf("fields" to fields)
         )
@@ -8318,9 +8644,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         body: CredentialsApi3? = null,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.post<ByteArray>(
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_api3",
             mapOf("fields" to fields), body
         )
@@ -8339,10 +8665,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         credentials_embed_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
         val path_credentials_embed_id = encodeParam(credentials_embed_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_embed/$path_credentials_embed_id",
             mapOf("fields" to fields)
         )
@@ -8359,10 +8685,12 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun delete_user_credentials_embed(
         user_id: Long,
         credentials_embed_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
         val path_credentials_embed_id = encodeParam(credentials_embed_id)
-        return this.delete<ByteArray>("/users/$path_user_id/credentials_embed/$path_credentials_embed_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/users/$path_user_id/credentials_embed/$path_credentials_embed_id", mapOf()
+        )
     }
 
     /**
@@ -8376,9 +8704,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_user_credentials_embeds(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_embed",
             mapOf("fields" to fields)
         )
@@ -8395,9 +8723,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun user_credentials_looker_openid(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_looker_openid",
             mapOf("fields" to fields)
         )
@@ -8412,9 +8740,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_user_credentials_looker_openid(
         user_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.delete<ByteArray>("/users/$path_user_id/credentials_looker_openid", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/users/$path_user_id/credentials_looker_openid", mapOf()
+        )
     }
 
     /**
@@ -8430,10 +8760,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         session_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
         val path_session_id = encodeParam(session_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/sessions/$path_session_id",
             mapOf("fields" to fields)
         )
@@ -8450,10 +8780,12 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun delete_user_session(
         user_id: Long,
         session_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
         val path_session_id = encodeParam(session_id)
-        return this.delete<ByteArray>("/users/$path_user_id/sessions/$path_session_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/users/$path_user_id/sessions/$path_session_id", mapOf()
+        )
     }
 
     /**
@@ -8467,9 +8799,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_user_sessions(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/sessions",
             mapOf("fields" to fields)
         )
@@ -8496,9 +8828,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         expires: Boolean? = null,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.post<ByteArray>(
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_email/password_reset",
             mapOf(
                 "expires" to expires,
@@ -8520,9 +8852,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         fields: String? = null,
         direct_association_only: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/roles",
             mapOf(
                 "fields" to fields,
@@ -8544,9 +8876,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         body: Array<Long>,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.put<ByteArray>(
+        return this.put<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/roles",
             mapOf("fields" to fields), body
         )
@@ -8584,9 +8916,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         user_attribute_ids: DelimArray<Long>? = null,
         all_values: Boolean? = null,
         include_unset: Boolean? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/attribute_values",
             mapOf(
                 "fields" to fields,
@@ -8612,10 +8944,12 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         user_id: Long,
         user_attribute_id: Long,
         body: WriteUserAttributeWithValue
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
         val path_user_attribute_id = encodeParam(user_attribute_id)
-        return this.patch<ByteArray>("/users/$path_user_id/attribute_values/$path_user_attribute_id", mapOf(), body)
+        return this.patch<ByteArray, com.looker.sdk.Error>(
+            "/users/$path_user_id/attribute_values/$path_user_attribute_id", mapOf(), body
+        )
     }
 
     /**
@@ -8634,10 +8968,12 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun delete_user_attribute_user_value(
         user_id: Long,
         user_attribute_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
         val path_user_attribute_id = encodeParam(user_attribute_id)
-        return this.delete<ByteArray>("/users/$path_user_id/attribute_values/$path_user_attribute_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/users/$path_user_id/attribute_values/$path_user_attribute_id", mapOf()
+        )
     }
 
     /**
@@ -8657,9 +8993,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun send_user_credentials_email_password_reset(
         user_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_id = encodeParam(user_id)
-        return this.post<ByteArray>(
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/users/$path_user_id/credentials_email/send_password_reset",
             mapOf("fields" to fields)
         )
@@ -8680,8 +9016,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_user_attributes(
         fields: String? = null,
         sorts: String? = null
-    ): SDKResponse {
-        return this.get<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/user_attributes",
             mapOf(
                 "fields" to fields,
@@ -8710,8 +9046,8 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun create_user_attribute(
         body: WriteUserAttribute,
         fields: String? = null
-    ): SDKResponse {
-        return this.post<ByteArray>(
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.post<ByteArray, com.looker.sdk.Error>(
             "/user_attributes",
             mapOf("fields" to fields), body
         )
@@ -8728,9 +9064,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun user_attribute(
         user_attribute_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_attribute_id = encodeParam(user_attribute_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/user_attributes/$path_user_attribute_id",
             mapOf("fields" to fields)
         )
@@ -8749,9 +9085,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
         user_attribute_id: Long,
         body: WriteUserAttribute,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_attribute_id = encodeParam(user_attribute_id)
-        return this.patch<ByteArray>(
+        return this.patch<ByteArray, com.looker.sdk.Error>(
             "/user_attributes/$path_user_attribute_id",
             mapOf("fields" to fields), body
         )
@@ -8766,9 +9102,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun delete_user_attribute(
         user_attribute_id: Long
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_attribute_id = encodeParam(user_attribute_id)
-        return this.delete<ByteArray>("/user_attributes/$path_user_attribute_id", mapOf())
+        return this.delete<ByteArray, com.looker.sdk.Error>(
+            "/user_attributes/$path_user_attribute_id", mapOf()
+        )
     }
 
     /**
@@ -8788,9 +9126,9 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     @JvmOverloads fun all_user_attribute_group_values(
         user_attribute_id: Long,
         fields: String? = null
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_attribute_id = encodeParam(user_attribute_id)
-        return this.get<ByteArray>(
+        return this.get<ByteArray, com.looker.sdk.Error>(
             "/user_attributes/$path_user_attribute_id/group_values",
             mapOf("fields" to fields)
         )
@@ -8826,9 +9164,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
     fun set_user_attribute_group_values(
         user_attribute_id: Long,
         body: Array<UserAttributeGroupValue>
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_user_attribute_id = encodeParam(user_attribute_id)
-        return this.post<ByteArray>("/user_attributes/$path_user_attribute_id/group_values", mapOf(), body)
+        return this.post<ByteArray, com.looker.sdk.Error>(
+            "/user_attributes/$path_user_attribute_id/group_values", mapOf(), body
+        )
     }
 
     //endregion UserAttribute: Manage User Attributes
@@ -8842,8 +9182,10 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      *
      * GET /workspaces -> ByteArray
      */
-    fun all_workspaces(): SDKResponse {
-        return this.get<ByteArray>("/workspaces", mapOf())
+    fun all_workspaces(): SdkResult<ByteArray, com.looker.sdk.Error> {
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/workspaces", mapOf()
+        )
     }
 
     /**
@@ -8883,9 +9225,11 @@ class LookerSDKStream(authSession: AuthSession) : APIMethods(authSession) {
      */
     fun workspace(
         workspace_id: String
-    ): SDKResponse {
+    ): SdkResult<ByteArray, com.looker.sdk.Error> {
         val path_workspace_id = encodeParam(workspace_id)
-        return this.get<ByteArray>("/workspaces/$path_workspace_id", mapOf())
+        return this.get<ByteArray, com.looker.sdk.Error>(
+            "/workspaces/$path_workspace_id", mapOf()
+        )
     }
 
     //endregion Workspace: Manage Workspaces

--- a/packages/sdk-codegen/src/kotlin.gen.spec.ts
+++ b/packages/sdk-codegen/src/kotlin.gen.spec.ts
@@ -59,29 +59,25 @@ describe('Kotlin generator', () => {
  * Type of permission: "view" or "edit" Valid values are: "view", "edit".
  */
 enum class PermissionType : Serializable {
-  view,
-  edit
+    view,
+    edit
 }`
       expect(actual).toEqual(expected)
     })
     it('special needs', () => {
       const type = apiTestModel.types.HyphenType
       const actual = gen.declareType('', type)
-      const expected = `data class HyphenType (
-  /**
-   * A normal variable name (read-only)
-   */
-  var project_name: String? = null,
-  /**
-   * A hyphenated property name (read-only)
-   */
-  @JsonProperty("project-digest")
-  var project_digest: String? = null,
-  /**
-   * A spaced out property name (read-only)
-   */
-  @JsonProperty("computation time")
-  var computation_time: Float? = null
+      const expected = `/**
+ * @property project_name A normal variable name (read-only)
+ * @property project_digest A hyphenated property name (read-only)
+ * @property computation_time A spaced out property name (read-only)
+ */
+data class HyphenType (
+    var project_name: String? = null,
+    @JsonProperty("project-digest")
+    var project_digest: String? = null,
+    @JsonProperty("computation time")
+    var computation_time: Float? = null
 ) : Serializable`
       expect(actual).toEqual(expected)
     })


### PR DESCRIPTION
The goals of this PR are twofold:
- Improve the handling of errors
- Improve the typing of responses

This mostly revoles around replacing SDKResponse with
SdkResult<TSuccess, TFailure>.  This allows us to track the type
information with the SdkResult and easily get out the expected type on
success or failure.

For now, all errors are expected to be of type com.looker.sdk.Error,
even though we do have some methods which return more precise errors.
If for some reason you need to escape the default typing, such as to get
a finer Error type, you can use `bodyAs<T>()` on both SuccessResponse
and FailureResponse.

For clients, this commit keeps the concept of the `ok()` method that
returns the success type or throws an error.  This moved from being a
method on the sdk itself to an extension function on the SdkResult,
so you can do `val foo: Foo = sdk.get_foo().ok()`.  If you want to do
more precise handling, SdkResult is a `sealed` class, so you can use a
`when` statement to check for the various type (SuccessResonse,
FailureResponse, Error) and get smart casting to access the appropriate
types and Response metatdata.