### PR TITLE
feat: adds independent scrolling to apix windows

### DIFF
--- a/packages/api-explorer/src/ApiExplorer.tsx
+++ b/packages/api-explorer/src/ApiExplorer.tsx
@@ -98,7 +98,7 @@ const ApiExplorer: FC<ApiExplorerProps> = ({
               specDispatch={specDispatch}
               toggleNavigation={toggleNavigation}
             />
-            <Layout hasAside>
+            <Layout hasAside height={'100%'}>
               {hasNavigation && (
                 <AsideBorder pt="large" width="20rem">
                   <SideNav api={spec.api} specKey={spec.key} />

--- a/packages/api-explorer/src/components/SideNav/SideNav.tsx
+++ b/packages/api-explorer/src/components/SideNav/SideNav.tsx
@@ -118,7 +118,7 @@ export const SideNav: FC<SideNavProps> = ({ api, specKey }) => {
         <Tab>Methods ({methodCount})</Tab>
         <Tab>Types ({typeCount})</Tab>
       </TabList>
-      <TabPanels {...tabs} pt="xsmall">
+      <TabPanels {...tabs} pt="xsmall" height={'90%'} overflowY={'scroll'}>
         <TabPanel>
           <SideNavTags tags={tags} specKey={specKey} />
         </TabPanel>

--- a/packages/api-explorer/src/scenes/HomeScene/HomeScene.tsx
+++ b/packages/api-explorer/src/scenes/HomeScene/HomeScene.tsx
@@ -41,7 +41,7 @@ export const HomeScene: FC<DocHomeProps> = ({ api }) => {
   const { specKey } = useParams<DocHomeParams>()
 
   return (
-    <Section p="xxlarge">
+    <Section p="xxlarge" style={{ height: '100%', overflowY: 'visible' }}>
       <DocTitle>{`Looker API ${specKey} Reference`}</DocTitle>
       {api.spec.info.description && (
         <DocMarkdown source={api.spec.info.description} specKey={specKey} />

--- a/packages/api-explorer/src/scenes/MethodScene/MethodScene.tsx
+++ b/packages/api-explorer/src/scenes/MethodScene/MethodScene.tsx
@@ -86,7 +86,11 @@ export const MethodScene: FC<DocMethodProps> = ({ api }) => {
 
   return (
     <>
-      <Section id="top" p="xxlarge">
+      <Section
+        id="top"
+        p="xxlarge"
+        style={{ height: '100%', overflowY: 'scroll' }}
+      >
         <Space between>
           <DocTitle>{method.summary}</DocTitle>
           {runItToggle}

--- a/packages/api-explorer/src/scenes/TagScene/TagScene.tsx
+++ b/packages/api-explorer/src/scenes/TagScene/TagScene.tsx
@@ -59,7 +59,7 @@ export const TagScene: FC<TagSceneProps> = ({ api }) => {
   }, [methodTag])
 
   return (
-    <Section p="xxlarge">
+    <Section p="xxlarge" style={{ height: '100%', overflowY: 'scroll' }}>
       <DocTitle>{`${tag.name}: ${tag.description}`}</DocTitle>
       <ButtonToggle mb="small" mt="xlarge" value={value} onChange={setValue}>
         <ButtonItem key="ALL" px="large" py="xsmall">

--- a/packages/api-explorer/src/scenes/TypeScene/TypeScene.tsx
+++ b/packages/api-explorer/src/scenes/TypeScene/TypeScene.tsx
@@ -46,7 +46,7 @@ export const TypeScene: FC<DocTypeProps> = ({ api }) => {
   const seeMethods = methodRefs(api, type.methodRefs)
 
   return (
-    <Section p="xxlarge">
+    <Section p="xxlarge" style={{ height: '100%', overflowY: 'scroll' }}>
       <DocTitle>{type.name}</DocTitle>
       <ExploreType type={type} />
       <DocReferences


### PR DESCRIPTION
https://looker.atlassian.net/browse/EMBED-1481

https://drive.google.com/file/d/1HMPa5yty7K_8CDyZ7ZOLXjsqDIy-1hjo/view?usp=sharing&resourcekey=0-9Y8Dh84M7gtV2SV439bPng

This change adds independent scrolling to the various windows within the extension. The problem with fixing side scrolling as assigned is that the rest of the content still hangs down the page. This change makes sure the windows do not exceed 100% page height and scroll as expected