### PR TITLE
feat: extension framework identifies looker host type

### DIFF
--- a/packages/extension-sdk/README.md
+++ b/packages/extension-sdk/README.md
@@ -63,8 +63,13 @@ The following create methods are also available
 
 Looker host data is made available once the host connection has been established
 
+- `extensionId` - id of the extension.
 - `lookerVersion` - host Looker version. Test this value if the extension depends on a particular version of Looker.
 - `route` - if routes are tracked, route is the last active route tracked by the host. On initialization the extension may set its route to this value.
+- `routeState`- if routes are tracked, [push state](https://developer.mozilla.org/en-US/docs/Web/API/History/state) associated with the route
+- `hostOrigin` - [origin](https://developer.mozilla.org/en-US/docs/Web/API/Location/origin) of the Looker host. **Looker >=21.8**.
+- `hostType` - Looker host type. `standard`|`embed`|`spartan`. **Looker >=21.8**.
+- `mountType` - Extension mount type. `fullscreen`. **Looker >=21.8**.
 
 #### Context data
 

--- a/packages/extension-sdk/src/connect/connect_extension_host.spec.ts
+++ b/packages/extension-sdk/src/connect/connect_extension_host.spec.ts
@@ -26,7 +26,12 @@
 
 import { connectExtensionHost } from './connect_extension_host'
 import * as globalListener from './global_listener'
-import { ExtensionNotification, ExtensionNotificationType } from './types'
+import {
+  ExtensionNotification,
+  ExtensionNotificationType,
+  HostType,
+  MountType,
+} from './types'
 
 let channel: any
 class MockMessageChannel {
@@ -96,6 +101,9 @@ describe('connect_extension_host tests', () => {
       payload: {
         lookerVersion: '7.14.0',
         hostUrl: 'https://self-signed.looker.com:9999',
+        hostOrigin: 'https://self-signed.looker.com:9999',
+        hostType: HostType.STANDARD,
+        mountType: MountType.FULLSCREEN,
         extensionId: 'a::b',
       },
     })
@@ -125,6 +133,9 @@ describe('connect_extension_host tests', () => {
         routeState: { hello: 'world' },
         lookerVersion: '7.14.0',
         hostUrl: 'https://self-signed.looker.com:9999',
+        hostOrigin: 'https://self-signed.looker.com:9999',
+        hostType: HostType.STANDARD,
+        mountType: MountType.FULLSCREEN,
         extensionId: 'a::b',
       },
     })
@@ -151,6 +162,9 @@ describe('connect_extension_host tests', () => {
         routeState: { hello: 'world' },
         lookerVersion: '7.14.0',
         hostUrl: 'https://self-signed.looker.com:9999',
+        hostOrigin: 'https://self-signed.looker.com:9999',
+        hostType: HostType.STANDARD,
+        mountType: MountType.FULLSCREEN,
         extensionId: 'a::b',
       },
     })

--- a/packages/extension-sdk/src/connect/types.ts
+++ b/packages/extension-sdk/src/connect/types.ts
@@ -252,6 +252,20 @@ export interface RouteChangeData {
 }
 
 /**
+ * Looker host type.
+ * standard - Standard Looker host with the navigation bar.
+ * embed - Embedded Looker host.
+ * spartan - Spartan Looker host.
+ */
+export type HostType = 'standard' | 'embed' | 'spartan'
+
+/**
+ * Extension mount type.
+ * Fullscreen mount.
+ */
+export type MountType = 'fullscreen'
+
+/**
  * Initialization data. Looker host data.
  */
 export interface LookerHostData {
@@ -272,9 +286,25 @@ export interface LookerHostData {
    */
   routeState?: any
   /**
-   * hostUrl url of Looker host
+   * Origin of Looker host
+   * @deprecated
    */
   hostUrl?: string
+  /**
+   * Origin of Looker host
+   * <code>Looker >=21.8</code>
+   */
+  hostOrigin?: string
+  /**
+   * Looker host type (standard, embed, spartan)
+   * <code>Looker >=21.8</code>
+   */
+  hostType?: HostType
+  /**
+   * Extension mount type.
+   * <code>Looker >=21.8</code>
+   */
+  mountType?: MountType
   /**
    * Extension context data
    */

--- a/packages/run-it/src/components/ShowResponse/ShowResponse.spec.tsx
+++ b/packages/run-it/src/components/ShowResponse/ShowResponse.spec.tsx
@@ -56,9 +56,9 @@ describe('ShowResponse', () => {
   })
 
   test('it renders html responses', () => {
-    render(<ShowResponse response={testHtmlResponse} />)
+    renderWithTheme(<ShowResponse response={testHtmlResponse} />)
     expect(screen.getByText('200: text/html;charset=utf-8')).toBeInTheDocument()
-    expect(screen.getByRole('textbox', { name: '' })).toBeInTheDocument()
+    expect(screen.getByText('Orders Created Date')).toBeInTheDocument()
   })
 
   test('it renders png responses', () => {
@@ -79,8 +79,8 @@ describe('ShowResponse', () => {
     expect(screen.getByRole('img')).toBeInTheDocument()
   })
 
-  test.skip('it renders a message for unknown response types', () => {
-    render(<ShowResponse response={testUnknownResponse} />)
+  test('it renders a message for unknown response types', () => {
+    renderWithTheme(<ShowResponse response={testUnknownResponse} />)
     expect(
       screen.getByText(
         `Received ${testUnknownResponse.body.length} bytes of ${testUnknownResponse.contentType} data.`


### PR DESCRIPTION
The Looker host type is sent in the lookerHostData parameter of the initialization message.

Looker host type can be
1. standard - standard chromed Looker UI.
2. embed - embedded extension.
3. spartan - spartan extension.

Requires Looker 21.8.

In addition the
1. hostUrl has been deprecated in favor of hostOrigin (hostOrigin reflects more accurately what the contents of the parameter contains)
2. mountType - extension mount type. Currently fullscreen. In preparation for alternative mount points in the future.
