### PR TITLE
docs: Linkify the link for setting environment variable in Readme

### DIFF
--- a/python/README.rst
+++ b/python/README.rst
@@ -98,7 +98,7 @@ Configuring the SDK
 ===================
 
 The SDK supports configuration through a ``.ini`` file on disk as well
-as setting environment variables <https://github.com/looker-open-source/sdk-codegen#environment-variable-configuration> (the latter override the former).
+as `setting environment variables <https://github.com/looker-open-source/sdk-codegen#environment-variable-configuration>`_ (the latter override the former).
 
 **Note**: The ``.ini`` configuration for the Looker SDK is a sample
 implementation intended to speed up the initial development of python


### PR DESCRIPTION
The paragraph looks a bit weird. Perhaps the "Setting environment variables" was meant to be linked?

![Screen Shot 2021-03-18 at 2 31 21 PM](https://user-images.githubusercontent.com/5844587/111700476-aed79280-87f6-11eb-8b58-ce96d7994ca5.png)
