### PR TITLE
fix: removes deprecated object attribute reference

### DIFF
--- a/packages/api-explorer/src/components/DocSDKs/DocSDKs.spec.tsx
+++ b/packages/api-explorer/src/components/DocSDKs/DocSDKs.spec.tsx
@@ -35,7 +35,7 @@ import { DocSDKs } from './DocSDKs'
 
 describe('DocSDKs', () => {
   let store: Store<RootState>
-  const supportedLanguages = codeGenerators.map((g) => g.label || g.language)
+  const supportedLanguages = codeGenerators.map((g) => g.language)
   const pattern = new RegExp(`${supportedLanguages.join('|')}`)
 
   beforeAll(() => {

--- a/packages/run-it/src/components/DocSdkCalls/DocSdkCalls.spec.tsx
+++ b/packages/run-it/src/components/DocSdkCalls/DocSdkCalls.spec.tsx
@@ -32,7 +32,7 @@ import { api } from '../../test-data'
 import { DocSdkCalls } from './DocSdkCalls'
 
 describe('DocSdkCalls', () => {
-  const supportedLanguages = codeGenerators.map((g) => g.label || g.language)
+  const supportedLanguages = codeGenerators.map((g) => g.language)
   const pattern = new RegExp(`${supportedLanguages.join('|')}`)
 
   test('it can render SDK call syntax for all supported languages', () => {


### PR DESCRIPTION
Usage of the deprecated `label` attribute in these tests were causing the latest Api Explorer build to fail