### PR TITLE
allow id_token as response_type

### DIFF
--- a/packages/extension-sdk/src/connect/extension_host_api.ts
+++ b/packages/extension-sdk/src/connect/extension_host_api.ts
@@ -492,6 +492,7 @@ export class ExtensionHostApiImpl implements ExtensionHostApi {
     }
     if (
       authParameters.response_type !== 'token' &&
+      authParameters.response_type !== 'id_token' &&
       authParameters.response_type !== 'code'
     ) {
       return `invalid response_type, must be token or code, ${authParameters.response_type}`


### PR DESCRIPTION
allow id_token as response_type as the below example:

https://developer.okta.com/docs/guides/implement-implicit/use-flow/

GCP API gateway works only with id_token