### PR TITLE
yarn watch changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "test:sdk": "yarn jest packages/sdk",
     "test:jest": "DOT_ENV_FILE=.env.test jest",
     "bootstrap": "lerna clean -y && lerna bootstrap",
-    "watch": "lerna run --parallel watch"
+    "watch": "lerna run --parallel watch",
+    "watch:cjs": "lerna run --parallel watch:cjs"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.1",

--- a/packages/extension-api-explorer/package.json
+++ b/packages/extension-api-explorer/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@looker/api-explorer": "^21.0.4",
     "@looker/extension-sdk": "0.16.4",
-    "@looker/extension-sdk-react": "0.10.3",
+    "@looker/extension-sdk-react": "0.10.4",
     "@looker/run-it": "^21.0.4",
     "@looker/sdk": "^21.0.4",
     "react": "^16.13.1",

--- a/packages/hackathon/package.json
+++ b/packages/hackathon/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@looker/components": "^0.9.30",
     "@looker/extension-sdk": "0.16.4",
-    "@looker/extension-sdk-react": "0.10.3",
+    "@looker/extension-sdk-react": "0.10.4",
     "@looker/sdk": "^21.0.4",
     "@looker/sdk-rtl": "^21.0.4",
     "@looker/wholly-sheet": "^21.0.1",

--- a/packages/sdk-codegen-scripts/package.json
+++ b/packages/sdk-codegen-scripts/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/looker-open-source/sdk-codegen/tree/main/packages/sdk-codegen-scripts",
   "scripts": {
     "docs": "typedoc --mode file --out docs",
-    "watch": "yarn lerna exec --scope @looker/sdk-codegen-scripts --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib/esm --source-maps --extensions .ts,.tsx --no-comments --watch'"
+    "watch:cjs": "yarn lerna exec --scope @looker/sdk-codegen-scripts --stream 'BABEL_ENV=build_cjs babel src --root-mode upward --out-dir lib --source-maps --extensions .ts,.tsx --no-comments --watch'"
   },
   "dependencies": {
     "@looker/sdk": "^21.0.4",

--- a/packages/sdk-codegen-utils/package.json
+++ b/packages/sdk-codegen-utils/package.json
@@ -28,6 +28,6 @@
     "codegen"
   ],
   "scripts": {
-    "watch": "yarn lerna exec --scope @looker/sdk-codegen-utils --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib/esm --source-maps --extensions .ts,.tsx --no-comments --watch'"
+    "watch:cjs": "yarn lerna exec --scope @looker/sdk-codegen-utils --stream 'BABEL_ENV=build_cjs babel src --root-mode upward --out-dir lib --source-maps --extensions .ts,.tsx --no-comments --watch'"
   }
 }

--- a/packages/sdk-codegen/package.json
+++ b/packages/sdk-codegen/package.json
@@ -29,7 +29,7 @@
   ],
   "scripts": {
     "docs": "typedoc --mode file --out docs",
-    "watch": "yarn lerna exec --scope @looker/sdk-codegen --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib/esm --source-maps --extensions .ts,.tsx --no-comments --watch'"
+    "watch:cjs": "yarn lerna exec --scope @looker/sdk-codegen --stream 'BABEL_ENV=build_cjs babel src --root-mode upward --out-dir lib --source-maps --extensions .ts,.tsx --no-comments --watch'"
   },
   "dependencies": {
     "@looker/sdk": "^21.0.4",

--- a/packages/sdk-node/package.json
+++ b/packages/sdk-node/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "scripts": {
     "docs": "typedoc --mode file --out docs",
-    "watch": "yarn lerna exec --scope @looker/sdk-node --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib/esm --source-maps --extensions .ts,.tsx --no-comments --watch'"
+    "watch:cjs": "yarn lerna exec --scope @looker/sdk-node --stream 'BABEL_ENV=build_cjs babel src --root-mode upward --out-dir lib --source-maps --extensions .ts,.tsx --no-comments --watch'"
   },
   "bugs": {
     "url": "https://github.com/looker-open-source/sdk-codegen/issues"

--- a/packages/sdk-rtl/package.json
+++ b/packages/sdk-rtl/package.json
@@ -22,7 +22,8 @@
   "license": "MIT",
   "scripts": {
     "docs": "typedoc --mode file --out docs",
-    "watch": "yarn lerna exec --scope @looker/sdk-rtl --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib/esm --source-maps --extensions .ts,.tsx --no-comments --watch'"
+    "watch": "yarn lerna exec --scope @looker/sdk-rtl --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib/esm --source-maps --extensions .ts,.tsx --no-comments --watch'",
+    "watch:cjs": "yarn lerna exec --scope @looker/sdk-rtl --stream 'BABEL_ENV=build_cjs babel src --root-mode upward --out-dir lib --source-maps --extensions .ts,.tsx --no-comments --watch'"
   },
   "bugs": {
     "url": "https://github.com/looker-open-source/sdk-codegen/issues"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -25,7 +25,8 @@
   "license": "MIT",
   "scripts": {
     "docs": "typedoc --mode file --out docs",
-    "watch": "yarn lerna exec --scope @looker/sdk --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib/esm --source-maps --extensions .ts,.tsx --no-comments --watch'"
+    "watch": "yarn lerna exec --scope @looker/sdk --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib/esm --source-maps --extensions .ts,.tsx --no-comments --watch'",
+    "watch:cjs": "yarn lerna exec --scope @looker/sdk --stream 'BABEL_ENV=build_cjs babel src --root-mode upward --out-dir lib --source-maps --extensions .ts,.tsx --no-comments --watch'"
   },
   "bugs": {
     "url": "https://github.com/looker-open-source/sdk-codegen/issues"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2604,10 +2604,10 @@
     prettier "^2.2.1"
     typescript "4.1.2"
 
-"@looker/extension-sdk-react@0.10.3":
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/@looker/extension-sdk-react/-/extension-sdk-react-0.10.3.tgz#2031ae7651051c20960ac01c0b02eadd30069683"
-  integrity sha512-gco/NnDSWCKWV/bQvkumAgRTtxptTLkWSDUITecUZjpCMw98L1uUQBVoHObV02Gm3RKmGwFKgjK8JLKoObZeNg==
+"@looker/extension-sdk-react@0.10.4":
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/@looker/extension-sdk-react/-/extension-sdk-react-0.10.4.tgz#4d8924636a1f3a71465edbda3bda92815abbe3ca"
+  integrity sha512-pFVKdvonWYe5iVU1apKk14Y560kWrQ6rw6ncf1c5cUhvebaEnp8ygzEayGYtlxSvFFsZZ1nYJZeDvf9m/2CYxA==
   dependencies:
     ts-loader "^6.1.2"
 


### PR DESCRIPTION
There are now two watch commands
yarn watch - watches for changes and builds for browser based development
yarn watch:cjs - watches for changes and builds for node based development

In addition, updated extension-sdk-react package for extensions (fixes an issue with browser backward/forward buttons)