### PR TITLE
chore: try release-please bot as action replacement

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,0 +1,2 @@
+manifest: true
+handleGHRelease: true


### PR DESCRIPTION
this bot is google-cla approved AND should cause CI to run automatically
as well as publishing-after-release-creation to happen automatically

the action cannot perform either because it is an imposed limitation
in GitHub actions that a side effect of one action cannot trigger another action