### PR TITLE
chore: Update deprecated sdk-codegen package text

### DIFF
--- a/packages/sdk-codegen-scripts/README.md
+++ b/packages/sdk-codegen-scripts/README.md
@@ -4,7 +4,7 @@ This package contains the Node-based scripts used by the Looker SDK Codegen proj
 
 It has node dependencies, so it cannot be used in the browser.
 
-**DEPRECATED AND NOT SUPPORTED**: Looker does not support direct use of this package, other than via direct use in the
+**DEPRECATED AND NOT SUPPORTED**: Looker does not support direct use of this package, other than via indirect use in the
 [SDK Codegen project](https://github.com/looker-open-source/sdk-codegen) repository.
 
 ## Scripts

--- a/packages/sdk-codegen-utils/README.md
+++ b/packages/sdk-codegen-utils/README.md
@@ -6,7 +6,7 @@ The code in this package is really trivial and should not be used directly in yo
 
 This package has no node dependencies.
 
-**DEPRECATED AND NOT SUPPORTED**: Looker does not support direct use of this package, other than via direct use in the
+**DEPRECATED AND NOT SUPPORTED**: Looker does not support direct use of this package, other than via indirect use in the
 [SDK Codegen project](https://github.com/looker-open-source/sdk-codegen) repository.
 
 See the [SDK Codegen project](https://github.com/looker-open-source/sdk-codegen) repository for more information.

--- a/packages/sdk-codegen/README.md
+++ b/packages/sdk-codegen/README.md
@@ -4,7 +4,7 @@ This package contains the OpenAPI analysis files, and all source code necessary 
 
 This package can be used in a browser because it has no node dependencies.
 
-**DEPRECATED AND NOT SUPPORTED**: Looker does not support direct use of this package, other than via direct use in the
+**DEPRECATED AND NOT SUPPORTED**: Looker does not support direct use of this package, other than via indirect use in the
 [SDK Codegen project](https://github.com/looker-open-source/sdk-codegen) repository.
 
 ## Supported languages


### PR DESCRIPTION
changed "direct use" to "indirect use"
