### PR TITLE
chore: relase-please sdk release-as 21.4.1 for #580

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,7 +9,9 @@
     "packages/extension-sdk": {},
     "packages/hackathon": {},
     "packages/sdk-node": {},
-    "packages/sdk": {},
+    "packages/sdk": {
+      "release-as": "21.4.1"
+    },
     ".": {
       "release-as": ""
     },


### PR DESCRIPTION
based on conventional commits(e.g. the `feat: Typescript SDK tree-shaking support`)  + semver, this package would ordinarily bump to 21.6.0.

the remaining looker-versioned packages don't need an explicit release-as **this time** because they're only being patch bumped anyway by release-please/node-workspace (the lerna-based dependency version bumping)