### PR TITLE
feat: adds scrolling to frame elements

### DIFF
--- a/packages/api-explorer/src/ApiExplorer.tsx
+++ b/packages/api-explorer/src/ApiExplorer.tsx
@@ -98,7 +98,7 @@ const ApiExplorer: FC<ApiExplorerProps> = ({
               specDispatch={specDispatch}
               toggleNavigation={toggleNavigation}
             />
-            <Layout hasAside>
+            <Layout hasAside height={'100%'}>
               {hasNavigation && (
                 <AsideBorder pt="large" width="20rem">
                   <SideNav api={spec.api} specKey={spec.key} />

--- a/packages/api-explorer/src/components/DocMarkdown/DocMarkdown.tsx
+++ b/packages/api-explorer/src/components/DocMarkdown/DocMarkdown.tsx
@@ -64,7 +64,7 @@ export const DocMarkdown: FC<DocMarkdownProps> = ({ source, specKey }) => {
   }
 
   return (
-    <div onClick={handleClick}>
+    <span onClick={handleClick}>
       <ReactMarkdown
         source={highlightMarkdown(pattern, source)}
         escapeHtml={false}
@@ -84,6 +84,6 @@ export const DocMarkdown: FC<DocMarkdownProps> = ({ source, specKey }) => {
           tableCell: TableCell,
         }}
       />
-    </div>
+    </span>
   )
 }

--- a/packages/api-explorer/src/components/DocMarkdown/DocMarkdown.tsx
+++ b/packages/api-explorer/src/components/DocMarkdown/DocMarkdown.tsx
@@ -64,7 +64,7 @@ export const DocMarkdown: FC<DocMarkdownProps> = ({ source, specKey }) => {
   }
 
   return (
-    <span onClick={handleClick}>
+    <div onClick={handleClick}>
       <ReactMarkdown
         source={highlightMarkdown(pattern, source)}
         escapeHtml={false}
@@ -84,6 +84,6 @@ export const DocMarkdown: FC<DocMarkdownProps> = ({ source, specKey }) => {
           tableCell: TableCell,
         }}
       />
-    </span>
+    </div>
   )
 }

--- a/packages/api-explorer/src/components/SideNav/SideNav.tsx
+++ b/packages/api-explorer/src/components/SideNav/SideNav.tsx
@@ -118,7 +118,7 @@ export const SideNav: FC<SideNavProps> = ({ api, specKey }) => {
         <Tab>Methods ({methodCount})</Tab>
         <Tab>Types ({typeCount})</Tab>
       </TabList>
-      <TabPanels {...tabs} pt="xsmall" height={'90%'} overflowY={'scroll'}>
+      <TabPanels {...tabs} pt="xsmall" height={'90%'} overflow={'auto'}>
         <TabPanel>
           <SideNavTags tags={tags} specKey={specKey} />
         </TabPanel>

--- a/packages/api-explorer/src/components/SideNav/SideNav.tsx
+++ b/packages/api-explorer/src/components/SideNav/SideNav.tsx
@@ -118,7 +118,7 @@ export const SideNav: FC<SideNavProps> = ({ api, specKey }) => {
         <Tab>Methods ({methodCount})</Tab>
         <Tab>Types ({typeCount})</Tab>
       </TabList>
-      <TabPanels {...tabs} pt="xsmall">
+      <TabPanels {...tabs} pt="xsmall" height={'90%'} overflowY={'scroll'}>
         <TabPanel>
           <SideNavTags tags={tags} specKey={specKey} />
         </TabPanel>

--- a/packages/api-explorer/src/scenes/HomeScene/HomeScene.tsx
+++ b/packages/api-explorer/src/scenes/HomeScene/HomeScene.tsx
@@ -41,7 +41,7 @@ export const HomeScene: FC<DocHomeProps> = ({ api }) => {
   const { specKey } = useParams<DocHomeParams>()
 
   return (
-    <Section p="xxlarge" style={{ height: '100%', overflowY: 'visible' }}>
+    <Section p="xxlarge" style={{ height: '100%', overflow: 'auto' }}>
       <DocTitle>{`Looker API ${specKey} Reference`}</DocTitle>
       {api.spec.info.description && (
         <DocMarkdown source={api.spec.info.description} specKey={specKey} />

--- a/packages/api-explorer/src/scenes/HomeScene/HomeScene.tsx
+++ b/packages/api-explorer/src/scenes/HomeScene/HomeScene.tsx
@@ -41,7 +41,7 @@ export const HomeScene: FC<DocHomeProps> = ({ api }) => {
   const { specKey } = useParams<DocHomeParams>()
 
   return (
-    <Section p="xxlarge">
+    <Section p="xxlarge" style={{ height: '100%', overflowY: 'visible' }}>
       <DocTitle>{`Looker API ${specKey} Reference`}</DocTitle>
       {api.spec.info.description && (
         <DocMarkdown source={api.spec.info.description} specKey={specKey} />

--- a/packages/api-explorer/src/scenes/MethodScene/MethodScene.tsx
+++ b/packages/api-explorer/src/scenes/MethodScene/MethodScene.tsx
@@ -65,10 +65,12 @@ export const MethodScene: FC<DocMethodProps> = ({ api }) => {
   const { methodName, specKey } = useParams<DocMethodParams>()
   const { value, toggle } = useToggle()
   const [method, setMethod] = useState(api.methods[methodName])
+  const [scrollPx, setScrollPx] = useState(0)
   const seeTypes = typeRefs(api, method.customTypes)
 
   useEffect(() => {
     setMethod(api.methods[methodName])
+    setScrollPx(0)
   }, [api, methodName])
 
   const { colors } = useContext(ThemeContext)
@@ -84,12 +86,14 @@ export const MethodScene: FC<DocMethodProps> = ({ api }) => {
     </RunItButton>
   )
 
+  document.getElementById('top')?.scrollTo(scrollPx, 0)
+
   return (
     <>
       <Section
         id="top"
         p="xxlarge"
-        style={{ height: '100%', overflowY: 'scroll' }}
+        style={{ height: '100%', overflow: 'auto' }}
       >
         <Space between>
           <DocTitle>{method.summary}</DocTitle>

--- a/packages/api-explorer/src/scenes/MethodScene/MethodScene.tsx
+++ b/packages/api-explorer/src/scenes/MethodScene/MethodScene.tsx
@@ -86,7 +86,11 @@ export const MethodScene: FC<DocMethodProps> = ({ api }) => {
 
   return (
     <>
-      <Section id="top" p="xxlarge">
+      <Section
+        id="top"
+        p="xxlarge"
+        style={{ height: '100%', overflowY: 'scroll' }}
+      >
         <Space between>
           <DocTitle>{method.summary}</DocTitle>
           {runItToggle}

--- a/packages/api-explorer/src/scenes/TagScene/TagScene.tsx
+++ b/packages/api-explorer/src/scenes/TagScene/TagScene.tsx
@@ -52,14 +52,22 @@ export const TagScene: FC<TagSceneProps> = ({ api }) => {
   )!
   const operations = getOperations(methods)
   const [value, setValue] = useState('ALL')
+  const [scrollPx, setScrollPx] = useState(0)
 
   useEffect(() => {
     /** Reset ButtonToggle value on route change */
     setValue('ALL')
+    setScrollPx(0)
   }, [methodTag])
 
+  document.getElementById('top')?.scrollTo(scrollPx, 0)
+
   return (
-    <Section p="xxlarge" style={{ height: '100%', overflowY: 'scroll' }}>
+    <Section
+      p="xxlarge"
+      id={'top'}
+      style={{ height: '100%', overflow: 'auto' }}
+    >
       <DocTitle>{`${tag.name}: ${tag.description}`}</DocTitle>
       <ButtonToggle mb="small" mt="xlarge" value={value} onChange={setValue}>
         <ButtonItem key="ALL" px="large" py="xsmall">

--- a/packages/api-explorer/src/scenes/TagScene/TagScene.tsx
+++ b/packages/api-explorer/src/scenes/TagScene/TagScene.tsx
@@ -59,7 +59,7 @@ export const TagScene: FC<TagSceneProps> = ({ api }) => {
   }, [methodTag])
 
   return (
-    <Section p="xxlarge">
+    <Section p="xxlarge" style={{ height: '100%', overflowY: 'scroll' }}>
       <DocTitle>{`${tag.name}: ${tag.description}`}</DocTitle>
       <ButtonToggle mb="small" mt="xlarge" value={value} onChange={setValue}>
         <ButtonItem key="ALL" px="large" py="xsmall">

--- a/packages/api-explorer/src/scenes/TypeScene/TypeScene.tsx
+++ b/packages/api-explorer/src/scenes/TypeScene/TypeScene.tsx
@@ -24,7 +24,7 @@
 
  */
 
-import React, { FC } from 'react'
+import React, { FC, useState, useEffect } from 'react'
 import { Section } from '@looker/components'
 import { typeRefs, methodRefs, ApiModel } from '@looker/sdk-codegen'
 import { useParams } from 'react-router-dom'
@@ -44,9 +44,16 @@ export const TypeScene: FC<DocTypeProps> = ({ api }) => {
   const type = api.types[typeName]
   const seeTypes = typeRefs(api, type.customTypes)
   const seeMethods = methodRefs(api, type.methodRefs)
+  const [scrollPx, setScrollPx] = useState(0)
+
+  useEffect(() => {
+    setScrollPx(0)
+  }, [api, type])
+
+  document.getElementById('top')?.scrollTo(scrollPx, 0)
 
   return (
-    <Section p="xxlarge" style={{ height: '100%', overflowY: 'scroll' }}>
+    <Section id="top" p="xxlarge" style={{ height: '100%', overflow: 'auto' }}>
       <DocTitle>{type.name}</DocTitle>
       <ExploreType type={type} />
       <DocReferences

--- a/packages/api-explorer/src/scenes/TypeScene/TypeScene.tsx
+++ b/packages/api-explorer/src/scenes/TypeScene/TypeScene.tsx
@@ -46,7 +46,7 @@ export const TypeScene: FC<DocTypeProps> = ({ api }) => {
   const seeMethods = methodRefs(api, type.methodRefs)
 
   return (
-    <Section p="xxlarge">
+    <Section p="xxlarge" style={{ height: '100%', overflowY: 'scroll' }}>
       <DocTitle>{type.name}</DocTitle>
       <ExploreType type={type} />
       <DocReferences


### PR DESCRIPTION
https://looker.atlassian.net/browse/EMBED-1481

https://drive.google.com/file/d/1n7tL5mVMWUqqjSdkM8tt-pKJvHE24BeQ/view?usp=sharing&resourcekey=0-uKp3TXkcVWDaMBPILkHKqA

This change adds independent scrolling to the various windows within the extension. The problem with fixing side scrolling as assigned is that the rest of the content still hangs down the page. This change makes sure the windows do not exceed 100% page height and scroll as expected
