### PR TITLE
Added definition for a legacy Java SDK generator

### DIFF
--- a/packages/sdk-codegen-scripts/src/legacy.ts
+++ b/packages/sdk-codegen-scripts/src/legacy.ts
@@ -35,7 +35,9 @@ import { quit } from './nodeUtils'
     // Look for the Looker config section and only run that one
     const name = 'Looker'
     const props = config[name]
-    await runConfig(name, props)
+    const args = process.argv.slice(2)
+
+    await runConfig(name, props, args)
   } catch (e) {
     quit(e)
   }

--- a/packages/sdk-codegen-scripts/src/legacyGenerator.ts
+++ b/packages/sdk-codegen-scripts/src/legacyGenerator.ts
@@ -77,11 +77,16 @@ const generate = async (
 
 /**
  * Generate all languages for the specified configuration
- * @param {string} name configuration name
- * @param {ISDKConfigProps} props SDK configuration properties
- * @returns {Promise<any[]>} generation promises
+ * @param name configuration name
+ * @param props SDK configuration properties
+ * @param targets Optional array of languages to generate
+ * @returns generation promises
  */
-export const runConfig = async (name: string, props: ISDKConfigProps) => {
+export const runConfig = async (
+  name: string,
+  props: ISDKConfigProps,
+  targets: string[] = []
+) => {
   log(`processing ${name} configuration ...`)
   const apiVersion = defaultApiVersion(props)
   props.api_version = apiVersion
@@ -91,9 +96,14 @@ export const runConfig = async (name: string, props: ISDKConfigProps) => {
 
   const results: any[] = []
   for (const language of languages) {
-    const tag = `${name} API ${language.language} version ${apiVersion}`
-    log(`generating ${tag} ...`)
-    results.push(await generate(openApiFile, language, props))
+    if (
+      targets.length === 0 ||
+      targets.find((t) => t.localeCompare(language.language) === 0)
+    ) {
+      const tag = `${name} API ${language.language} version ${apiVersion}`
+      log(`generating ${tag} ...`)
+      results.push(await generate(openApiFile, language, props))
+    }
   }
 
   return results

--- a/packages/sdk-codegen/src/codeGenerators.ts
+++ b/packages/sdk-codegen/src/codeGenerators.ts
@@ -89,10 +89,16 @@ export const Generators: Array<IGeneratorSpec> = [
     factory: (api: ApiModel, versions?: IVersionInfo) =>
       new GoGen(api, versions),
     language: 'Go',
-    legacy: 'go',
     options: '-papiPackage=Looker -ppackageName=looker',
     extension: /\.go/gi,
   },
+  {
+    language: 'java',
+    legacy: 'java',
+    options: '-papiPackage=Looker -ppackageName=looker',
+    extension: /\.java/gi,
+  },
+
   // {
   //   language: 'php',
   //   legacy: 'php',


### PR DESCRIPTION
```sh
yarn
yarn build
yarn legacy java
````

will generate a Java SDK to `/api/4.0/java` using the API 4.0 specification

The package name arguments may need additional tweaks. I didn't attempt to build the SDK, just invoke the OpenAPI generator for Java to emit it.