### PR TITLE
Fixes an issue with Golang API requests containing strings

### DIFF
--- a/go/example/main.go
+++ b/go/example/main.go
@@ -35,6 +35,23 @@ func printAllProjects(sdk *v4.LookerSDK) {
 	}
 }
 
+func printAboutMe(sdk *v4.LookerSDK) {
+
+	me,err := sdk.Me("",nil)
+	check(err)
+
+	fmt.Printf("You are %s\n", *(me.Email))
+
+	// Search for this user by their e-mail
+	users,err := sdk.SearchUsers(v4.RequestSearchUsers{Email: me.Email}, nil)
+	if err != nil {
+		fmt.Printf("Error getting myself %v\n", err)
+	}
+	if len(users) != 1 {
+		fmt.Printf("Found %d users with my email expected 1\n")
+	}
+}
+
 func main() {
 	// Default config file location
 	lookerIniPath := "../../looker.ini"
@@ -53,5 +70,7 @@ func main() {
 	printAllProjects(sdk)
 
 	printAllUsers(sdk)
+
+	printAboutMe(sdk)
 
 }

--- a/go/rtl/auth_test.go
+++ b/go/rtl/auth_test.go
@@ -3,6 +3,7 @@ package rtl
 import (
 	"testing"
 	"time"
+	"net/url"
 )
 
 func TestNewAccessToken(t *testing.T) {
@@ -91,5 +92,35 @@ func TestAuthSession_login(t *testing.T) {
 				t.Errorf("login() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestSetQuery(t *testing.T) {
+	somestring := "somestring"
+	testcases := []struct{
+			url      string
+			params   map[string]interface{}
+			expected string
+		}{
+			// ignores empty/nil
+			{
+				url: "https://foo",
+				params: map[string]interface{}{"integer": "", "str": nil},
+				expected: "https://foo",
+			},
+			// strings and integers work as expected no quotes
+			{
+				url: "https://foo",
+				params: map[string]interface{}{"integer": 5, "str": "string", "pstr": &somestring},
+				expected: "https://foo?integer=5&pstr=somestring&str=string",
+			},
+		}
+	for i,testcase := range testcases {
+		url,_ := url.Parse(testcase.url)
+		setQuery(url, testcase.params)
+		strURLWithQuery := url.String()
+		if strURLWithQuery != testcase.expected {
+			t.Errorf("case %d: wanted: %s got %s", i, testcase.expected, strURLWithQuery)
+		}
 	}
 }


### PR DESCRIPTION
It turns out that the string was marshalled with quotes
for instance https://test.looker.com:443/api/4.0/users/search?email="foo@bar.com"
instead of https://test.looker.com:443/api/4.0/users/search?email=foo@bar.com
causing the server to ignore it.