### PR TITLE
Python CI workflow

### DIFF
--- a/.github/scripts/wait_for_looker.py
+++ b/.github/scripts/wait_for_looker.py
@@ -1,0 +1,34 @@
+import ssl
+import sys
+import time
+import urllib.request
+
+# turn off ssl checking
+ctx = ssl.create_default_context()
+ctx.check_hostname = False
+ctx.verify_mode = ssl.CERT_NONE
+
+MAX_RETRIES = 160
+ATTEMPTS = 1
+while MAX_RETRIES:
+    retry_msg = f"after {ATTEMPTS} attempts: {MAX_RETRIES} retries remaining."
+    try:
+        status = urllib.request.urlopen(
+            "https://localhost:10000/login", context=ctx
+        ).getcode()
+    except urllib.error.URLError:
+        msg = f"Looker server connection rejected {retry_msg}"
+    else:
+        if status == 200:
+            print(f"Looker ready after {ATTEMPTS} attempts.")
+            sys.exit(0)
+        else:
+            msg = f"Received status({status}) from Looker {retry_msg}"
+
+    ATTEMPTS += 1
+    MAX_RETRIES -= 1
+    time.sleep(2)
+    print(msg)
+
+print(f"Looker took too long to start {retry_msg}")
+sys.exit(1)

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,0 +1,181 @@
+name: Python CI
+on:
+  pull_request_target:
+    paths:
+      - python/**
+      - packages/sdk-codegen*/**
+
+  push:
+    branches:
+      - $default-branch
+    paths:
+      - python/**
+      - packages/sdk-codegen*/**
+
+env:
+  LOOKERSDK_BASE_URL: https://localhost:20000
+  LOOKERSDK_VERIFY_SSL: false
+  TOX_JUNIT_OUTPUT_DIR: results
+
+defaults:
+  run:
+    shell: bash
+    working-directory: python/
+
+jobs:
+  unit:
+    name: Unit - ${{ matrix.os }} / py${{ matrix.python-version }}
+    env:
+      TOX_JUNIT_OUTPUT_NAME: ${{ matrix.os }}.py${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      matrix:
+        os:
+          - ubuntu
+          - macos
+          - windows
+        python-version:
+          - '3.6'
+          - '3.7'
+          - '3.8'
+          - '3.9'
+
+    steps:
+      - name: Repo Checkout
+        uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Tox and any other packages
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+      - name: Set LOOKERSDK_CLIENT_{ID,SECRET}
+        run: |
+          echo "LOOKERSDK_CLIENT_ID=${{ secrets[format('LOOKERSDK_CLIENT_ID__{0}', matrix.looker)]}}" >> $GITHUB_ENV
+          echo "LOOKERSDK_CLIENT_SECRET=${{ secrets[format('LOOKERSDK_CLIENT_SECRET__{0}', matrix.looker)]}}" >> $GITHUB_ENV
+      - name: Run Unit Tests
+        run: tox -e unit
+      - name: Upload pytest test results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: python-test-results
+          path: python/results/
+
+  integration:
+    needs: unit
+    name: Integration - ${{ matrix.os }} / Looker.${{ matrix.looker }}
+    env:
+      TOX_JUNIT_OUTPUT_NAME: ${{ matrix.os }}.Looker-${{ matrix.looker }}
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      matrix:
+        os:
+          - ubuntu
+        looker:
+          - '7_18'
+          - '7_20'
+          # TODO uncomment `include:` when either macos or windows works to satisfaction.
+          #include:
+          # TODO: macos matrix leg is functional but it takes ~20 minutes (compared
+          # to ~4 minutes for ubuntu) because docker install takes ~5 minutes
+          # and docker pull takes ~10 minutes. We can probably figure out how to
+          # cache the docker install but hopefully github will soon have docker
+          # available pre-installed on macos so not worth the effort now.
+          # Regarding docker pull ... it would be nice if there's a way to cache
+          # only some layers of the image on the runner but we don't want to cache
+          # the final layer(s) with Looker IP. This would speed up docker pull on
+          # all OSs.
+          #- os: macos
+          #  python-version: '3.x'
+          #  looker: '7_20'
+          # TODO: currently can't run linux containers on windows.
+          # Pending new windows server version
+          # https://github.com/actions/virtual-environments/issues/1143#issuecomment-698797524
+          #- os: windows
+          #  python-version: '3.x'
+          #  looker: '7_20'
+    steps:
+      - name: Repo Checkout
+        uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+      - name: Install Tox and any other packages
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+      - name: Set LOOKERSDK_CLIENT_{ID,SECRET}
+        run: |
+          echo "LOOKERSDK_CLIENT_ID=${{ secrets[format('LOOKERSDK_CLIENT_ID__{0}', matrix.looker)]}}" >> $GITHUB_ENV
+          echo "LOOKERSDK_CLIENT_SECRET=${{ secrets[format('LOOKERSDK_CLIENT_SECRET__{0}', matrix.looker)]}}" >> $GITHUB_ENV
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v0.2.0
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_AR_READER_SA_KEY }}
+          export_default_credentials: true
+      - name: Install docker on macos
+        if: ${{ matrix.os == 'macos' }}
+        uses: docker-practice/actions-setup-docker@v1
+        with:
+          docker_channel: stable
+          docker_buildx: false
+          docker_cli_experimental: disabled
+      - name: Bump docker for mac memory
+        if: ${{ matrix.os == 'macos' }}
+        run: |
+          osascript -e 'quit app "Docker"'
+          sed -i'.original' -e's/  "memoryMiB" : 2048/  "memoryMiB" : 8192/' ~/Library/Group\ Containers/group.com.docker/settings.json
+          open -g /Applications/Docker.app
+          # re-run docker startup logic from docker-practice/actions-setup-docker action
+          sleep 60
+          i=0
+          while ! docker system info &>/dev/null; do
+          (( i++ == 0 )) && printf %s '-- Waiting for Docker to finish starting up...' || printf '.'
+          sleep 1
+          done
+          (( i )) && printf '\n'
+          echo "-- Docker is ready."
+      - name: Authenticate Artifact Repository
+        run: gcloud auth configure-docker us-west1-docker.pkg.dev --quiet
+      - name: Pull and run Looker docker image
+        # TODO: can we cache some layers of the image for faster download?
+        # we probably don't want to cache the final image for IP security...
+        run: |
+          docker pull --quiet us-west1-docker.pkg.dev/cloud-looker-sdk-codegen-cicd/looker/${{ matrix.looker }}
+          # set $LOOKER_OPTS to --no-ssl if we want to turn off ssl
+          docker run --name looker-sdk-codegen-ci -d -p 10000:9999 -p 20000:19999 us-west1-docker.pkg.dev/cloud-looker-sdk-codegen-cicd/looker/${{ matrix.looker }}
+          docker logs -f looker-sdk-codegen-ci --until=30s &
+          python ${{ github.workspace }}/.github/scripts/wait_for_looker.py
+      - name: Run Integration Tests
+        run: tox -e integration
+      - name: Upload pytest test results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: python-test-results
+          path: python/results/
+
+  publish-test-results:
+    name: "Publish Unit Tests Results"
+    needs: [unit, integration]
+    if: success() || failure()
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: artifacts
+
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1.6
+        with:
+          check_name: Test Results
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          report_individual_runs: true
+          files: 'artifacts/python-test-results/*.xml'

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -17,11 +17,11 @@ deps =
 
 [testenv:unit]
 commands =
-    pytest --junitxml={env:TOX_JUNIT_OUTPUT_DIR:../results/}/{env:TOX_JUNIT_OUTPUT_NAME:python.{envname}.xml} tests/rtl/
+    pytest --junitxml={env:TOX_JUNIT_OUTPUT_DIR:../results/}/{env:TOX_JUNIT_OUTPUT_NAME:python}-{envname}.xml tests/rtl/
 
 [testenv:integration]
 deps =
     pillow
     {[testenv]deps}
 commands =
-    pytest --junitxml={env:TOX_JUNIT_OUTPUT_DIR:../results/}/{env:TOX_JUNIT_OUTPUT_NAME:python.{envname}.xml} tests/integration/
+    pytest --junitxml={env:TOX_JUNIT_OUTPUT_DIR:../results/}/{env:TOX_JUNIT_OUTPUT_NAME:python}-{envname}.xml tests/integration/


### PR DESCRIPTION
Run unit and integration tests using Github Actions.

Some notes for future consideration:
* It would be really nice if GA supported yaml anchors/aliases to DRY
  out the configuration. An alternative could be to use [composite run
  steps](https://docs.github.com/en/free-pro-team@latest/actions/creating-actions/creating-a-composite-run-steps-action)
  but keeping it simple and slightly duplicated for now.
* See TODOs about integration tests on windows and macos
* I wanted to include a "LOOKER_LATEST" version variable so that the
  windows and macos job config blocks could reference it and not have
  to be changed each time a new looker version is added but currently
  the "env" and "secrets" contexts aren't available and job level
  configuration syntax