### PR TITLE
chore: configure semantic PRs to only care about the PR title

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,5 @@
+# Config file for Semantic Pull Requests Probot
+# See https://github.com/probot/semantic-pull-requests
+
+# Always validate the PR title, and ignore the commits
+titleOnly: true


### PR DESCRIPTION
Since we always squash/merge, it is really the PR title we are about more
than individual commit titles. On that note, we should consider
only allowing squash/merge on sdk-codegen