### PR TITLE
chore: reset release-please release-as config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,17 +1,13 @@
 {
   "plugins": ["node-workspace"],
-  "release-as": "21.6.0",
+  "release-as": "",
   "packages": {
-    "packages/extension-api-explorer": {
-      "release-as": "21.4.1"
-    },
+    "packages/extension-api-explorer": {},
     "packages/extension-sdk-react": {},
     "packages/extension-sdk": {},
     "packages/hackathon": {},
     "packages/sdk-node": {},
-    "packages/sdk": {
-      "release-as": "21.4.1"
-    },
+    "packages/sdk": {},
     ".": {
       "release-as": ""
     },
@@ -25,18 +21,10 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true
     },
-    "packages/sdk-codegen-scripts": {
-      "release-as": "21.0.12"
-    },
-    "packages/sdk-codegen-utils": {
-      "release-as": "21.0.12"
-    },
-    "packages/sdk-codegen": {
-      "release-as": "21.0.12"
-    },
-    "packages/sdk-rtl": {
-      "release-as": "21.0.12"
-    },
+    "packages/sdk-codegen-scripts": {},
+    "packages/sdk-codegen-utils": {},
+    "packages/sdk-codegen": {},
+    "packages/sdk-rtl": {},
     "packages/wholly-sheet": {
       "release-as": "",
       "bump-minor-pre-major": true,
@@ -44,7 +32,6 @@
     },
     "python": {
       "release-type": "python",
-      "release-as": "21.4.1",
       "draft": true,
       "package-name": "looker_sdk"
     }


### PR DESCRIPTION
Part of our "non-Looker-release" release cycle needs to be resetting
"release-as" keys so we can see what release-please would propose
normally based purely on conventional commits and THEN we can
make the necessary "release-as" adjustments