### PR TITLE
chore: python ci/release workflow tweaks

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -10,14 +10,12 @@ on:
       - labeled
     paths:
       - python/**
-      - packages/sdk-codegen*/**
 
   push:
     branches:
       - master
     paths:
       - python/**
-      - packages/sdk-codegen*/**
 
 env:
   LOOKERSDK_BASE_URL: https://localhost:20000
@@ -33,6 +31,7 @@ jobs:
   unit:
     # 1st condition: push event (restricted to master above)
     # 2nd condition: PR opened/synchronized/reopened (types filter above)
+    #                except Release PRs, those need a manual CI:TEST
     # 3rd condition: PR labeled with "CI:TEST"
     if: >
       github.event_name == 'push' ||
@@ -85,6 +84,11 @@ jobs:
           pip install tox
       - name: Run Unit Tests
         run: tox -e unit
+      - name: Twine upload check
+        run: |
+          pip install wheel twine
+          python setup.py sdist bdist_wheel
+          twine check dist/*
       - name: Upload pytest test results
         if: ${{ always() }}
         uses: actions/upload-artifact@v2
@@ -94,7 +98,6 @@ jobs:
 
   integration:
     needs: unit
-    if: false
     name: Integration - ${{ matrix.os }} / Looker.${{ matrix.looker }}
     env:
       TOX_JUNIT_OUTPUT_NAME: ${{ matrix.os }}.Looker-${{ matrix.looker }}
@@ -212,24 +215,15 @@ jobs:
 
   remove-CI-TEST-label:
     name: Remove CI:TEST Label
-    needs: [unit, integration]
-    # TODO: can we move the step "if" below up to this level and combine with
-    # "always()" somehow? That would skip the job completely rather than firing
-    # up a runner to then skip the only step.
-    #
-    # We want this step to run only after unit and integration (hence "needs")
-    # but we want it to run regardless of whether those jobs
-    # succeeded/failed/skipped (hence "always()")
-    if: always()
+    if: >
+      (
+        github.event_name == 'pull_request' &&
+        github.event.action == 'labeled' &&
+        github.event.label.name == 'CI:TEST'
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Remove CI:TEST Label
-        if: >
-          (
-            github.event_name == 'pull_request' &&
-            github.event.action == 'labeled' &&
-            github.event.label.name == 'CI:TEST'
-          )
         uses: actions/github-script@v3
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -1,25 +1,44 @@
 name: Python Publish to PYPI
 on:
   release:
-    types: [published, edited]
+    types: [edited]
+
+defaults:
+  run:
+    shell: bash
+    working-directory: python/
 
 jobs:
   publish:
 
     if: >
-      startsWith(github.event.release.tag_name, 'lktstpy') &&
+      startsWith(github.event.release.tag_name, 'looker_sdk') &&
       !github.event.release.draft &&
       !github.event.release.prerelease
 
     runs-on: ubuntu-latest
 
     steps:
+      - name: Repo Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
       - name: Package release artifacts
-        run: python setup.py bdist_wheel sdist
+        run: |
+          pip install wheel
+          python setup.py sdist bdist_wheel
 
       - name: Publish to pypi
         uses: pypa/gh-action-pypi-publish@v1.4.1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
+          # TODO: remove repository_url to default to prod
           repository_url: https://test.pypi.org/legacy/
+          packages_dir: python/dist/

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,33 +7,20 @@
    release-please-py:
      runs-on: ubuntu-latest
      steps:
-       - uses: google-github-actions/release-please-action@41efee8ee32a4c9f72e461eb37cfba3a0e8e32e6
+       - uses: google-github-actions/release-please-action@master
          with:
            release-type: python
-           package-name: lktstpy
+           package-name: looker_sdk
            monorepo-tags: true
            path: python/
-           # ${{ secrets.GITHUB_TOKEN }} is restricted from any work it performs
-           # having the side effect of triggering other workflows. However, we
-           # need this workflow to trigger the "Python Publish to PYPI" workflow
-           # when it creates a release. Hence we're using a personal token from
-           # the joeldodge79 account with full "repo" permissions.
-           #
-           # TODO: user looker-jenkins or some other service account?
-           # TODO: when a "normal" PR is merged, CI will run on master.
-           # The Release PR will synchronize and, as a result of using this
-           # personal token, CI will now run on it too. Is that desired or do we
-           # want to only run CI manually ("CI:TEST" label) before merging it?
-           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+           token: ${{ secrets.GITHUB_TOKEN }}
 
    release-please-ts:
      runs-on: ubuntu-latest
      steps:
-       - uses: google-github-actions/release-please-action@41efee8ee32a4c9f72e461eb37cfba3a0e8e32e6
+       - uses: google-github-actions/release-please-action@master
          with:
            release-type: node
            monorepo-tags: true
            path: packages/sdk/
-
-           # see comment in release-please-py
-           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Python CI
* remove "if: false" for integration tests to re-enable
* only trigger on files under python/
* add "Twine upload check" as part of CI so we avoid that pitfal when
  publishing
* More intelligent "Remove CI:TEST Label" conditional that will skip the
  whole job rather than start the job and skip the single step

Python Release
* trigger on release/edited so that marking a release as non-draft will be
  the condition for publishing to PyPI

Release Please
* stop using secrets.RELEASE_PLEASE_TOKEN - we no longer want to have
the release-please-action's side-effects trigger other workflows.
  * We'll have a separate solution for running CI on a Release PR prior
  to merging it
  * we're no longer publishing on "release/published".