### PR TITLE
chore: publish workflows go automatically now

### DIFF
--- a/.github/workflows/lerna-publish.yml
+++ b/.github/workflows/lerna-publish.yml
@@ -1,6 +1,9 @@
 name: Publish NPM Packages
 
 on:
+  release:
+    types: published
+
   workflow_dispatch:
     inputs:
       ref:
@@ -8,7 +11,12 @@ on:
         required: true
 
 jobs:
-  release:
+  publish:
+    if: >
+      (github.event.inputs) ||
+      (startsWith(github.event.release.tag_name, 'sdk-codegen-all') &&
+      !github.event.release.draft &&
+      !github.event.release.prerelease)
     runs-on: ubuntu-latest
     env:
       LOOKERSDK_BASE_URL: https://localhost:20000
@@ -20,7 +28,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           persist-credentials: false
-          ref: ${{ github.event.inputs.ref }}
+          ref: ${{  github.event.release.tag_name || github.event.inputs.ref }}
       - uses: actions/setup-node@v2
         with:
           node-version: 15

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,18 +1,12 @@
 name: Python Publish to PYPI
 on:
-  # Automatic release based on either creating a published release or
-  # publishing a draft release (creating a draft release will not trigger the
-  # "release" event type according to the docs).
-  # The workflow file version used is that from the tag corresponding to the
-  # release. This is why the "workflow_dispatch" trigger is configured as well:
-  # in case we need to manually re-publish a tag using a modified workflow
   release:
-    types: [created, published]
+    types: published
 
   workflow_dispatch:
     inputs:
-      tag:
-        description: 'tag to release'
+      ref:
+        description: 'commit/tag/branch to release from'
         required: true
 
 defaults:
@@ -31,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.release.tag_name || github.event.inputs.tag }}
+          ref: ${{ github.event.release.tag_name || github.event.inputs.ref }}
 
       - uses: actions/setup-python@v2
         with:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -36,7 +36,6 @@
     },
     "python": {
       "release-type": "python",
-      "draft": true,
       "package-name": "looker_sdk"
     }
   }


### PR DESCRIPTION
prior to this change the lerna publish workflow could only be triggered
by a manual run. Now it will go as soon as release-please creates the
release (which happens right after the Release PR is merged)