### PR TITLE
Eslint fixes

### DIFF
--- a/.github/workflows/tssdk-ci.yml
+++ b/.github/workflows/tssdk-ci.yml
@@ -73,6 +73,7 @@ jobs:
       - name: Install dependencies
         run: |
           yarn
+          yarn lint:es
           yarn build
 
       - name: Mock looker.ini

--- a/.github/workflows/tssdk-ci.yml
+++ b/.github/workflows/tssdk-ci.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Install dependencies
         run: |
           yarn
-          yarn lint:es
+          yarn lint:es --quiet
           yarn build
 
       - name: Mock looker.ini

--- a/packages/api-explorer/scripts/utils.ts
+++ b/packages/api-explorer/scripts/utils.ts
@@ -118,7 +118,9 @@ const brokenPromise = (message: string) => Promise.reject(new Error(message))
 export const registerApp = async () => {
   const args = process.argv.slice(2)
   const total = args.length
+  // eslint-disable-next-line node/no-path-concat
   const iniFile = total < 1 ? `${__dirname}/../../../looker.ini` : args[0]
+  // eslint-disable-next-line node/no-path-concat
   const configFile = total < 2 ? `${__dirname}/appconfig.json` : args[1]
   let result = ''
   console.log(

--- a/packages/api-explorer/src/components/DocCode/utils.spec.ts
+++ b/packages/api-explorer/src/components/DocCode/utils.spec.ts
@@ -39,6 +39,7 @@ twice! Query, again!
       expect(markers).toBeDefined()
       expect(markers.length).toEqual(2)
       let mark = markers[0]
+      // eslint-disable-next-line jest-dom/prefer-to-have-class
       expect(mark.className).toEqual('codeMarker')
       expect(mark.startCol).toEqual(6)
       expect(mark.endCol).toEqual(6 + 5)

--- a/packages/api-explorer/src/components/DocMarkdown/DocMarkdown.spec.tsx
+++ b/packages/api-explorer/src/components/DocMarkdown/DocMarkdown.spec.tsx
@@ -55,8 +55,16 @@ describe('DocMarkdown', () => {
     const input =
       'A link to the [create_dashboard](#!/Dashboard/create_dashboard) endpoint'
     renderWithTheme(<DocMarkdown source={input} specKey={'3.1'} />)
+    // TODO revisit the following expect
+    // eslint reports the following errors:
+    // 59:7  error  `findByText` must have `await` operator                       testing-library/await-async-query
+    // 60:7  error  Prefer .toBeInTheDocument() for asserting DOM node existence  jest-dom/prefer-in-document
+    // I tried fixing per the recommendations but the test failed. Falling back to eslint-disable in abject failure
+    // As an aside, the data coming out of the screen looks correct as per the test.
     expect(
+      // eslint-disable-next-line testing-library/await-async-query
       screen.findByText('A link to the create_dashboard endpoint')
+      // eslint-disable-next-line jest-dom/prefer-in-document
     ).toBeDefined()
     expect(screen.getByText('create_dashboard')).toHaveAttribute(
       'href',

--- a/packages/api-explorer/src/components/DocPseudo/DocParams.spec.tsx
+++ b/packages/api-explorer/src/components/DocPseudo/DocParams.spec.tsx
@@ -32,8 +32,9 @@ import { DocParams } from './DocParams'
 
 describe('DocParams', () => {
   test('it works when method only has required params', () => {
-    const params = api.methods['create_connection'].allParams
+    const params = api.methods.create_connection.allParams
     expect(params).toHaveLength(1)
+    // eslint-disable-next-line jest-dom/prefer-required
     expect(params[0]).toHaveProperty('required', true)
 
     renderWithTheme(<DocParams parameters={params} />)
@@ -41,8 +42,9 @@ describe('DocParams', () => {
   })
 
   test('it works when method only has optional params', () => {
-    const params = api.methods['me'].allParams
+    const params = api.methods.me.allParams
     expect(params).toHaveLength(1)
+    // eslint-disable-next-line jest-dom/prefer-required
     expect(params[0]).toHaveProperty('required', false)
 
     renderWithTheme(<DocParams parameters={params} />)
@@ -50,7 +52,7 @@ describe('DocParams', () => {
   })
 
   test('it works when method has both required and optional params', () => {
-    const params = api.methods['user'].allParams
+    const params = api.methods.user.allParams
     const requiredParams = params.filter((param) => param.required)
     const optionalParams = params.filter((param) => !param.required)
     expect(requiredParams).toHaveLength(1)

--- a/packages/api-explorer/src/components/DocPseudo/DocPseudo.spec.tsx
+++ b/packages/api-explorer/src/components/DocPseudo/DocPseudo.spec.tsx
@@ -31,7 +31,7 @@ import { api } from '../../test-data'
 import { DocPseudo } from './DocPseudo'
 
 describe('DocPseudo', () => {
-  const method = api.methods['create_dashboard_filter']
+  const method = api.methods.create_dashboard_filter
 
   test('it renders', () => {
     renderWithTheme(<DocPseudo method={method} />)

--- a/packages/api-explorer/src/components/ExploreType/ExploreProperty.spec.tsx
+++ b/packages/api-explorer/src/components/ExploreType/ExploreProperty.spec.tsx
@@ -40,6 +40,7 @@ describe('ExploreProperty', () => {
         renderWithSearchAndRouter(<ExplorePropertyDetail property={property} />)
         expect(property.deprecated).toEqual(false)
         expect(property.readOnly).toEqual(true)
+        // eslint-disable-next-line jest-dom/prefer-required
         expect(property.required).toEqual(false)
         expect(screen.getByText(property.description)).toBeInTheDocument()
         await waitFor(() => {
@@ -56,6 +57,7 @@ describe('ExploreProperty', () => {
         renderWithSearchAndRouter(<ExplorePropertyDetail property={property} />)
         expect(property.deprecated).toEqual(false)
         expect(property.readOnly).toEqual(false)
+        // eslint-disable-next-line jest-dom/prefer-required
         expect(property.required).toEqual(true)
         expect(screen.getByText(property.description)).toBeInTheDocument()
         await waitFor(() => {

--- a/packages/api-explorer/src/components/ExploreType/ExploreType.spec.tsx
+++ b/packages/api-explorer/src/components/ExploreType/ExploreType.spec.tsx
@@ -26,10 +26,10 @@
 
 import React from 'react'
 import { screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import { api } from '../../test-data'
 import { renderWithRouter, renderWithSearchAndRouter } from '../../test-utils'
 import { ExploreType, ExploreTypeLink } from '.'
-import { MemoryRouter } from 'react-router-dom'
 
 describe('ExploreType', () => {
   const targetType = api.types.ColorCollection
@@ -55,8 +55,11 @@ describe('ExploreType', () => {
     )
 
     expect(screen.getByText(targetType.jsonName)).toBeInTheDocument()
+    // eslint-disable-next-line jest-dom/prefer-in-document
     expect(screen.queryAllByText(colors)).toHaveLength(0)
+    // eslint-disable-next-line jest-dom/prefer-in-document
     expect(screen.queryAllByText(stops)).toHaveLength(0)
+    // eslint-disable-next-line jest-dom/prefer-in-document
     expect(screen.queryAllByText(offset)).toHaveLength(0)
   })
 
@@ -68,6 +71,7 @@ describe('ExploreType', () => {
     expect(screen.getByText(targetType.jsonName)).toBeInTheDocument()
     expect(screen.queryAllByText(colors)).toHaveLength(colorsExpected)
     expect(screen.queryAllByText(stops)).toHaveLength(stopsExpected)
+    // eslint-disable-next-line jest-dom/prefer-in-document
     expect(screen.queryAllByText(offset)).toHaveLength(0)
   })
 

--- a/packages/api-explorer/src/components/SideNav/SideNav.spec.tsx
+++ b/packages/api-explorer/src/components/SideNav/SideNav.spec.tsx
@@ -54,10 +54,11 @@ describe('SideNav', () => {
     expect(screen.getAllByText(allTagsPattern)).toHaveLength(2)
     expect(
       screen.queryAllByRole('link', { name: allTypesPattern })
-    ).toHaveLength(0)
+    ).toHaveLength(0) // eslint-disable-line jest-dom/prefer-in-document
 
     userEvent.click(screen.getByRole('tab', { name: /^Types$/ }))
 
+    // eslint-disable-next-line jest-dom/prefer-in-document
     expect(screen.queryAllByText(allTagsPattern)).toHaveLength(0)
     expect(screen.getAllByRole('link', { name: allTypesPattern })).toHaveLength(
       2
@@ -66,6 +67,7 @@ describe('SideNav', () => {
 
   test('url determines active tab', () => {
     renderWithRouter(<SideNav api={api} specKey={'3.1'} />, ['/3.1/types'])
+    // eslint-disable-next-line jest-dom/prefer-in-document
     expect(screen.queryAllByText(allTagsPattern)).toHaveLength(0)
     expect(screen.getAllByRole('link', { name: allTypesPattern })).toHaveLength(
       2

--- a/packages/api-explorer/src/scenes/TagScene/TagScene.spec.tsx
+++ b/packages/api-explorer/src/scenes/TagScene/TagScene.spec.tsx
@@ -90,6 +90,7 @@ describe('TagScene', () => {
     /** Filter by DELETE operation */
     userEvent.click(screen.getByRole('button', { name: 'DELETE' }))
     await waitFor(() => {
+      // eslint-disable-next-line jest-dom/prefer-in-document
       expect(screen.getAllByText(allLookMethods)).toHaveLength(1)
     })
     /** Restore original state */

--- a/packages/hackathon/src/components/Header/Header.tsx
+++ b/packages/hackathon/src/components/Header/Header.tsx
@@ -31,5 +31,12 @@ export interface HeaderProps {
 }
 
 export const Header: FC<HeaderProps> = ({ text }) => (
-  <Heading style={{position: "relative"}} fontSize="xxxxlarge" textAlign="center" py="large">{text}</Heading>
+  <Heading
+    style={{ position: 'relative' }}
+    fontSize="xxxxlarge"
+    textAlign="center"
+    py="large"
+  >
+    {text}
+  </Heading>
 )

--- a/packages/hackathon/src/data/admin/reducer.ts
+++ b/packages/hackathon/src/data/admin/reducer.ts
@@ -65,13 +65,14 @@ export const adminReducer = (
         ...state,
         validationMessages: undefined,
       }
-    case Actions.SAVE_USER_ATTRIBUTES_RESPONSE:
+    case Actions.SAVE_USER_ATTRIBUTES_RESPONSE: {
       const { adminUserAttributes, validationMessages } = action.payload
       return {
         ...state,
         adminUserAttributes,
         validationMessages,
       }
+    }
     default:
       return state
   }

--- a/packages/hackathon/src/data/admin/sagas.ts
+++ b/packages/hackathon/src/data/admin/sagas.ts
@@ -24,6 +24,7 @@
 
  */
 import { all, call, put, takeEvery } from 'redux-saga/effects'
+import { ValidationMessages } from '@looker/components'
 import { getCore40SDK } from '@looker/extension-sdk-react'
 import { getExtensionSDK } from '@looker/extension-sdk'
 import { IUserAttribute } from '@looker/sdk'
@@ -35,7 +36,6 @@ import {
   saveUserAttributesRequest,
   saveUserAttributesResponse,
 } from './actions'
-import { ValidationMessages } from '@looker/components'
 
 const findUserAttributeValue = (
   name: string,

--- a/packages/hackathon/src/data/hackers/reducer.ts
+++ b/packages/hackathon/src/data/hackers/reducer.ts
@@ -47,7 +47,7 @@ export const hackersReducer = (
   action: HackerAction
 ): HackersState => {
   switch (action.type) {
-    case Actions.ALL_HACKERS_RESPONSE:
+    case Actions.ALL_HACKERS_RESPONSE: {
       const { hackers, staff, admins, judges } = action.payload
       return {
         ...state,
@@ -56,6 +56,7 @@ export const hackersReducer = (
         staff,
         admins,
       }
+    }
     case Actions.UPDATE_HACKERS_PAGE_NUM:
       return {
         ...state,

--- a/packages/hackathon/src/data/judgings/sagas.ts
+++ b/packages/hackathon/src/data/judgings/sagas.ts
@@ -54,7 +54,7 @@ function* getJudgingsSaga() {
 function* getJudgingSaga({ payload: judgingId }: GetJudgingRequestAction) {
   try {
     // Pull judging out of state.
-    let state = yield select()
+    const state = yield select()
     let judgings = getJudgingsState(state)
     if (judgings.length === 0) {
       // judgings are lost on page reload so load them

--- a/packages/hackathon/src/data/projects/reducer.ts
+++ b/packages/hackathon/src/data/projects/reducer.ts
@@ -90,7 +90,7 @@ export const projectsReducer = (
         projectUpdated: undefined,
         projectLoaded: false,
       }
-    case Actions.GET_PROJECT_RESPONSE:
+    case Actions.GET_PROJECT_RESPONSE: {
       const { project, isProjectMember } = action.payload
       return {
         ...state,
@@ -98,6 +98,7 @@ export const projectsReducer = (
         isProjectMember,
         projectLoaded: true,
       }
+    }
     case Actions.UPDATE_PROJECT_DATA:
       return {
         ...state,
@@ -109,11 +110,6 @@ export const projectsReducer = (
         currentPageNum: action.payload,
       }
     case Actions.CREATE_PROJECT:
-      return {
-        ...state,
-        validationMessages: undefined,
-      }
-    case Actions.UPDATE_PROJECT_DATA:
       return {
         ...state,
         validationMessages: undefined,

--- a/packages/hackathon/src/data/projects/sagas.ts
+++ b/packages/hackathon/src/data/projects/sagas.ts
@@ -93,7 +93,7 @@ function* getProjectSaga({ payload: projectId }: GetProjectRequestAction) {
       yield put(getProjectResponse(createNewProject(), false))
     } else {
       // Pull prpjects out of state.
-      let state = yield select()
+      const state = yield select()
       let projects = getCurrentProjectsState(state)
       if (projects.length === 0) {
         // projects are lost on page reload so load them
@@ -123,8 +123,8 @@ function* createProjectSaga(action: CreateProjectAction) {
       [sheetsClient, sheetsClient.validateProject],
       project
     )
-    let state = yield select()
-    let isProjectMember = getIsProjectMemberState(state)
+    const state = yield select()
+    const isProjectMember = getIsProjectMemberState(state)
     if (validationMessages) {
       yield put(
         saveProjectResponse(project, isProjectMember, validationMessages)
@@ -161,8 +161,8 @@ function* updateProjectSaga(action: UpdateProjectAction) {
       [sheetsClient, sheetsClient.validateProject],
       project
     )
-    let state = yield select()
-    let isProjectMember = getIsProjectMemberState(state)
+    const state = yield select()
+    const isProjectMember = getIsProjectMemberState(state)
     if (validationMessages) {
       yield put(
         saveProjectResponse(project, isProjectMember, validationMessages)
@@ -230,8 +230,8 @@ function* lockProjectSaga(action: LockProjectAction) {
   try {
     const { lock, projectId } = action.payload
     yield put(beginLoading())
-    let state = yield select()
-    let isProjectMember = getIsProjectMemberState(state)
+    const state = yield select()
+    const isProjectMember = getIsProjectMemberState(state)
     yield call([sheetsClient, sheetsClient.lockProject], lock, projectId)
     const updatedProject = yield call(
       [sheetsClient, sheetsClient.getProject],

--- a/packages/hackathon/src/models/Hacker.spec.ts
+++ b/packages/hackathon/src/models/Hacker.spec.ts
@@ -24,6 +24,7 @@
 
  */
 import path from 'path'
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { NodeSettingsIniFile, LookerNodeSDK } from '@looker/sdk-node'
 import { Hacker } from './Hacker'
 

--- a/packages/hackathon/src/scenes/AdminScene/AdminScene.tsx
+++ b/packages/hackathon/src/scenes/AdminScene/AdminScene.tsx
@@ -27,8 +27,8 @@ import React, { FC, useEffect } from 'react'
 import { TabList, Tab, TabPanels, TabPanel } from '@looker/components'
 import { useHistory, useRouteMatch } from 'react-router-dom'
 import { Routes } from '../../routes/AppRouter'
-import { UserAttributes } from './components/UserAttributes'
 import { getTabInfo } from '../../utils'
+import { UserAttributes } from './components/UserAttributes'
 
 const tabnames = ['general', 'config']
 

--- a/packages/hackathon/src/scenes/JudgingEditorScene/JudgingEditorScene.tsx
+++ b/packages/hackathon/src/scenes/JudgingEditorScene/JudgingEditorScene.tsx
@@ -33,8 +33,8 @@ import {
   getJudgingState,
   getJudgingLoadedState,
 } from '../../data/judgings/selectors'
-import { JudgingForm } from './components'
 import { canJudge } from '../../utils'
+import { JudgingForm } from './components'
 
 export const JudgingEditorScene: FC = () => {
   const dispatch = useDispatch()

--- a/packages/hackathon/src/scenes/ProjectsScene/ProjectsScene.tsx
+++ b/packages/hackathon/src/scenes/ProjectsScene/ProjectsScene.tsx
@@ -32,11 +32,11 @@ import { lockProjects } from '../../data/projects/actions'
 import { isLoadingState } from '../../data/common/selectors'
 import { Loading } from '../../components/Loading'
 import { Routes } from '../../routes/AppRouter'
-import { ProjectList } from './components'
 import {
   getCurrentHackathonState,
   getHackerState,
 } from '../../data/hack_session/selectors'
+import { ProjectList } from './components'
 
 interface ProjectSceneProps {}
 

--- a/packages/hackathon/src/scenes/ProjectsScene/components/ProjectList.tsx
+++ b/packages/hackathon/src/scenes/ProjectsScene/components/ProjectList.tsx
@@ -42,10 +42,10 @@ import {
   getHackerState,
   getProjectsHeadings,
 } from '../../../data/hack_session/selectors'
-import { deleteProject } from '../../../data/projects/actions'
 import { canDoProjectAction } from '../../../utils'
 import { PAGE_SIZE } from '../../../constants'
 import {
+  deleteProject,
   currentProjectsRequest,
   updateProjectsPageNum,
   setMoreInfo,

--- a/packages/hackathon/src/scenes/UsersScene/UsersScene.tsx
+++ b/packages/hackathon/src/scenes/UsersScene/UsersScene.tsx
@@ -41,8 +41,8 @@ import {
   getStaffState,
   getHackersPageNumState,
 } from '../../data/hackers/selectors'
-import { HackerList } from './components/HackerList'
 import { getTabInfo } from '../../utils'
+import { HackerList } from './components/HackerList'
 
 interface UsersSceneProps {}
 

--- a/packages/run-it/src/RunIt.spec.tsx
+++ b/packages/run-it/src/RunIt.spec.tsx
@@ -124,8 +124,12 @@ describe('RunIt', () => {
       expect(screen.getByRole('switch', { name: 'cache' })).toBeInTheDocument()
       expect(screen.getByText('body')).toBeInTheDocument()
       expect(screen.getByRole('button', { name: run })).toBeInTheDocument()
-      expect(screen.queryByRole('button', { name: 'Login' })).toBeNull()
-      expect(screen.queryByRole('button', { name: 'Remove' })).toBeNull()
+      expect(
+        screen.queryByRole('button', { name: 'Login' })
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: 'Remove' })
+      ).not.toBeInTheDocument()
     })
 
     test('the form submit handler invokes the request callback on submit', async () => {
@@ -155,8 +159,12 @@ describe('RunIt', () => {
     test('it renders ConfigForm', () => {
       renderRunIt()
       expect(screen.getByRole('button', { name: 'Remove' })).toBeInTheDocument()
-      expect(screen.queryByRole('button', { name: run })).toBeNull()
-      expect(screen.queryByRole('button', { name: 'Login' })).toBeNull()
+      expect(
+        screen.queryByRole('button', { name: run })
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: 'Login' })
+      ).not.toBeInTheDocument()
     })
   })
 
@@ -172,8 +180,12 @@ describe('RunIt', () => {
     test('it renders LoginForm', () => {
       renderRunIt()
       expect(screen.getByRole('button', { name: 'Login' })).toBeInTheDocument()
-      expect(screen.queryByRole('button', { name: 'Remove' })).toBeNull()
-      expect(screen.queryByRole('button', { name: run })).toBeNull()
+      expect(
+        screen.queryByRole('button', { name: 'Remove' })
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: run })
+      ).not.toBeInTheDocument()
     })
   })
 })

--- a/packages/run-it/src/components/ConfigForm/ConfigForm.spec.tsx
+++ b/packages/run-it/src/components/ConfigForm/ConfigForm.spec.tsx
@@ -80,7 +80,7 @@ describe('ConfigForm', () => {
         name: 'Save',
       }) as HTMLButtonElement
       expect(button).toBeInTheDocument()
-      expect(button).not.toBeEnabled()
+      expect(button).toBeDisabled()
       expect(screen.getByText(`'bad' is not a valid url`)).toBeInTheDocument()
     })
 
@@ -145,7 +145,7 @@ describe('ConfigForm', () => {
       <ConfigForm title="New title" configurator={defaultConfigurator} />
     )
     const title = screen.getByRole('heading') as HTMLHeadingElement
-    expect(title.textContent).toEqual('New title')
+    expect(title).toHaveTextContent('New title')
   })
 
   test('it gets config from local storage', async () => {

--- a/packages/run-it/src/components/DataGrid/gridUtils.tsx
+++ b/packages/run-it/src/components/DataGrid/gridUtils.tsx
@@ -74,10 +74,10 @@ export const gridCellId = (rowId: string, index: number) => `${rowId}.${index}`
  */
 export const gridRows = (data: any[]) => {
   const result: JSX.Element[] = []
-  data.map((row, index) => {
+  data.forEach((row, index) => {
     const id = gridRowId(index)
     const cells: any = []
-    row.map((item: any, index: number) => {
+    row.forEach((item: any, index: number) => {
       const key = gridCellId(id, index)
       const cell = <DataTableCell key={key}>{item}</DataTableCell>
       cells.push(cell)

--- a/packages/run-it/src/components/PerfTracker/PerfTable.spec.tsx
+++ b/packages/run-it/src/components/PerfTracker/PerfTable.spec.tsx
@@ -52,9 +52,9 @@ describe('PerfTable', () => {
   })
   test('it skips some columns by default', () => {
     renderWithTheme(<PerfTable onSelect={mockSelect} data={mockPerfEntries} />)
-    expect(screen.queryByText(/Domain/i)).toBeNull()
-    expect(screen.queryByText(/Connect/i)).toBeNull()
-    expect(screen.queryByText(/Secure/i)).toBeNull()
+    expect(screen.queryByText(/Domain/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Connect/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Secure/i)).not.toBeInTheDocument()
 
     // Check the partial url is in PerfTable
     const url = new URL(mockPerfEntries[1].name)

--- a/packages/run-it/src/components/PerfTracker/PerfTracker.spec.tsx
+++ b/packages/run-it/src/components/PerfTracker/PerfTracker.spec.tsx
@@ -27,9 +27,9 @@
 import { screen } from '@testing-library/react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import React from 'react'
+import { defaultConfigurator } from '../ConfigForm'
 import { PerfTracker } from './PerfTracker'
 import { LoadTimes, PerfTimings } from './perfUtils'
-import { defaultConfigurator } from '../ConfigForm'
 
 export const mockPerfEntries: LoadTimes[] = [
   new LoadTimes({
@@ -92,19 +92,23 @@ describe('PerfTracker', () => {
     const url = new URL(mockPerfEntries[1].name)
     const path = `${url.pathname}${url.search}`
     expect(screen.getByText(path)).toBeInTheDocument()
-    expect(screen.queryByText('No performance data is loaded')).toBeNull()
+    expect(
+      screen.queryByText('No performance data is loaded')
+    ).not.toBeInTheDocument()
     expect(
       screen.queryByText('Performance timing is not supported in this browser')
-    ).toBeNull()
+    ).not.toBeInTheDocument()
   })
   test('shows a "no data" message with performance but no entries', () => {
     jest.spyOn(PerfTimings.prototype, 'entries').mockReturnValue([])
     PerfTimings.supported = true
     renderWithTheme(<PerfTracker configurator={defaultConfigurator} />)
-    expect(screen.queryByText('No performance data is loaded')).toBeDefined()
+    expect(
+      screen.queryByText('No performance data is loaded')
+    ).toBeInTheDocument()
     expect(
       screen.queryByText('Performance timing is not supported in this browser')
-    ).toBeNull()
+    ).not.toBeInTheDocument()
   })
   describe('performance support', () => {
     const supported = PerfTimings.supported
@@ -118,8 +122,10 @@ describe('PerfTracker', () => {
         screen.queryByText(
           'Performance timing is not supported in this browser'
         )
-      ).toBeDefined()
-      expect(screen.queryByText('No performance data is loaded')).toBeNull()
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByText('No performance data is loaded')
+      ).not.toBeInTheDocument()
     })
   })
 })

--- a/packages/run-it/src/components/SdkCalls/callUtils.ts
+++ b/packages/run-it/src/components/SdkCalls/callUtils.ts
@@ -23,8 +23,12 @@
  SOFTWARE.
 
  */
-import { ApiModel, KeyedCollection, CodeGen } from '@looker/sdk-codegen'
-import { codeGenerators } from '@looker/sdk-codegen'
+import {
+  ApiModel,
+  KeyedCollection,
+  CodeGen,
+  codeGenerators,
+} from '@looker/sdk-codegen'
 
 /**
  * Returns a collection of generators for all supported (non legacy) languages

--- a/packages/run-it/src/components/ShowResponse/responseUtils.tsx
+++ b/packages/run-it/src/components/ShowResponse/responseUtils.tsx
@@ -152,8 +152,7 @@ export const responseHandlers: Responder[] = [
   // TODO: Add support for content type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet and pdf
   {
     label: 'json',
-    isRecognized: (contentType) =>
-      RegExp(/application\/json/g).test(contentType),
+    isRecognized: (contentType) => /application\/json/g.test(contentType),
     component: (response) => ShowJSON(response),
   },
   {
@@ -170,14 +169,13 @@ export const responseHandlers: Responder[] = [
   {
     label: 'img',
     isRecognized: (contentType) =>
-      RegExp(/image\/(png|jpg|jpeg|svg\+xml)/).test(contentType),
+      /image\/(png|jpg|jpeg|svg\+xml)/.test(contentType),
     component: (response) => ShowImage(response),
   },
   {
     // render task: 9d52f842b2c3f474970123302b2fa7e0
     label: 'pdf',
-    isRecognized: (contentType) =>
-      RegExp(/application\/pdf/g).test(contentType),
+    isRecognized: (contentType) => /application\/pdf/g.test(contentType),
     component: (response) => ShowPDF(response),
   },
   {

--- a/packages/sdk-codegen-scripts/src/fetchSpec.spec.ts
+++ b/packages/sdk-codegen-scripts/src/fetchSpec.spec.ts
@@ -99,8 +99,10 @@ describe('fetch operations', () => {
   it('authGetUrl', async () => {
     expect(props).toBeDefined()
     const versions = await fetchLookerVersions(props)
-    const fileUrl = swaggerFileUrl(props, versions)
-      .replace(versions.api_server_url, props.base_url)
+    const fileUrl = (swaggerFileUrl(props, versions) as string).replace(
+      versions.api_server_url,
+      props.base_url
+    )
     const content = await authGetUrl(props, fileUrl)
     expect(content).toBeDefined()
     expect(content.swagger).toBeDefined()

--- a/packages/sdk-codegen-scripts/src/fetchSpec.ts
+++ b/packages/sdk-codegen-scripts/src/fetchSpec.ts
@@ -158,7 +158,7 @@ export const openApiFileName = (name: string, props: ISDKConfigProps) =>
  * @param {string | object} content response to check
  * @returns {boolean} True if there's an authentication error
  */
-const badAuth = (content: string | object) => {
+const badAuth = (content: string | Record<string, unknown>) => {
   const text = typeof content === 'object' ? JSON.stringify(content) : content
   return text.indexOf('Requires authentication') > 0
 }
@@ -305,7 +305,10 @@ export const fetchLookerVersion = async (
  * @param {object | string} content to convert to a JSON string
  * @returns {string} name of file written
  */
-export const writeSpecFile = (specFile: string, content: object | string) => {
+export const writeSpecFile = (
+  specFile: string,
+  content: Record<string, unknown> | string
+) => {
   const data = typeof content === 'string' ? content : JSON.stringify(content)
   if (!isDirSync(specPath)) fs.mkdirSync(specPath, { recursive: true })
   fs.writeFileSync(specFile, data, utf8Encoding)

--- a/packages/sdk-codegen/src/sdkModels.spec.ts
+++ b/packages/sdk-codegen/src/sdkModels.spec.ts
@@ -349,9 +349,11 @@ describe('sdkModels', () => {
       expect(type).toBeDefined()
       const actual = apiTestModel.mayGetWriteableType(type)
       expect(actual).toBeDefined()
+      /* eslint-disable jest-dom/prefer-required */
       expect(type.properties.query_id.required).toEqual(true)
       expect(type.properties.result_format.required).toEqual(true)
       expect(type.properties.source.required).toEqual(false)
+      /* eslint-enable jest-dom/prefer-required */
       expect(Object.keys(type.requiredProperties)).toEqual([
         'query_id',
         'result_format',

--- a/packages/sdk-codegen/src/specConverter.ts
+++ b/packages/sdk-codegen/src/specConverter.ts
@@ -500,7 +500,7 @@ export const upgradeSpecObject = (spec: any) => {
  * Upgrade a spec to OpenAPI if it's not already an OpenAPI spec
  * @param spec to upgrade
  */
-export const upgradeSpec = (spec: string | object) => {
+export const upgradeSpec = (spec: string | Record<string, unknown>) => {
   if (typeof spec === 'string') spec = JSON.parse(spec)
   return JSON.stringify(upgradeSpecObject(spec))
 }

--- a/packages/sdk-codegen/src/typescript.gen.spec.ts
+++ b/packages/sdk-codegen/src/typescript.gen.spec.ts
@@ -129,8 +129,8 @@ describe('typescript generator', () => {
   it('license comment header', () => {
     const text =
       '\n\nMIT License\n\nCopyright (c) 2021 Looker Data Sciences, Inc.\n\nPermission\n\n\n'
-    let actual = gen.commentHeader('', text, ' ')
-    let expected = `/*
+    const actual = gen.commentHeader('', text, ' ')
+    const expected = `/*
 
  MIT License
 

--- a/packages/sdk-node/test/methods.spec.ts
+++ b/packages/sdk-node/test/methods.spec.ts
@@ -394,27 +394,31 @@ describe('LookerNodeSDK', () => {
       expect(sdk.authSession.isAuthenticated()).toBeFalsy()
     })
 
-    it('search_looks fields and title', async () => {
-      const sdk = new LookerSDK(session)
-      const looks = await sdk.ok(sdk.all_looks('id,title'))
-      expect(looks).not.toHaveLength(0)
-      const expected = looks[0]
-      const actual = await sdk.ok(
-        sdk.search_looks({
-          fields: 'id,title',
-          title: expected.title,
-        })
-      )
-      expect(actual).toBeDefined()
-      expect(actual.length).toBeGreaterThanOrEqual(1)
-      const look = actual[0]
-      expect(look.id).toBeDefined()
-      expect(look.title).toBeDefined()
-      expect(look.title).toEqual(expected.title)
-      expect(look.description).not.toBeDefined()
-      await sdk.authSession.logout()
-      expect(sdk.authSession.isAuthenticated()).toBeFalsy()
-    }, fifteen)
+    it(
+      'search_looks fields and title',
+      async () => {
+        const sdk = new LookerSDK(session)
+        const looks = await sdk.ok(sdk.all_looks('id,title'))
+        expect(looks).not.toHaveLength(0)
+        const expected = looks[0]
+        const actual = await sdk.ok(
+          sdk.search_looks({
+            fields: 'id,title',
+            title: expected.title,
+          })
+        )
+        expect(actual).toBeDefined()
+        expect(actual.length).toBeGreaterThanOrEqual(1)
+        const look = actual[0]
+        expect(look.id).toBeDefined()
+        expect(look.title).toBeDefined()
+        expect(look.title).toEqual(expected.title)
+        expect(look.description).not.toBeDefined()
+        await sdk.authSession.logout()
+        expect(sdk.authSession.isAuthenticated()).toBeFalsy()
+      },
+      fifteen
+    )
   })
 
   describe('User CRUD-it checks', () => {

--- a/packages/wholly-sheet/src/RowModel.ts
+++ b/packages/wholly-sheet/src/RowModel.ts
@@ -121,13 +121,13 @@ export interface IRowModel extends IRowModelProps {
   typeCast(key: string, value: any): any
 
   /** Converts instance to plain javascript object */
-  toObject(): object
+  toObject(): Record<string, unknown>
 
   /**
    * Converts from plain javascript object to class instance
    * @param obj to assign to row. Uses properties of the same name
    */
-  fromObject(obj: object): IRowModel
+  fromObject(obj: Record<string, unknown>): IRowModel
 
   /** Mark a row for update. Sets the $action and returns true if the row can be marked for updating */
   setUpdate(): boolean
@@ -275,11 +275,11 @@ export class RowModel<T extends IRowModel> implements IRowModel {
     return undefined
   }
 
-  toObject(): object {
+  toObject(): Record<string, unknown> {
     return omit({ ...this }, ['$_action'])
   }
 
-  fromObject(obj: object): IRowModel {
+  fromObject(obj: Record<string, unknown>): IRowModel {
     return this.assign(obj)
   }
 }


### PR DESCRIPTION
This fixes some but not all eslint issues. In some cases eslint disable has been used. Reasons any one of the following
1. lint rule does not make sense for code. example prefer-required, prefer to have class, prefer in document and import no extraneous dependencies (this one is weirs suspect eslint and lerna at cross purposes)
2. fix breaks test - example DocMarkdown.spec.ts
3. fix change to impactful and no really good test (api-explorer/scripts/utils.ts for example)

Note one fix removed a duplicate case statement (data/projects/reducer.ts). Probably not an issue but could be the wrong action or could be that the value should be cleared. Will wait for a bug to be reported.

Once this is merged I'm going to turn on lint:es as part of the CI build