### PR TITLE
feat: APIX now uses google font appropriately

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "register": "SUPPRESS_NO_CONFIG_WARNING=1 ts-node -O '{ \"module\": \"commonjs\", \"target\": \"es2019\" }' packages/sdk-codegen-scripts/scripts/register.ts",
     "test": "yarn jest",
     "test:ts": "yarn jest --reporters=default --reporters=jest-junit",
-    "test:apix": "yarn jest packages/api-explorer packages/run-it packages/code-editor",
+    "test:apix": "yarn jest packages/api-explorer packages/run-it packages/code-editor  packages/extension-api-explorer",
     "test:iphone": "xcodebuild test -project swift/looker/looker.xcodeproj -scheme looker-Package -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 11,OS=13.4.1' | xcpretty --test --color",
     "test:gen": "yarn jest packages/sdk-codegen",
     "test:sdk": "yarn jest packages/sdk",

--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -51,6 +51,7 @@
   "dependencies": {
     "@looker/components": "^1.1.3",
     "@looker/icons": "1.1.3",
+    "@looker/design-tokens": "1.1.3",
     "@styled-icons/material": "^10.28.0",
     "@styled-icons/material-outlined": "^10.28.0",
     "@styled-icons/material-rounded": "^10.28.0",

--- a/packages/api-explorer/src/ApiExplorer.tsx
+++ b/packages/api-explorer/src/ApiExplorer.tsx
@@ -99,15 +99,11 @@ const ApiExplorer: FC<ApiExplorerProps> = ({
     getSettings()
   }, [envAdaptor, setSdkLanguageAction])
 
+  const themeOverrides = envAdaptor.themeOverrides()
+
   return (
     <>
-      <ComponentsProvider
-        loadGoogleFonts
-        themeCustomizations={{
-          fontFamilies: { brand: 'Google Sans' },
-          colors: { key: '#1A73E8' },
-        }}
-      >
+      <ComponentsProvider {...themeOverrides}>
         <EnvAdaptorContext.Provider value={{ envAdaptor }}>
           <LodeContext.Provider value={{ ...lode }}>
             <SearchContext.Provider

--- a/packages/api-explorer/src/utils/envAdaptor.spec.ts
+++ b/packages/api-explorer/src/utils/envAdaptor.spec.ts
@@ -23,31 +23,35 @@
  SOFTWARE.
 
  */
-import React, { FC } from 'react'
-import {
-  ComponentsProvider,
-  Flex,
-  FlexItem,
-  Heading,
-  Spinner,
-} from '@looker/components'
-import { ThemeOverrides } from '@looker/api-explorer/src/utils'
+import { StandaloneEnvAdaptor, ThemeOverrides } from './envAdaptor'
 
-export interface LoaderProps {
-  themeOverrides: ThemeOverrides
+const googleFontOverrides = {
+  loadGoogleFonts: true,
+  themeCustomizations: {
+    fontFamilies: { brand: 'Google Sans' },
+    colors: { key: '#1A73E8' },
+  },
 }
 
-export const Loader: FC<LoaderProps> = ({ themeOverrides }) => (
-  <ComponentsProvider {...themeOverrides}>
-    <Flex flexDirection="column" justifyContent="center" mt="25%">
-      <FlexItem alignSelf="center">
-        <Spinner color="key" size={150} />
-      </FlexItem>
-      <FlexItem mt="large" alignSelf="center">
-        <Heading color="key" as="h2">
-          Loading API Specifications
-        </Heading>
-      </FlexItem>
-    </Flex>
-  </ComponentsProvider>
-)
+describe('StandaloneEnvAdaptor', () => {
+  test.each([
+    ['www.looker.com', googleFontOverrides],
+    ['www.google.com', googleFontOverrides],
+    ['localhost', googleFontOverrides],
+    ['127.0.0.1', {}],
+  ])(
+    'returns correct font overrides',
+    (hostname: string, expectedOverrides: ThemeOverrides) => {
+      const saveLoc = window.location
+      delete (window as any).location
+      window.location = {
+        ...saveLoc,
+        hostname,
+      }
+      expect(new StandaloneEnvAdaptor().themeOverrides()).toEqual(
+        expectedOverrides
+      )
+      window.location = saveLoc
+    }
+  )
+})

--- a/packages/api-explorer/src/utils/envAdaptor.ts
+++ b/packages/api-explorer/src/utils/envAdaptor.ts
@@ -24,6 +24,8 @@
 
  */
 
+import { ThemeCustomizations } from '@looker/design-tokens'
+
 /**
  * NOTE: This interface should describe all methods that require an adaptor when running in standalone vs extension mode
  * Examples include: local storage operations, writing to clipboard and various link navigation functions amongst others
@@ -35,6 +37,18 @@ export interface IApixEnvAdaptor {
   localStorageSetItem(key: string, value: string): void
   /** Method for removing a keyed value from local storage */
   localStorageRemoveItem(key: string): void
+  /** Theme settings for extension */
+  themeOverrides(): ThemeOverrides
+}
+
+/**
+ * Theme overrides used to load google fonts in Google environments only.
+ * Google fonts should NOT be used when it is not obvious that a Google
+ * system is being used (for example an embedded extension).
+ */
+export interface ThemeOverrides {
+  loadGoogleFonts?: boolean
+  themeCustomizations?: ThemeCustomizations
 }
 
 /**
@@ -51,6 +65,21 @@ export class StandaloneEnvAdaptor implements IApixEnvAdaptor {
 
   async localStorageRemoveItem(key: string) {
     await localStorage.removeItem(key)
+  }
+
+  themeOverrides(): ThemeOverrides {
+    const { hostname } = location
+    return hostname.endsWith('.looker.com') ||
+      hostname.endsWith('.google.com') ||
+      hostname === 'localhost'
+      ? {
+          loadGoogleFonts: true,
+          themeCustomizations: {
+            fontFamilies: { brand: 'Google Sans' },
+            colors: { key: '#1A73E8' },
+          },
+        }
+      : {}
   }
 }
 

--- a/packages/api-explorer/src/utils/index.ts
+++ b/packages/api-explorer/src/utils/index.ts
@@ -31,4 +31,5 @@ export {
   IApixEnvAdaptor,
   StandaloneEnvAdaptor,
   EnvAdaptorConstants,
+  ThemeOverrides,
 } from './envAdaptor'

--- a/packages/code-editor/package.json
+++ b/packages/code-editor/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@looker/components": "^1.1.3",
-    "@looker/design-tokens": "^1.1.3",
+    "@looker/design-tokens": "1.1.3",
     "@looker/sdk-codegen": "^21.0.15",
     "prism-react-renderer": "^1.2.0",
     "react": "^16.13.1",

--- a/packages/extension-api-explorer/src/ExtensionApiExplorer.tsx
+++ b/packages/extension-api-explorer/src/ExtensionApiExplorer.tsx
@@ -130,7 +130,7 @@ export const ExtensionApiExplorer: FC = () => {
           {specs ? (
             <ApiExplorer specs={specs} envAdaptor={extensionEnvAdaptor} />
           ) : (
-            <Loader />
+            <Loader themeOverrides={extensionEnvAdaptor.themeOverrides()} />
           )}
         </>
       </RunItProvider>

--- a/packages/extension-api-explorer/src/utils.spec.ts
+++ b/packages/extension-api-explorer/src/utils.spec.ts
@@ -23,31 +23,34 @@
  SOFTWARE.
 
  */
-import React, { FC } from 'react'
-import {
-  ComponentsProvider,
-  Flex,
-  FlexItem,
-  Heading,
-  Spinner,
-} from '@looker/components'
 import { ThemeOverrides } from '@looker/api-explorer/src/utils'
+import { ExtensionSDK, LookerHostData } from '@looker/extension-sdk'
+import { ExtensionEnvAdaptor } from './utils'
 
-export interface LoaderProps {
-  themeOverrides: ThemeOverrides
+const googleFontOverrides = {
+  loadGoogleFonts: true,
+  themeCustomizations: {
+    fontFamilies: { brand: 'Google Sans' },
+    colors: { key: '#1A73E8' },
+  },
 }
 
-export const Loader: FC<LoaderProps> = ({ themeOverrides }) => (
-  <ComponentsProvider {...themeOverrides}>
-    <Flex flexDirection="column" justifyContent="center" mt="25%">
-      <FlexItem alignSelf="center">
-        <Spinner color="key" size={150} />
-      </FlexItem>
-      <FlexItem mt="large" alignSelf="center">
-        <Heading color="key" as="h2">
-          Loading API Specifications
-        </Heading>
-      </FlexItem>
-    </Flex>
-  </ComponentsProvider>
-)
+describe('ExtensionEnvAdaptor', () => {
+  test.each([
+    [undefined, {}],
+    ['standard', googleFontOverrides],
+    ['embed', {}],
+    ['spartan', {}],
+  ])(
+    'returns correct font overrides',
+    (hostType?: string, expectedOverrides?: ThemeOverrides) => {
+      expect(
+        new ExtensionEnvAdaptor({
+          lookerHostData: {
+            hostType,
+          } as Readonly<LookerHostData>,
+        } as ExtensionSDK).themeOverrides()
+      ).toEqual(expectedOverrides)
+    }
+  )
+})

--- a/packages/extension-api-explorer/src/utils.ts
+++ b/packages/extension-api-explorer/src/utils.ts
@@ -23,7 +23,7 @@
  SOFTWARE.
 
  */
-import { IApixEnvAdaptor } from '@looker/api-explorer/src/utils'
+import { IApixEnvAdaptor, ThemeOverrides } from '@looker/api-explorer/src/utils'
 import { ExtensionSDK } from '@looker/extension-sdk'
 
 /**
@@ -42,5 +42,17 @@ export class ExtensionEnvAdaptor implements IApixEnvAdaptor {
 
   async localStorageRemoveItem(key: string) {
     await this.extensionSdk.localStorageRemoveItem(key)
+  }
+
+  themeOverrides(): ThemeOverrides {
+    return (this.extensionSdk.lookerHostData || {}).hostType === 'standard'
+      ? {
+          loadGoogleFonts: true,
+          themeCustomizations: {
+            fontFamilies: { brand: 'Google Sans' },
+            colors: { key: '#1A73E8' },
+          },
+        }
+      : {}
   }
 }

--- a/packages/run-it/package.json
+++ b/packages/run-it/package.json
@@ -48,10 +48,10 @@
   "dependencies": {
     "@looker/components": "^1.1.3",
     "@looker/icons": "1.1.3",
+    "@looker/design-tokens": "1.1.3",
     "@styled-icons/material": "^10.28.0",
     "@styled-icons/material-outlined": "^10.28.0",
     "@styled-icons/material-rounded": "^10.28.0",
-    "@looker/design-tokens": "0.9.27",
     "@looker/sdk": "^21.4.3",
     "@looker/sdk-codegen": "^21.0.15",
     "@looker/sdk-codegen-utils": "^21.0.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2236,19 +2236,7 @@
     styled-system "^5.1.5"
     uuid "^8.3.2"
 
-"@looker/design-tokens@0.9.27":
-  version "0.9.27"
-  resolved "https://registry.yarnpkg.com/@looker/design-tokens/-/design-tokens-0.9.27.tgz#667ce852a0702bbeb28c98181db9bb3a41a7751b"
-  integrity sha512-2Jzo3i/yeCJS7dWrByJ7b0NI/oh+MBymUMO9p1vYVgTx2LUdv+7QDSMBU5T+SgNWY5fckfjooDwmuQuKWstwJw==
-  dependencies:
-    "@styled-system/props" "^5.1.5"
-    "@styled-system/should-forward-prop" "5.1.5"
-    "@types/styled-system" "^5.1.10"
-    lodash "^4.17.20"
-    polished "^4.0.5"
-    styled-system "^5.1.5"
-
-"@looker/design-tokens@^1.1.3":
+"@looker/design-tokens@1.1.3", "@looker/design-tokens@^1.1.3":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@looker/design-tokens/-/design-tokens-1.1.3.tgz#620ef2be3de589b64b92e76f379f194a97a3d46f"
   integrity sha512-Is9GoNsXCWSvf32AQclBh8ynVs6F+RfJ22t6jBwYAvRpnLOb8VV+wqGjY1t2lZFSTTPEnM4JOr6I9H2EPgDLBA==


### PR DESCRIPTION
APIX will use google fonts when running as a non embedded extension OR, in stand alone mode, when running from a looker.com or google.com domain.

Also
1. adds extension-api-explorer package to apix tests script.
2. fixes looker design token dependencies. missing or wrong version from some packages. specifies an explicit version as an alpha version is the current version in npm.
