### PR TITLE
Fixed dev environment

### DIFF
--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -22,7 +22,7 @@
     "develop": "webpack-dev-server --host=0.0.0.0 --disable-host-check --config webpack.dev.config.js",
     "docs": "typedoc --mode file --out docs",
     "register": "SUPPRESS_NO_CONFIG_WARNING=1 ts-node -O '{ \"module\": \"commonjs\", \"target\": \"es2019\" }' scripts/register.ts",
-    "watch": "yarn lerna exec --scope @looker/api-explorer --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib --source-maps --extensions .ts,.tsx --no-comments --watch'"
+    "watch": "yarn lerna exec --scope @looker/api-explorer --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib/esm --source-maps --extensions .ts,.tsx --no-comments --watch'"
   },
   "devDependencies": {
     "@looker/components-test-utils": "^0.9.29",

--- a/packages/extension-api-explorer/package.json
+++ b/packages/extension-api-explorer/package.json
@@ -10,7 +10,7 @@
     "bundle": "tsc && webpack --config webpack.prod.config.js",
     "deploy": "bin/deploy",
     "develop": "webpack-dev-server --hot --disable-host-check --port 8080 --https --config webpack.dev.config.js",
-    "watch": "yarn lerna exec --scope @looker/extension-api-explorer --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib --source-maps --extensions .ts,.tsx --no-comments --watch'"
+    "watch": "yarn lerna exec --scope @looker/extension-api-explorer --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib/esm --source-maps --extensions .ts,.tsx --no-comments --watch'"
   },
   "dependencies": {
     "@looker/api-explorer": "^21.0.4",

--- a/packages/hackathon/package.json
+++ b/packages/hackathon/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "bundle": "tsc && webpack --config webpack.prod.config.js",
     "develop": "webpack-dev-server --hot --disable-host-check --port 8080 --https --config webpack.dev.config.js",
-    "watch": "yarn lerna exec --scope @looker/wholly-sheet --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib --source-maps --extensions .ts,.tsx --no-comments --watch'"
+    "watch": "yarn lerna exec --scope @looker/wholly-sheet --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib/esm --source-maps --extensions .ts,.tsx --no-comments --watch'"
   },
   "dependencies": {
     "@looker/components": "^0.9.30",

--- a/packages/run-it/package.json
+++ b/packages/run-it/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "play": "webpack-dev-server --https --disable-host-check --config webpack.dev.config.js --entry ./playground/index.tsx",
     "test": "jest",
-    "watch": "yarn lerna exec --scope @looker/run-it --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib --source-maps --extensions .ts,.tsx --no-comments --watch'"
+    "watch": "yarn lerna exec --scope @looker/run-it --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib/esm --source-maps --extensions .ts,.tsx --no-comments --watch'"
   },
   "devDependencies": {
     "@looker/components-test-utils": "^0.9.29",

--- a/packages/sdk-codegen-scripts/package.json
+++ b/packages/sdk-codegen-scripts/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/looker-open-source/sdk-codegen/tree/master/packages/sdk-codegen-scripts",
   "scripts": {
     "docs": "typedoc --mode file --out docs",
-    "watch": "yarn lerna exec --scope @looker/sdk-codegen-scripts --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib --source-maps --extensions .ts,.tsx --no-comments --watch'"
+    "watch": "yarn lerna exec --scope @looker/sdk-codegen-scripts --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib/esm --source-maps --extensions .ts,.tsx --no-comments --watch'"
   },
   "dependencies": {
     "@looker/sdk": "^21.0.4",

--- a/packages/sdk-codegen-utils/package.json
+++ b/packages/sdk-codegen-utils/package.json
@@ -28,6 +28,6 @@
     "codegen"
   ],
   "scripts": {
-    "watch": "yarn lerna exec --scope @looker/sdk-codegen-utils --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib --source-maps --extensions .ts,.tsx --no-comments --watch'"
+    "watch": "yarn lerna exec --scope @looker/sdk-codegen-utils --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib/esm --source-maps --extensions .ts,.tsx --no-comments --watch'"
   }
 }

--- a/packages/sdk-codegen/package.json
+++ b/packages/sdk-codegen/package.json
@@ -29,7 +29,7 @@
   ],
   "scripts": {
     "docs": "typedoc --mode file --out docs",
-    "watch": "yarn lerna exec --scope @looker/sdk-codegen --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib --source-maps --extensions .ts,.tsx --no-comments --watch'"
+    "watch": "yarn lerna exec --scope @looker/sdk-codegen --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib/esm --source-maps --extensions .ts,.tsx --no-comments --watch'"
   },
   "dependencies": {
     "@looker/sdk": "^21.0.4",

--- a/packages/sdk-node/package.json
+++ b/packages/sdk-node/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "scripts": {
     "docs": "typedoc --mode file --out docs",
-    "watch": "yarn lerna exec --scope @looker/sdk-node --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib --source-maps --extensions .ts,.tsx --no-comments --watch'"
+    "watch": "yarn lerna exec --scope @looker/sdk-node --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib/esm --source-maps --extensions .ts,.tsx --no-comments --watch'"
   },
   "bugs": {
     "url": "https://github.com/looker-open-source/sdk-codegen/issues"

--- a/packages/sdk-rtl/package.json
+++ b/packages/sdk-rtl/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "scripts": {
     "docs": "typedoc --mode file --out docs",
-    "watch": "yarn lerna exec --scope @looker/sdk-rtl --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib --source-maps --extensions .ts,.tsx --no-comments --watch'"
+    "watch": "yarn lerna exec --scope @looker/sdk-rtl --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib/esm --source-maps --extensions .ts,.tsx --no-comments --watch'"
   },
   "bugs": {
     "url": "https://github.com/looker-open-source/sdk-codegen/issues"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "scripts": {
     "docs": "typedoc --mode file --out docs",
-    "watch": "yarn lerna exec --scope @looker/sdk --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib --source-maps --extensions .ts,.tsx --no-comments --watch'"
+    "watch": "yarn lerna exec --scope @looker/sdk --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib/esm --source-maps --extensions .ts,.tsx --no-comments --watch'"
   },
   "bugs": {
     "url": "https://github.com/looker-open-source/sdk-codegen/issues"

--- a/packages/wholly-sheet/package.json
+++ b/packages/wholly-sheet/package.json
@@ -28,7 +28,7 @@
     "codegen"
   ],
   "scripts": {
-    "watch": "yarn lerna exec --scope @looker/wholly-sheet --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib --source-maps --extensions .ts,.tsx --no-comments --watch'"
+    "watch": "yarn lerna exec --scope @looker/wholly-sheet --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib/esm --source-maps --extensions .ts,.tsx --no-comments --watch'"
   },
   "dependencies": {
     "@looker/sdk": "^21.0.4",


### PR DESCRIPTION
Corrected babel's out dir when running in watch mode. Prior to this, webpack was not recompiling when for example APIX's dev server was running and a change was made in one of APIX's dependencies, such as RunIt. 