### PR TITLE
fix: error handling for TS SDK, GSon body serialization for Kotlin SDK

### DIFF
--- a/kotlin/src/main/com/looker/rtl/Transport.kt
+++ b/kotlin/src/main/com/looker/rtl/Transport.kt
@@ -24,12 +24,12 @@
 
 package com.looker.rtl
 
+import com.google.gson.Gson
 import io.ktor.client.HttpClient
 import io.ktor.client.call.receive
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.features.json.JacksonSerializer
 import io.ktor.client.features.json.JsonFeature
-import io.ktor.client.features.json.defaultSerializer
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.forms.FormDataContent
 import io.ktor.client.request.request
@@ -336,11 +336,12 @@ class Transport(val options: TransportOptions) {
                 }
                 else -> {
                     // Request body
-                    val json = defaultSerializer()
+//                    val gson = GsonBuilder().setDateFormat("yyyy-MM-dd'T'HH:mm:ssX").create()
+                    val gson = Gson()
+                    val jsonBody = gson.toJson(body)
 
-                    val jsonBody = json.write(body)
-                    builder.body = jsonBody // TODO: I think having to do this is a bug? https://github.com/ktorio/ktor/issues/1265 aka https://youtrack.jetbrains.com/issue/KTOR-576
-                    headers["Content-Length"] = jsonBody.contentLength.toString()
+                    builder.body = jsonBody
+                    headers["Content-Length"] = jsonBody.length.toString()
                 }
             }
         }

--- a/kotlin/src/test/TestMethods.kt
+++ b/kotlin/src/test/TestMethods.kt
@@ -546,7 +546,9 @@ class TestMethods {
                 value_is_hidden=false,
                 user_can_view=true,
                 user_can_edit=true,
-//                hidden_value_domain_whitelist=null // this will cause validation error. It should be omitted
+                // this will cause a validation error. It should comply with the correct pattern.
+                // hidden_value_domain_whitelist must be a comma-separated list of urls with optional wildcards
+                hidden_value_domain_whitelist=null
             )
             val actual = sdk.ok<UserAttribute>(sdk.create_user_attribute(body))
             // We won't get here when there's an error

--- a/kotlin/src/test/TestMethods.kt
+++ b/kotlin/src/test/TestMethods.kt
@@ -537,6 +537,27 @@ class TestMethods {
     }
 
     @Test
+    fun testCreateAttribute() {
+        try {
+            val body = WriteUserAttribute(
+                name="git_username",
+                label="Git Username",
+                type="string",
+                value_is_hidden=false,
+                user_can_view=true,
+                user_can_edit=true,
+//                hidden_value_domain_whitelist=null // this will cause validation error. It should be omitted
+            )
+            val actual = sdk.ok<UserAttribute>(sdk.create_user_attribute(body))
+            // We won't get here when there's an error
+            sdk.ok(sdk.delete_user_attribute(actual.id!!))
+        } catch (e: java.lang.Error) {
+            val msg = e.toString()
+            assertTrue(msg.contains("POST /user_attributes"))
+        }
+    }
+
+    @Test
     fun testAllWorkspaces() {
         testAll<Workspace, String, Workspace>(
             { sdk.all_workspaces() },

--- a/kotlin/src/test/TestMethods.kt
+++ b/kotlin/src/test/TestMethods.kt
@@ -546,8 +546,7 @@ class TestMethods {
                 value_is_hidden=false,
                 user_can_view=true,
                 user_can_edit=true,
-                // this will cause a validation error. It should comply with the correct pattern.
-                // hidden_value_domain_whitelist must be a comma-separated list of urls with optional wildcards
+                // Now that Transport.kt uses GSon, this null property will be stripped from the request payload
                 hidden_value_domain_whitelist=null
             )
             val actual = sdk.ok<UserAttribute>(sdk.create_user_attribute(body))
@@ -556,6 +555,7 @@ class TestMethods {
         } catch (e: java.lang.Error) {
             val msg = e.toString()
             assertTrue(msg.contains("POST /user_attributes"))
+            assertTrue(false, "create_user_attribute should have removed hidden_value_domain_whitelist")
         }
     }
 

--- a/packages/sdk-node/src/nodeTransport.ts
+++ b/packages/sdk-node/src/nodeTransport.ts
@@ -136,14 +136,15 @@ export class NodeTransport extends BaseTransport {
       if (e instanceof StatusCodeError) {
         statusCode = e.statusCode
         const text = e.message
+        body = e.message
         // Need to re-parse the error message
         const matches = /^\d+\s*-\s*({.*})/gim.exec(text)
         if (matches && matches.length > 1) {
           const json = matches[1]
           const obj = JSON.parse(json)
-          body = Buffer.from(obj.data).toString('utf8')
-        } else {
-          body = e.message
+          if (obj.data) {
+            body = Buffer.from(obj.data).toString('utf8')
+          }
         }
         body = `${statusMessage} ${body}`
       } else if (e.error instanceof Buffer) {

--- a/packages/sdk-node/test/methods.spec.ts
+++ b/packages/sdk-node/test/methods.spec.ts
@@ -220,6 +220,35 @@ describe('LookerNodeSDK', () => {
     expect(Looker40SDKStream.ApiVersion).toEqual('4.0')
   })
 
+  describe('issue-related tests', () => {
+    it('create_user_attribute options', async () => {
+      // Reported in #544
+      // WriteUserAttribute(name=git_username, label=Git Username, type=string, default_value=, value_is_hidden=false, user_can_view=true, user_can_edit=true, hidden_value_domain_whitelist=null)
+      const sdk = new LookerSDK(session)
+      try {
+        const attrib = await sdk.ok(
+          sdk.create_user_attribute({
+            name: 'git_username',
+            label: 'Git Username',
+            type: 'string',
+            default_value: undefined,
+            value_is_hidden: false,
+            user_can_edit: true,
+            user_can_view: true,
+            hidden_value_domain_whitelist: '',
+          })
+        )
+        // We shouldn't get here but if we do, delete the test attribute
+        await sdk.ok(sdk.delete_user_attribute(attrib.id!))
+      } catch (e) {
+        // Using this instead of `rejects.toThrowError` because that pattern fails to match valid RegEx condition
+        expect(e.message).toMatch(
+          /hidden_value_domain_whitelist must be a comma-separated list of urls with optional wildcards/gim
+        )
+      }
+    })
+  })
+
   describe('downloads', () => {
     it(
       'png and svg',


### PR DESCRIPTION
We have an outstanding feature request to improve analysis of Kotlin SDK errors, but this documents the encountered error in the Typescript SDK test, which has better error handling

API Explorer and the existing Looker API Docs UI can also be used to see what the actual 422 error is

Fixes #544 🦕
