### PR TITLE
Python RTL transport interface headers cleanup

### DIFF
--- a/examples/python/Pipfile
+++ b/examples/python/Pipfile
@@ -12,7 +12,7 @@ verify_ssl = true
 
 [packages]
 looker-sdk = "*"
-#looker-sdk = {version="0.1.3b19", index="testpypi"}
+#looker-sdk = {version="0.1.3b21", index="testpypi"}
 mypy = "*"
 black = "*"
 flake8 = "*"

--- a/examples/python/content_validator_comparison.py
+++ b/examples/python/content_validator_comparison.py
@@ -1,12 +1,11 @@
 import looker_sdk
 from looker_sdk import models
-from looker_sdk.rtl import transport
 import configparser
 import hashlib
 import csv
 
 config_file = "../../looker.ini"
-sdk = looker_sdk.init31()
+sdk = looker_sdk.init31(config_file)
 
 
 def main():
@@ -53,7 +52,7 @@ def get_space_data():
 def get_broken_content():
     """Collect broken content"""
     broken_content = sdk.content_validation(
-        transport_options=transport.TransportSettings(timeout=600)
+        transport_options={"timeout": 600}
     ).content_with_errors
     return broken_content
 

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.1.3b21]
+
+### Fixed
+
+- [Pass headers per sdk call](https://github.com/looker-open-source/sdk-codegen/issues/387)
+
+
 ## [0.1.3b20]
 
 ### Added

--- a/python/looker_sdk/rtl/auth_session.py
+++ b/python/looker_sdk/rtl/auth_session.py
@@ -150,7 +150,9 @@ class AuthSession:
                 transport.HttpMethod.POST,
                 f"{self.settings.base_url}/api/{self.version}/login",
                 body=serialized,
-                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                transport_options={
+                    "headers": {"Content-Type": "application/x-www-form-urlencoded"}
+                },
             )
         )
 

--- a/python/looker_sdk/rtl/requests_transport.py
+++ b/python/looker_sdk/rtl/requests_transport.py
@@ -58,17 +58,18 @@ class RequestsTransport(transport.Transport):
         query_params: Optional[MutableMapping[str, str]] = None,
         body: Optional[bytes] = None,
         authenticator: Optional[Callable[[], Dict[str, str]]] = None,
-        headers: Optional[MutableMapping[str, str]] = None,
-        transport_options: Optional[transport.PTransportSettings] = None,
+        transport_options: Optional[transport.TransportOptions] = None,
     ) -> transport.Response:
 
-        if headers is None:
-            headers = {}
+        headers: Dict[str, str] = {}
+        timeout = self.settings.timeout
         if authenticator:
             headers.update(authenticator())
-        timeout = self.settings.timeout
         if transport_options:
-            timeout = transport_options.timeout
+            if transport_options.get("headers"):
+                headers.update(transport_options["headers"])
+            if transport_options.get("timeout"):
+                timeout = transport_options["timeout"]
         self.logger.info("%s(%s)", method.name, path)
         try:
             resp = self.session.request(

--- a/python/looker_sdk/rtl/transport.py
+++ b/python/looker_sdk/rtl/transport.py
@@ -33,9 +33,9 @@ import attr
 from looker_sdk.rtl import constants
 
 if sys.version_info >= (3, 8):
-    from typing import Protocol
+    from typing import Protocol, TypedDict
 else:
-    from typing_extensions import Protocol
+    from typing_extensions import Protocol, TypedDict
 
 
 AGENT_PREFIX = "PY SDK"
@@ -64,6 +64,17 @@ class PTransportSettings(Protocol):
 
     def is_configured(self) -> bool:
         return bool(self.base_url)
+
+
+class TransportOptions(TypedDict, total=False):
+    """Dictionary of available per-request transport options
+
+    # make me() call with 5 minute timeout and send a special header
+    e.g. sdk.me(transport_options={"timeout": 60 * 5, headers: {"foo": "bar"}})
+    """
+
+    timeout: int
+    headers: Optional[MutableMapping[str, str]]
 
 
 TAuthenticator = Optional[Callable[[], Dict[str, str]]]
@@ -125,8 +136,7 @@ class Transport(abc.ABC):
         query_params: Optional[MutableMapping[str, str]] = None,
         body: Optional[bytes] = None,
         authenticator: TAuthenticator = None,
-        headers: Optional[MutableMapping[str, str]] = None,
-        transport_options: Optional[PTransportSettings] = None,
+        transport_options: Optional[TransportOptions] = None,
     ) -> Response:
         """Send API request.
         """

--- a/python/setup.py
+++ b/python/setup.py
@@ -5,7 +5,7 @@
 from setuptools import setup, find_packages  # noqa: H301
 
 NAME = "looker_sdk"
-VERSION = "0.1.3b20"
+VERSION = "0.1.3b21"
 REQUIRES = [
     "requests >= 2.22",
     # Python 3.6

--- a/python/tests/rtl/test_auth_session.py
+++ b/python/tests/rtl/test_auth_session.py
@@ -86,7 +86,7 @@ class MockTransport(transport.Transport):
         query_params=None,
         body=None,
         authenticator=None,
-        headers=None,
+        transport_options=None,
     ):
         if authenticator:
             authenticator()
@@ -97,7 +97,7 @@ class MockTransport(transport.Transport):
                     expected_header = {
                         "Content-Type": "application/x-www-form-urlencoded"
                     }
-                    if headers != expected_header:
+                    if transport_options["headers"] != expected_header:
                         raise TypeError(f"Must send {expected_header}")
                 else:
                     token = "UserAccessToken"


### PR DESCRIPTION
Moved headers down into the transport_options bag.
Called out the explicit "per-request" transport options shape.
Fixed example that broke a while ago :-()

closes #387 