### PR TITLE
fix: legacy generator was broken

### DIFF
--- a/packages/sdk-codegen-scripts/src/fetchSpec.ts
+++ b/packages/sdk-codegen-scripts/src/fetchSpec.ts
@@ -285,6 +285,7 @@ export const getVersionInfo = async (
 /**
  * Fetch (if needed) and convert a Swagger API specification to OpenAPI
  * @param name base name of the target file
+ * @param spec specification derived
  * @param props SDK configuration properties to use
  * @param force true to force re-conversion of the spec
  * @returns {Promise<string>} name of converted OpenAPI file

--- a/packages/sdk-codegen-scripts/src/legacyGenerator.ts
+++ b/packages/sdk-codegen-scripts/src/legacyGenerator.ts
@@ -93,7 +93,7 @@ export const runConfig = async (
   log(`processing ${name} configuration ...`)
   const apiVersion = defaultApiVersion(props)
   props.api_version = apiVersion
-  const lookerVersions = fetchLookerVersions(props)
+  const lookerVersions = await fetchLookerVersions(props)
   const specs = await getSpecsFromVersions(lookerVersions as IApiVersion)
   const openApiFile = await logConvertSpec(name, specs[apiVersion], props)
   const languages = legacyLanguages()

--- a/packages/sdk-codegen/src/codeGenerators.ts
+++ b/packages/sdk-codegen/src/codeGenerators.ts
@@ -98,24 +98,27 @@ export const Generators: Array<IGeneratorSpec> = [
     options: '-papiPackage=Looker -ppackageName=looker',
     extension: /\.java/gi,
   },
-
-  // {
-  //   language: 'php',
-  //   legacy: 'php',
-  //   options: '-papiPackage=Looker -ppackageName=looker'
-  // },
+  {
+    language: 'php',
+    legacy: 'php',
+    options: '-papiPackage=Looker -ppackageName=looker',
+    extension: /\.php/gi,
+  },
   // {
   //   language: 'R',
   //   legacy: 'r'
   //   options: '-papiPackage=Looker -ppackageName=looker'
+  //   extension: /\.r/gi,
   // },
   // {
   //   language: 'Ruby',
   //   options: '-papiPackage=Looker -ppackageName=looker'
+  //   extension: /\.rb/gi,
   // },
   // {
   //   language: 'Rust',
   //   options: '-papiPackage=Looker -ppackageName=looker'
+  //   extension: /\.rs/gi,
   // },
 ]
 


### PR DESCRIPTION
- Fixed the issue with the legacy generator (it was missing an `await` after recent spec processing changes)
- Corrected the php legacy language declaration and left it active
- Corrected legacy language declarations that are still commented out

update and use the legacy generator with:
```sh
yarn && yarn build
yarn legacy php
```

Fixes #442 🦕
