### PR TITLE
feat: added -n | --nostreams to code generator options

### DIFF
--- a/packages/sdk-codegen-scripts/README.md
+++ b/packages/sdk-codegen-scripts/README.md
@@ -9,7 +9,7 @@ It has node dependencies, so it cannot be used in the browser.
 
 ## Scripts
 
-* [sdkGen.ts](src/sdkGen.ts) is the script for the Looker SDK code generator. Run `yarn gen -h` to see generation options.
+* [sdkGen.ts](src/sdkGen.ts) is the script for the Looker SDK code generator. Run `yarn gen -h` to see options.
 * [legacy.ts](src/legacy.ts) for the OpenAPI legacy code generator
 * [specConvert.ts](src/specConvert.ts) converts a swagger (OpenAPI 2.x) file to OpenAPI 3.x
 * [yamlToJson.ts](src/yamlToJson.ts) converts a `YAML` file to a pretty-printed `JSON` file

--- a/packages/sdk-codegen-scripts/src/sdkGen.ts
+++ b/packages/sdk-codegen-scripts/src/sdkGen.ts
@@ -26,7 +26,7 @@
 
 import * as fs from 'fs'
 import path from 'path'
-import { danger, log } from '@looker/sdk-codegen-utils'
+import { danger, log, warn } from '@looker/sdk-codegen-utils'
 import { IVersionInfo } from '@looker/sdk-codegen'
 import { MethodGenerator, StreamGenerator, TypeGenerator } from './sdkGenerator'
 import { FilesFormatter } from './reformatter'
@@ -52,7 +52,7 @@ export const writeCodeFile = (fileName: string, content: string): string => {
 }
 ;(async () => {
   const config = await prepGen(process.argv.slice(2))
-  const { props, languages, lookerVersion, lastApi } = config
+  const { props, languages, lookerVersion, lastApi, noStreams } = config
 
   // load the specifications and create the unique keys in case of spec API version overlap
   const specs = await loadSpecs(config)
@@ -94,11 +94,15 @@ export const writeCodeFile = (fileName: string, content: string): string => {
         writeCodeFile(gen.sdkFileName(`methods`), output)
 
         if (gen.willItStream) {
-          // Generate streaming method declarations
-          log(`generating ${api} streaming methods ...`)
-          const s = new StreamGenerator(apiModel, gen)
-          const output = s.render(gen.indentStr)
-          writeCodeFile(gen.sdkFileName(`streams`), output)
+          if (noStreams) {
+            warn(`SKIPPING ${api} streaming methods ...`)
+          } else {
+            // Generate streaming method declarations
+            log(`generating ${api} streaming methods ...`)
+            const s = new StreamGenerator(apiModel, gen)
+            const output = s.render(gen.indentStr)
+            writeCodeFile(gen.sdkFileName(`streams`), output)
+          }
         }
 
         log(`generating ${api} models ...`)

--- a/packages/sdk-codegen-scripts/src/sdkGen.ts
+++ b/packages/sdk-codegen-scripts/src/sdkGen.ts
@@ -51,7 +51,13 @@ export const writeCodeFile = (fileName: string, content: string): string => {
   return fileName
 }
 ;(async () => {
-  const config = await prepGen(process.argv.slice(2))
+  let config
+  try {
+    config = await prepGen(process.argv.slice(2))
+  } catch (e) {
+    quit(e)
+  }
+  if (!config) return
   const { props, languages, lookerVersion, lastApi, noStreams } = config
 
   // load the specifications and create the unique keys in case of spec API version overlap

--- a/packages/sdk-codegen-scripts/src/utils.ts
+++ b/packages/sdk-codegen-scripts/src/utils.ts
@@ -65,10 +65,29 @@ export interface IGenProps {
   apis: string[]
   /** Last API version */
   lastApi: string
+  /** Skip generating streams files? */
+  noStreams: boolean
 }
 
 const generatorHelp = () => {
-  log(`sdkGen [languages...] [-v|--versions <versions file>] [-h|--help]`)
+  log(
+    `sdkGen [languages...] [-v|--versions <versions file>] [-n|--nostreams] [-h|--help]
+  languages...:   zero or more language specifiers separated by space or comma. Defaults to 'all'
+  -v|--versions:  location of a JSON versions file in ILookerVersions format to read for getting specs
+  -n|--nostreams: skip generation of a language SDK 'streams' files (if it supports streaming)
+  -h|--help:      display this output
+
+  examples:
+    # Generates all supported SDKs
+    yarn gen
+
+    # Generates Typescript and Python SDKs
+    yarn gen ts,py
+
+    # reads specs from './versions.json' and generates Typescript and Python SDKs
+    yarn gen ts -v ./versions.json py
+`
+  )
   process.exit(0)
 }
 
@@ -78,6 +97,7 @@ const generatorHelp = () => {
  */
 export const doArgs = (args: string[]) => {
   let versions: ILookerVersions | undefined
+  let noStreams = false
 
   const langs: string[] = []
   if (args.length > 0 && args.toString().toLowerCase() !== 'all') {
@@ -96,6 +116,10 @@ export const doArgs = (args: string[]) => {
         case '-h':
         case '--help':
           generatorHelp()
+          break
+        case '-n':
+        case '--nostreams':
+          noStreams = true
           break
         default:
           {
@@ -122,7 +146,7 @@ export const doArgs = (args: string[]) => {
         .map((l) => l.language)
   ).filter((value, index, all) => all.indexOf(value) === index)
 
-  return { languages, versions }
+  return { languages, versions, noStreams }
 }
 
 /**
@@ -139,7 +163,7 @@ export const loadConfig = () => {
  * @param args command-line style arguments to parse.
  */
 export const prepGen = async (args: string[]): Promise<IGenProps> => {
-  const { languages, versions } = doArgs(args)
+  const { languages, versions, noStreams } = doArgs(args)
   const { name, props } = loadConfig()
   let lookerVersions
   let lookerVersion = ''
@@ -186,6 +210,7 @@ export const prepGen = async (args: string[]): Promise<IGenProps> => {
     lookerVersion,
     apis,
     lastApi,
+    noStreams,
   }
 }
 

--- a/packages/sdk-codegen-scripts/src/utils.ts
+++ b/packages/sdk-codegen-scripts/src/utils.ts
@@ -72,7 +72,7 @@ export interface IGenProps {
 const generatorHelp = () => {
   log(
     `sdkGen [languages...] [-v|--versions <versions file>] [-n|--nostreams] [-h|--help]
-  languages...:   zero or more language specifiers separated by space or comma. Defaults to 'all'
+  languages...:   zero or more language specifiers separated by space or comma. Defaults to all supported languages.
   -v|--versions:  location of a JSON versions file in ILookerVersions format to read for getting specs
   -n|--nostreams: skip generation of a language SDK 'streams' files (if it supports streaming)
   -h|--help:      display this output
@@ -124,13 +124,17 @@ export const doArgs = (args: string[]) => {
         default:
           {
             const values = arg.split(',').filter((v) => v.trim())
-            values.forEach((v) => {
-              const gen = findGenerator(v.trim())
-              if (gen) {
-                // Valid language match
-                langs.push(gen.language)
-              }
-            })
+            if (values[0] !== 'all') {
+              values.forEach((v) => {
+                const gen = findGenerator(v.trim())
+                if (gen) {
+                  // Valid language match
+                  langs.push(gen.language)
+                } else {
+                  throw new Error(`"${v}" is not a valid option`)
+                }
+              })
+            }
           }
           break
       }


### PR DESCRIPTION
- for SDKs that support streaming, this skips generating the `streams` file. It does *not* remove any existing streams files, or change any other generated files
- expanded the `-h` display
- invalid gen options are rejected with an error
- recognize 'all' as a valid language switch but it can still be overridden if other language specifiers are used, so it's undocumented