### PR TITLE
refactor: remove sdk-codegen's dep on sdk

### DIFF
--- a/packages/sdk-codegen/package.json
+++ b/packages/sdk-codegen/package.json
@@ -32,7 +32,6 @@
     "watch:cjs": "yarn lerna exec --scope @looker/sdk-codegen --stream 'BABEL_ENV=build_cjs babel src --root-mode upward --out-dir lib --source-maps --extensions .ts,.tsx --no-comments --watch'"
   },
   "dependencies": {
-    "@looker/sdk": "^21.0.7",
     "@looker/sdk-codegen-utils": "^21.0.7",
     "@looker/sdk-node": "^21.0.7",
     "@looker/sdk-rtl": "^21.0.7",

--- a/packages/sdk-codegen/src/python.gen.spec.ts
+++ b/packages/sdk-codegen/src/python.gen.spec.ts
@@ -24,17 +24,6 @@
 
  */
 
-import {
-  IAccessToken,
-  IDictionary,
-  IMergeQuerySourceQuery,
-  IRequestAllUsers,
-  IRequestCreateQueryTask,
-  IWriteLookWithQuery,
-  IWriteMergeQuery,
-  ISqlQueryCreate,
-  ResultFormat,
-} from '@looker/sdk'
 import { DelimArray } from '@looker/sdk-rtl'
 import { TestConfig } from './testUtils'
 import { PythonGen } from './python.gen'
@@ -861,7 +850,7 @@ class MergeFields(model.Model):
     })
 
     it('assigns a body param', () => {
-      const body: IWriteLookWithQuery = {
+      const body = {
         title: 'test title',
         description: 'gen test',
         query: {
@@ -889,10 +878,10 @@ class MergeFields(model.Model):
     })
 
     it('assigns an enum', () => {
-      const inputs: IRequestCreateQueryTask = {
+      const inputs = {
         body: {
           query_id: 1,
-          result_format: ResultFormat.csv,
+          result_format: 'csv',
         },
       }
       const method = apiTestModel.methods.create_query_task
@@ -906,7 +895,7 @@ class MergeFields(model.Model):
     })
 
     it('assigns a DelimArray', () => {
-      const inputs: IRequestAllUsers = {
+      const inputs = {
         ids: new DelimArray<number>([1, 2, 3]),
       }
       const method = apiTestModel.methods.all_users
@@ -917,7 +906,7 @@ class MergeFields(model.Model):
     })
 
     it('assigns a DelimArray', () => {
-      const inputs: IRequestAllUsers = {
+      const inputs = {
         ids: new DelimArray<number>([1, 2, 3]),
       }
       const method = apiTestModel.methods.all_users
@@ -928,7 +917,7 @@ class MergeFields(model.Model):
     })
 
     it('assigns simple and complex arrays', () => {
-      const body: IWriteMergeQuery = {
+      const body = {
         column_limit: '5',
         pivots: ['one', 'two', 'three'],
         sorts: ['a'],
@@ -995,7 +984,7 @@ class MergeFields(model.Model):
     })
 
     it('assigns dictionaries', () => {
-      const query: ISqlQueryCreate = {
+      const query = {
         connection_name: 'looker',
         model_name: 'the_look',
         vis_config: { first: 1, second: 'two' },
@@ -1017,14 +1006,14 @@ class MergeFields(model.Model):
 
     describe('hashValue', () => {
       it('assigns a hash with heterogeneous values', () => {
-        const token: IAccessToken = {
+        const token = {
           access_token: 'backstage',
           token_type: 'test',
           expires_in: 10,
         }
         const oneItem = [1]
         const threeItems = ['Abe', 'Zeb', token]
-        const inputs: IDictionary<any> = {
+        const inputs = {
           /**
            * The below key is quoted in the generated dictionary. This is a bug
            * that might need addressing later on.
@@ -1068,7 +1057,7 @@ class MergeFields(model.Model):
     })
     describe('assignType', () => {
       it('assigns a complex type', () => {
-        const inputs: IMergeQuerySourceQuery = {
+        const inputs = {
           name: 'first query',
           query_id: 1,
           merge_fields: [

--- a/packages/sdk-codegen/src/specConverter.spec.ts
+++ b/packages/sdk-codegen/src/specConverter.spec.ts
@@ -27,7 +27,6 @@
 import { readFileSync } from 'fs'
 import { isEmpty } from 'lodash'
 import { NodeSettingsIniFile, LookerNodeSDK } from '@looker/sdk-node'
-import { environmentPrefix } from '@looker/sdk'
 import {
   fixConversion,
   openApiStyle,
@@ -407,11 +406,7 @@ const apiFile = `${config.rootPath}spec/Looker.4.0.oas.json`
 const swaggerSource = readFileSync(swaggerFile, 'utf-8')
 const fullSwagger = JSON.parse(swaggerSource)
 const apiSource = readFileSync(apiFile, 'utf-8')
-const settings = new NodeSettingsIniFile(
-  environmentPrefix,
-  config.localIni,
-  'Looker'
-)
+const settings = new NodeSettingsIniFile('LOOKERSDK', config.localIni, 'Looker')
 const sdk = LookerNodeSDK.init40(settings)
 
 describe('spec conversion', () => {

--- a/packages/sdk-codegen/src/typescript.gen.spec.ts
+++ b/packages/sdk-codegen/src/typescript.gen.spec.ts
@@ -24,17 +24,6 @@
 
  */
 
-import {
-  IRequestAllUsers,
-  IRequestCreateQueryTask,
-  IWriteLookWithQuery,
-  ResultFormat,
-  IWriteMergeQuery,
-  IMergeQuerySourceQuery,
-  ISqlQueryCreate,
-  IDictionary,
-  IAccessToken,
-} from '@looker/sdk'
 import { DelimArray } from '@looker/sdk-rtl'
 import { TestConfig } from './testUtils'
 import { TypescriptGen } from './typescript.gen'
@@ -76,7 +65,7 @@ describe('typescript generator', () => {
     })
 
     it('returns DelimArray', () => {
-      const inputs: IRequestAllUsers = {
+      const inputs = {
         ids: new DelimArray<number>([1, 2, 3]),
       }
       const actual = trimInputs(inputs)
@@ -213,7 +202,7 @@ query_task_ids: DelimArray<string>`)
     })
 
     it('assigns a body param', () => {
-      const body: IWriteLookWithQuery = {
+      const body = {
         title: 'test title',
         description: 'gen test',
         query: {
@@ -251,10 +240,10 @@ query_task_ids: DelimArray<string>`)
     })
 
     it('assigns an enum', () => {
-      const inputs: IRequestCreateQueryTask = {
+      const inputs = {
         body: {
           query_id: 1,
-          result_format: ResultFormat.csv,
+          result_format: 'csv',
         },
       }
       const method = apiTestModel.methods.create_query_task
@@ -270,7 +259,7 @@ query_task_ids: DelimArray<string>`)
     })
 
     it('assigns a DelimArray', () => {
-      const inputs: IRequestAllUsers = {
+      const inputs = {
         ids: new DelimArray<number>([1, 2, 3]),
       }
       const method = apiTestModel.methods.all_users
@@ -283,7 +272,7 @@ query_task_ids: DelimArray<string>`)
     })
 
     it('assigns simple and complex arrays', () => {
-      const body: IWriteMergeQuery = {
+      const body = {
         pivots: ['one', 'two', 'three'],
         sorts: ['a'],
         source_queries: [
@@ -350,7 +339,7 @@ query_task_ids: DelimArray<string>`)
     })
 
     it('assigns dictionaries', () => {
-      const query: ISqlQueryCreate = {
+      const query = {
         connection_name: 'looker',
         model_name: 'the_look',
         vis_config: { first: 1, second: 'two' },
@@ -372,14 +361,14 @@ query_task_ids: DelimArray<string>`)
 
     describe('hashValue', () => {
       it('assigns a hash with heterogeneous values', () => {
-        const token: IAccessToken = {
+        const token = {
           access_token: 'backstage',
           token_type: 'test',
           expires_in: 10,
         }
         const oneItem = [1]
         const threeItems = ['Abe', 'Zeb', token]
-        const inputs: IDictionary<any> = {
+        const inputs = {
           item: oneItem,
           items: threeItems,
           first: 1,
@@ -413,7 +402,7 @@ query_task_ids: DelimArray<string>`)
     })
     describe('assignType', () => {
       it('assigns a complex type', () => {
-        const inputs: IMergeQuerySourceQuery = {
+        const inputs = {
           name: 'first query',
           query_id: 1,
           merge_fields: [
@@ -441,7 +430,7 @@ query_task_ids: DelimArray<string>`)
     })
     describe('arrayValue', () => {
       it('assigns complex arrays', () => {
-        const sourceQueries: IMergeQuerySourceQuery[] = [
+        const sourceQueries = [
           {
             name: 'first query',
             query_id: 1,


### PR DESCRIPTION
Trying to simplify the dependency graph just a tad. Currently sdk is not
needed by sdk-codegen but if we do need it in the future I'd suggest
we copy in by hand the required interfaces/values etc