### PR TITLE
Python separate bin/{smoke,unit}

### DIFF
--- a/bin/smoke
+++ b/bin/smoke
@@ -31,7 +31,7 @@ if [[ $tests == *python* ]]
 then
   cd python || exit
   echo "Smoking Python SDK ..."
-  pipenv run tox
+  PIPENV_DOTENV_LOCATION=tests/integration/.env pipenv run tox
   cd ..
 fi
 

--- a/bin/unit_test
+++ b/bin/unit_test
@@ -31,8 +31,8 @@ fi
 if [[ $tests == *python* ]]
 then
   cd python || exit
-  echo "TODO: Unit testing Python SDK ..."
-  #pipenv run tox
+  echo "Unit testing Python SDK ..."
+  PIPENV_DOTENV_LOCATION=tests/rtl/.env pipenv run tox
   cd ..
 fi
 

--- a/python/tests/integration/.env
+++ b/python/tests/integration/.env
@@ -1,0 +1,1 @@
+TOX_SKIP_ENV=.*-unit

--- a/python/tests/rtl/.env
+++ b/python/tests/rtl/.env
@@ -1,0 +1,1 @@
+TOX_SKIP_ENV=.*-integration

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -4,15 +4,22 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py36, py37, py38, py39
-
+envlist = {py36,py37,py38,py39}-{unit,integration}
 
 [testenv]
 deps =
-    pytest-mock
-    pillow
     pytest
-    pyyaml
     pytest-cov
+    pytest-mock
+    pyyaml
+
+[testenv:unit]
 commands =
-    pytest --junitxml=../results/smokepython.{envname}.xml tests/
+    pytest --junitxml={env:TOX_JUNIT_OUTPUT_DIR:../results/}/{env:TOX_JUNIT_OUTPUT_NAME:python.{envname}.xml} tests/rtl/
+
+[testenv:integration]
+deps =
+    pillow
+    {[testenv]deps}
+commands =
+    pytest --junitxml={env:TOX_JUNIT_OUTPUT_DIR:../results/}/{env:TOX_JUNIT_OUTPUT_NAME:python.{envname}.xml} tests/integration/


### PR DESCRIPTION
CI will actually call "tox -e unit" and "tox -e integration" per the
[github actions docs](https://docs.github.com/en/free-pro-team@latest/actions/guides/building-and-testing-python#running-tests-with-tox)
using the python-versions matrix rather than relying on tox native
multi-python version testing. CI will set TOX_JUNIT_OUTPUT_DIR and
TOX_JUNIT_OUTPUT_NAME to approriate values for CI artifact uploading

Local tox usage will execute from from bin/smoke and bin/unit_test
which will rely on the generative envlist for a matrix of version/type
testing