### PR TITLE
chore(release-please): fix release-as for sdk-codegen and sdk-codegen-all

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,7 +10,7 @@
     "packages/sdk-node": {},
     "packages/sdk": {},
     ".": {
-      "release-as": ""
+      "release-as": "1.1.0"
     },
     "packages/api-explorer": {
       "release-as": "",
@@ -27,7 +27,7 @@
       "release-as": ""
     },
     "packages/sdk-codegen": {
-      "release-as": ""
+      "release-as": "21.1.0"
     },
     "packages/sdk-rtl": {
       "release-as": ""


### PR DESCRIPTION
The python SDK had a breaking change which caused these semver packages to
major bump - not what we want right now.