### PR TITLE
Getting roles for each user was very slow

### DIFF
--- a/packages/hackathon/README.md
+++ b/packages/hackathon/README.md
@@ -33,7 +33,7 @@ application: hackathon_app {
     use_form_submit: yes
     use_embeds: no
     external_api_urls: ["http://localhost:8081/*", "https://sheets.googleapis.com/*"]
-    core_api_methods: ["me", "user_roles", "all_user_attributes", "delete_user_attribute", "create_user_attribute", "search_groups", "search_users"]
+    core_api_methods: ["me", "all_roles", "all_user_attributes", "delete_user_attribute", "create_user_attribute", "search_groups", "search_users", "user_roles", "role_users"]
     scoped_user_attributes: ["sheet_id", "token_server_url"]
   }
 }

--- a/packages/hackathon/src/data/sheets_client.ts
+++ b/packages/hackathon/src/data/sheets_client.ts
@@ -254,22 +254,15 @@ class SheetsClient {
       const lookerSdk = getCore40SDK()
       const hacker = new Hacker(lookerSdk)
       await hacker.getMe()
-      let me
       try {
         const data = await this.getSheetData()
         await this.loadHackers(data)
-        // TODO revisit this with JK
-        me = this.hackers?.rows.find(
-          (maybeMe) => maybeMe.user.id === hacker.user.id
-        )
       } catch (error) {
         console.warn(
           'Error loading sheets data. Has hackathon application been configured?'
         )
       }
-      this.hacker = me
-        ? this.decorateHacker(me.toObject(), me)
-        : this.decorateHacker(hacker.toObject(), hacker)
+      this.hacker = this.decorateHacker(hacker.toObject(), hacker)
     }
     return this.hacker
   }

--- a/packages/hackathon/src/models/Hacker.ts
+++ b/packages/hackathon/src/models/Hacker.ts
@@ -274,12 +274,15 @@ export class Hackers extends TypedRows<Hacker> {
     for (const hacker of this.rows) {
       if (admins.includes(hacker.id)) {
         hacker.roles.add('admin')
+        hacker.canAdmin = true
       }
       if (staff.includes(hacker.id)) {
         hacker.roles.add('staff')
+        hacker.canStaff = true
       }
       if (judges.includes(hacker.id)) {
         hacker.roles.add('judge')
+        hacker.canJudge = true
       }
       hacker.findRegistration(hackathon, regs)
     }

--- a/packages/hackathon/src/models/Hacker.ts
+++ b/packages/hackathon/src/models/Hacker.ts
@@ -270,11 +270,60 @@ export class Hackers extends TypedRows<Hacker> {
     const regs = data.registrations.rows.filter(
       (r) => r.hackathon_id === hackathon._id
     )
+    const { admins, staff, judges } = await this.getSpecialUsers()
     for (const hacker of this.rows) {
-      await hacker.assignRoles()
+      if (admins.includes(hacker.id)) {
+        hacker.roles.add('admin')
+      }
+      if (staff.includes(hacker.id)) {
+        hacker.roles.add('staff')
+      }
+      if (judges.includes(hacker.id)) {
+        hacker.roles.add('judge')
+      }
       hacker.findRegistration(hackathon, regs)
     }
     this.loadGroups()
     return this
+  }
+
+  private async getSpecialUsers() {
+    let judges: string[] = []
+    let staff: string[] = []
+    let admins: string[] = []
+    try {
+      const roles = await this.sdk.ok(this.sdk.all_roles({ fields: 'name,id' }))
+      const adminRole = roles.find((r: IRole) => r.name?.match(/admin/i))
+      if (adminRole) {
+        const users = await this.sdk.ok(
+          this.sdk.role_users({ fields: 'id', role_id: adminRole.id! })
+        )
+        admins = users.map((user) => user.id?.toString() || 'no id')
+      }
+      const judgeRole = roles.find((r: IRole) =>
+        r.name?.match(/hackathon judge/i)
+      )
+      if (judgeRole) {
+        const users = await this.sdk.ok(
+          this.sdk.role_users({ fields: 'id', role_id: judgeRole.id! })
+        )
+        judges = users.map((user) => user.id?.toString() || 'no id')
+      }
+      const staffRole = roles.find((r: IRole) =>
+        r.name?.match(/hackathon staff/i)
+      )
+      if (staffRole) {
+        const users = await this.sdk.ok(
+          this.sdk.role_users({ fields: 'id', role_id: staffRole.id! })
+        )
+        staff = users.map((user) => user.id?.toString() || 'no id')
+      }
+    } catch (err) {
+      // Likely caused by permission access failure for regular user who
+      // does not have access to all roles or role users apis.
+      // It's okay to eat as regular user does not need information about
+      // other users.
+    }
+    return { admins, judges, staff }
   }
 }


### PR DESCRIPTION
This fix falls back to using all roles for all users. If all roles fails, thats okay as the kind of user that does not have access to all roles will not care about the roles of other users.