### PR TITLE
chore: CI overhaul

### DIFF
--- a/.github/workflows/codegen-ci.yml
+++ b/.github/workflows/codegen-ci.yml
@@ -1,13 +1,6 @@
 name: Codegen CI
 on:
   pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      # first three are default, adding labeled for "CI:TEST" support
-      # (see jobs.unit.if below)
-      - labeled
     paths:
       - packages/sdk-codegen/**
       - packages/sdk-codegen-utils/**
@@ -21,6 +14,8 @@ on:
       - packages/sdk-codegen-utils/**
       - packages/sdk-codegen-scripts/**
 
+  workflow_dispatch:
+
 env:
   LOOKERSDK_BASE_URL: https://localhost:20000
   LOOKERSDK_VERIFY_SSL: false
@@ -30,23 +25,6 @@ env:
 
 jobs:
   unit:
-    # 1st condition: push event (restricted to main above)
-    # 2nd condition: PR opened/synchronized/reopened (types filter above)
-    #                unless the PR has the CI:HOLD label
-    # 3rd condition: PR labeled with "CI:TEST"
-    if: >
-      github.event_name == 'push' ||
-      (
-        github.event_name == 'pull_request' &&
-        github.event.action != 'labeled' &&
-        !contains(github.event.pull_request.labels, 'CI:HOLD')
-      ) ||
-      (
-        github.event_name == 'pull_request' &&
-        github.event.action == 'labeled' &&
-        github.event.label.name == 'CI:TEST'
-      )
-
     env:
       JEST_JUNIT_OUTPUT_DIR: results/sdk-codegen
       JEST_JUNIT_OUTPUT_NAME: ubuntu-latest.sdk-codegen15x.xml
@@ -120,7 +98,7 @@ jobs:
           path: results/sdk-codegen
 
   publish-test-results:
-    name: Publish Test Results
+    name: Codegen Test Results
     needs: [unit]
     if: success() || failure()
     runs-on: ubuntu-latest
@@ -132,31 +110,33 @@ jobs:
           path: artifacts
 
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1.6
+        uses: EnricoMi/publish-unit-test-result-action@v1.12
         with:
-          check_name: Test Results
+          check_name: Codegen Tests
           github_token: ${{ secrets.GITHUB_TOKEN }}
           report_individual_runs: true
+          hide_comments: orphaned commits
+          check_run_annotations_branch: '*'
           files: 'artifacts/sdk-codegen-test-results/*.xml'
 
-  remove-CI-TEST-label:
-    name: Remove CI:TEST Label
-    if: >
-      (
-        github.event_name == 'pull_request' &&
-        github.event.action == 'labeled' &&
-        github.event.label.name == 'CI:TEST'
-      )
+  # The following jobs are necessary because they are configured as required
+  # checks on PRs and would not otherwise run in this workflow. If the PR/branch
+  # triggering this workflow file also needs to actually run these tests, the
+  # other workflow files will pick it up and submit the results. In that case
+  # there will be duplicate PR check names but github handles this and requires
+  # both to be passing.
+  noop-python-results:
+    name: Python Test Results
+    needs: [publish-test-results]
+    if: success() || failure()
     runs-on: ubuntu-latest
     steps:
-      - name: Remove CI:TEST Label
-        uses: actions/github-script@v3
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            github.issues.removeLabel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              name: 'CI:TEST'
-            })
+      - run: exit 0
+
+  noop-typescript-results:
+    name: Typescript Test Results
+    needs: [publish-test-results]
+    if: success() || failure()
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,13 +1,6 @@
 name: Python CI
 on:
   pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      # first three are default, adding labeled for "CI:TEST" support
-      # (see jobs.unit.if below)
-      - labeled
     paths:
       - python/**
 
@@ -16,6 +9,8 @@ on:
       - main
     paths:
       - python/**
+
+  workflow_dispatch:
 
 env:
   LOOKERSDK_BASE_URL: https://localhost:20000
@@ -36,7 +31,7 @@ jobs:
         uses: styfle/cancel-workflow-action@0.6.0
         with:
           access_token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
           python-version: 3.x
@@ -46,23 +41,6 @@ jobs:
 
   unit:
     needs: typecheck
-    # 1st condition: push event (restricted to main above)
-    # 2nd condition: PR opened/synchronized/reopened (types filter above)
-    #                unless the PR has the CI:HOLD label
-    # 3rd condition: PR labeled with "CI:TEST"
-    if: >
-      github.event_name == 'push' ||
-      (
-        github.event_name == 'pull_request' &&
-        github.event.action != 'labeled' &&
-        !contains(github.event.pull_request.labels, 'CI:HOLD')
-      ) ||
-      (
-        github.event_name == 'pull_request' &&
-        github.event.action == 'labeled' &&
-        github.event.label.name == 'CI:TEST'
-      )
-
     name: Unit - ${{ matrix.os }} / py${{ matrix.python-version }}
     env:
       TOX_JUNIT_OUTPUT_NAME: ${{ matrix.os }}.py${{ matrix.python-version }}
@@ -114,7 +92,7 @@ jobs:
     needs: unit
     name: Integration - ${{ matrix.os }} / Looker.${{ matrix.looker }}
     env:
-      TOX_JUNIT_OUTPUT_NAME: ${{ matrix.os }}.Looker-${{ matrix.looker }}
+      TOX_JUNIT_OUTPUT_NAME: ${{ matrix.os }}.Looker-${{ matrix.looker }}.py3.x
     runs-on: ${{ matrix.os }}-latest
     strategy:
       matrix:
@@ -210,7 +188,7 @@ jobs:
           path: python/results/
 
   publish-test-results:
-    name: Publish Test Results
+    name: Python Test Results
     needs: [unit, integration]
     if: success() || failure()
     runs-on: ubuntu-latest
@@ -222,31 +200,33 @@ jobs:
           path: artifacts
 
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1.6
+        uses: EnricoMi/publish-unit-test-result-action@v1.12
         with:
-          check_name: Test Results
+          check_name: Python Tests
           github_token: ${{ secrets.GITHUB_TOKEN }}
           report_individual_runs: true
+          hide_comments: orphaned commits
+          check_run_annotations_branch: '*'
           files: 'artifacts/python-test-results/*.xml'
 
-  remove-CI-TEST-label:
-    name: Remove CI:TEST Label
-    if: >
-      (
-        github.event_name == 'pull_request' &&
-        github.event.action == 'labeled' &&
-        github.event.label.name == 'CI:TEST'
-      )
+  # The following jobs are necessary because they are configured as required
+  # checks on PRs and would not otherwise run in this workflow. If the PR/branch
+  # triggering this workflow file also needs to actually run these tests, the
+  # other workflow files will pick it up and submit the results. In that case
+  # there will be duplicate PR check names but github handles this and requires
+  # both to be passing.
+  noop-codegen-results:
+    name: Codegen Test Results
+    needs: [publish-test-results]
+    if: success() || failure()
     runs-on: ubuntu-latest
     steps:
-      - name: Remove CI:TEST Label
-        uses: actions/github-script@v3
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            github.issues.removeLabel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              name: 'CI:TEST'
-            })
+      - run: exit 0
+
+  noop-typescript-results:
+    name: Typescript Test Results
+    needs: [publish-test-results]
+    if: success() || failure()
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0

--- a/.github/workflows/tssdk-ci.yml
+++ b/.github/workflows/tssdk-ci.yml
@@ -1,13 +1,6 @@
 name: TypeScript SDK CI
 on:
   pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      # first three are default, adding labeled for "CI:TEST" support
-      # (see jobs.unit.if below)
-      - labeled
     paths:
       - packages/sdk/**
       - packages/sdk-rtl/**
@@ -25,6 +18,8 @@ on:
       - packages/extension-sdk/**
       - packages/extension-sdk-react/**
 
+  workflow_dispatch:
+
 env:
   LOOKERSDK_BASE_URL: https://localhost:20000
   LOOKERSDK_VERIFY_SSL: false
@@ -32,23 +27,6 @@ env:
 
 jobs:
   unit:
-    # 1st condition: push event (restricted to main above)
-    # 2nd condition: PR opened/synchronized/reopened (types filter above)
-    #                unless the PR has the CI:HOLD label
-    # 3rd condition: PR labeled with "CI:TEST"
-    if: >
-      github.event_name == 'push' ||
-      (
-        github.event_name == 'pull_request' &&
-        github.event.action != 'labeled' &&
-        !contains(github.event.pull_request.labels, 'CI:HOLD')
-      ) ||
-      (
-        github.event_name == 'pull_request' &&
-        github.event.action == 'labeled' &&
-        github.event.label.name == 'CI:TEST'
-      )
-
     name: Unit - ${{ matrix.os }} / Node ${{ matrix.node-version }}
     env:
       JEST_JUNIT_OUTPUT_DIR: results/tssdk
@@ -130,7 +108,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -181,7 +159,7 @@ jobs:
           path: results/tssdk
 
   publish-test-results:
-    name: Publish Test Results
+    name: Typescript Test Results
     needs: [unit, integration]
     if: success() || failure()
     runs-on: ubuntu-latest
@@ -193,31 +171,33 @@ jobs:
           path: artifacts
 
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1.6
+        uses: EnricoMi/publish-unit-test-result-action@v1.12
         with:
           check_name: Test Results
           github_token: ${{ secrets.GITHUB_TOKEN }}
           report_individual_runs: true
+          hide_comments: orphaned commits
+          check_run_annotations_branch: '*'
           files: 'artifacts/tssdk-test-results/*.xml'
 
-  remove-CI-TEST-label:
-    name: Remove CI:TEST Label
-    if: >
-      (
-        github.event_name == 'pull_request' &&
-        github.event.action == 'labeled' &&
-        github.event.label.name == 'CI:TEST'
-      )
+  # The following jobs are necessary because they are configured as required
+  # checks on PRs and would not otherwise run in this workflow. If the PR/branch
+  # triggering this workflow file also needs to actually run these tests, the
+  # other workflow files will pick it up and submit the results. In that case
+  # there will be duplicate PR check names but github handles this and requires
+  # both to be passing.
+  noop-codegen-results:
+    name: Codegen Test Results
+    needs: [publish-test-results]
+    if: success() || failure()
     runs-on: ubuntu-latest
     steps:
-      - name: Remove CI:TEST Label
-        uses: actions/github-script@v3
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            github.issues.removeLabel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              name: 'CI:TEST'
-            })
+      - run: exit 0
+
+  noop-python-results:
+    name: Python Test Results
+    needs: [publish-test-results]
+    if: success() || failure()
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0


### PR DESCRIPTION
- get rid of CI:TEST/HOLD label logic
-- this was causing problems: when other labels were applied
   (e.g. "cla: yes") then the workflow would report as skipped
   and it appeared that all checks passed.
-- replacement: go to the actions UI, and for each CI workflow trigger
   it on your branch

- add "noop" duplicate/dummy jobs to support enabling "required checks"
  on PRs so that we no longer accidentally merge broken changes.
  See code comments and
  https://github.community/t/github-actions-and-required-checks-in-a-monorepo-using-paths-to-limit-execution/16586/7?u=joeldodge79

This will allow us to enable the following required checks on PRs
* Python Test Results
* Typescript Test Results
* Codegen Test Results
* cla/google
* Semantic Pull Request