### PR TITLE
chore: codegen-ci fix and rp config tweak

### DIFF
--- a/.github/workflows/codegen-ci.yml
+++ b/.github/workflows/codegen-ci.yml
@@ -105,7 +105,7 @@ jobs:
 
   publish-test-results:
     name: Publish Test Results
-    needs: [unit, integration]
+    needs: [unit]
     if: success() || failure()
     runs-on: ubuntu-latest
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -13,11 +13,13 @@
     },
     "packages/api-explorer": {
       "release-as": "",
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true
     },
     "packages/run-it": {
       "release-as": "",
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true
     },
     "packages/sdk-codegen-scripts": {
       "release-as": "21.0.12"
@@ -33,7 +35,8 @@
     },
     "packages/wholly-sheet": {
       "release-as": "",
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true
     },
     "python": {
       "release-type": "python",


### PR DESCRIPTION
bump-patch-for-minor-pre-major setting preserves the standard
"only bump patch number for both features and fixes". This
augments the setting to "only bump the minor version for
breaking changes"
