### PR TITLE
Fixed Python makeTheCall dictionary syntax

### DIFF
--- a/packages/sdk-codegen/src/codeGen.ts
+++ b/packages/sdk-codegen/src/codeGen.ts
@@ -167,8 +167,14 @@ export interface ICodeGen {
   /** argument separator string. Typically ', ' */
   argDelimiter: string
 
-  /** type properties/args expression separater. E.g ': ' for Typescript */
+  /** type properties/args expression separator. E.g ': ' for Typescript */
   argSetSep: string
+
+  /** hash type properties/args expression separator. E.g ': ' for Typescript */
+  hashSetSep: string
+
+  /** hash key quotes E.g '' for Typescript and '"' for Python */
+  hashKeyQuote: string
 
   /** parameter delimiter. Typically ",\n" */
   paramDelimiter: string
@@ -642,6 +648,7 @@ export abstract class CodeGen implements ICodeGen {
   fileExtension = '.code'
   argDelimiter = ', '
   argSetSep = ': '
+  hashSetSep = ': '
   paramDelimiter = ',\n'
   propDelimiter = '\n'
   enumDelimiter = ',\n'
@@ -652,6 +659,7 @@ export abstract class CodeGen implements ICodeGen {
   arrayClose = ']'
   hashOpen = '{'
   hashClose = '}'
+  hashKeyQuote = ''
   typeOpen = '{'
   typeClose = '}'
   useModelClassForTypes = false
@@ -934,7 +942,8 @@ export abstract class CodeGen implements ICodeGen {
     const bump = this.bumper(indent)
     Object.entries(val).forEach(([name, v]) => {
       const exp = this.anyValue(bump, v)
-      args.push(this.argSet(name, this.argSetSep, exp))
+      const key = `${this.hashKeyQuote}${name}${this.hashKeyQuote}`
+      args.push(this.argSet(key, this.hashSetSep, exp))
     })
     return this.argIndent(indent, args, this.hashOpen, this.hashClose)
   }

--- a/packages/sdk-codegen/src/python.gen.spec.ts
+++ b/packages/sdk-codegen/src/python.gen.spec.ts
@@ -1025,14 +1025,23 @@ class MergeFields(model.Model):
         const oneItem = [1]
         const threeItems = ['Abe', 'Zeb', token]
         const inputs: IDictionary<any> = {
+          /**
+           * The below key is quoted in the generated dictionary. This is a bug
+           * that might need addressing later on.
+           */
+          1: 'one',
+          '2': 'two',
           item: oneItem,
           items: threeItems,
           first: 1,
           second: 'two',
           third: false,
           token,
+          'foo.bar': 'foobar',
         }
         const expected = `{
+    "1": "one",
+    "2": "two",
     "item": [1],
     "items": [
         "Abe",
@@ -1050,7 +1059,8 @@ class MergeFields(model.Model):
         "access_token": "backstage",
         "token_type": "test",
         "expires_in": 10
-    }
+    },
+    "foo.bar": "foobar"
 }`
         const actual = gen.hashValue('', inputs)
         expect(actual).toEqual(expected)

--- a/packages/sdk-codegen/src/python.gen.spec.ts
+++ b/packages/sdk-codegen/src/python.gen.spec.ts
@@ -1006,10 +1006,10 @@ class MergeFields(model.Model):
     body=models.SqlQueryCreate(
         connection_name="looker",
         model_name="the_look",
-        vis_config=dict(
-            first=1,
-            second="two"
-        )
+        vis_config={
+            "first": 1,
+            "second": "two"
+        }
     ))`
       const actual = gen.makeTheCall(method, inputs)
       expect(actual).toEqual(expected)
@@ -1032,26 +1032,26 @@ class MergeFields(model.Model):
           third: false,
           token,
         }
-        const expected = `dict(
-    item=[1],
-    items=[
+        const expected = `{
+    "item": [1],
+    "items": [
         "Abe",
         "Zeb",
-        dict(
-            access_token="backstage",
-            token_type="test",
-            expires_in=10
-        )
+        {
+            "access_token": "backstage",
+            "token_type": "test",
+            "expires_in": 10
+        }
     ],
-    first=1,
-    second="two",
-    third=false,
-    token=dict(
-        access_token="backstage",
-        token_type="test",
-        expires_in=10
-    )
-)`
+    "first": 1,
+    "second": "two",
+    "third": false,
+    "token": {
+        "access_token": "backstage",
+        "token_type": "test",
+        "expires_in": 10
+    }
+}`
         const actual = gen.hashValue('', inputs)
         expect(actual).toEqual(expected)
       })

--- a/packages/sdk-codegen/src/python.gen.ts
+++ b/packages/sdk-codegen/src/python.gen.ts
@@ -54,8 +54,6 @@ export class PythonGen extends CodeGen {
   codeQuote = '"'
   typeOpen = '('
   typeClose = ')'
-  hashOpen = '{'
-  hashClose = '}'
   hashKeyQuote = '"'
   useModelClassForTypes = true
 

--- a/packages/sdk-codegen/src/python.gen.ts
+++ b/packages/sdk-codegen/src/python.gen.ts
@@ -47,7 +47,6 @@ export class PythonGen extends CodeGen {
   indentStr = '    '
   argDelimiter = `,\n${this.indentStr.repeat(3)}`
   argSetSep = '='
-  hashSetSep = ': '
   paramDelimiter = ',\n'
   propDelimiter = '\n'
   dataStructureDelimiter = ', '

--- a/packages/sdk-codegen/src/python.gen.ts
+++ b/packages/sdk-codegen/src/python.gen.ts
@@ -47,6 +47,7 @@ export class PythonGen extends CodeGen {
   indentStr = '    '
   argDelimiter = `,\n${this.indentStr.repeat(3)}`
   argSetSep = '='
+  hashSetSep = ': '
   paramDelimiter = ',\n'
   propDelimiter = '\n'
   dataStructureDelimiter = ', '
@@ -54,8 +55,9 @@ export class PythonGen extends CodeGen {
   codeQuote = '"'
   typeOpen = '('
   typeClose = ')'
-  hashOpen = 'dict('
-  hashClose = ')'
+  hashOpen = '{'
+  hashClose = '}'
+  hashKeyQuote = '"'
   useModelClassForTypes = true
 
   endTypeStr = ''
@@ -617,9 +619,5 @@ ${this.hooks.join('\n')}
 
   typeMapModels(type: IType) {
     return this.typeMap(type, 'models')
-  }
-
-  argSet(name: string, _sep: string, exp: string) {
-    return `${name}=${exp}`
   }
 }


### PR DESCRIPTION
### The Problem

Currently the Python generator defines dictionaries using the `dict()` function, e.g. `dict(k1 = "v1", k2 = "v2")`. 

This generates incorrect syntax when the key contains periods or other special characters like hyphens, as it requires it to be quoted, e.g. `dict("foo.bar" = "v1")`. Additionally, passing keyword arguments into `dict()` is risky if the keys are not valid Python identifiers, e.g. `import`. 

### Solution
Initialize dictionaries using curly braces as it works for all kinds of keys. 
- Added `hashKeyQuote` and `hashSetSep` attributes to `ICodeGen`
- Removed overriding `argSet` method in PythonGen

Note that currently we do not capture the key types and all keys are quoted. This is a bug that is unlikely to be experienced but might need fixing later on. See [here](https://github.com/looker-open-source/sdk-codegen/blob/e00f8f7d2d6d138232ed21be231788c7898b9184/packages/sdk-codegen/src/python.gen.spec.ts#L1028-L1032).