### PR TITLE
ci: centralize noop checks

### DIFF
--- a/.github/workflows/codegen-ci.yml
+++ b/.github/workflows/codegen-ci.yml
@@ -117,25 +117,3 @@ jobs:
           hide_comments: orphaned commits
           check_run_annotations_branch: '*'
           files: 'artifacts/sdk-codegen-test-results/*.xml'
-
-  # The following jobs are necessary because they are configured as required
-  # checks on PRs and would not otherwise run in this workflow. If the PR/branch
-  # triggering this workflow file also needs to actually run these tests, the
-  # other workflow files will pick it up and submit the results. In that case
-  # there will be duplicate PR check names but github handles this and requires
-  # both to be passing.
-  noop-python-results:
-    name: Python Tests
-    needs: [publish-test-results]
-    if: success() || failure()
-    runs-on: ubuntu-latest
-    steps:
-      - run: exit 0
-
-  noop-typescript-results:
-    name: Typescript Tests
-    needs: [publish-test-results]
-    if: success() || failure()
-    runs-on: ubuntu-latest
-    steps:
-      - run: exit 0

--- a/.github/workflows/noop-ci.yml
+++ b/.github/workflows/noop-ci.yml
@@ -1,45 +1,43 @@
+# The jobs in this workflow are necessary because they are configured as
+# required checks on PRs. Each job actually has a corresponding "real" job
+# definition in a different workflow file:
+#
+# codegen-ci.yml: Codegen Tests
+# tssdk-ci.yml: Typescript Tests
+# python-ci.yml: Python Tests
+#
+# By hard-coding passing jobs with the same name here every PR will satisfy the
+# repo's "required checks" EXCEPT those that trigger the "real" job AND that
+# "real" job fails.
+#
+# It will look a little confusing: any PR that triggers a corresponding "real"
+# job will have duplicate check entries, one that passes (this noop job) and the
+# "real" job that either passes or fails.
 name: Noop CI
 on:
-  # This workflow is intended to be manually run on a branch for which the
-  # PR triggers no other CI workflow (and thus cannot trigger any of the
-  # required jobs). Eg. docs, examples, new packages that don't have a CI
-  # workflow setup yet.
-  workflow_dispatch:
+  pull_request:
 
 jobs:
-  noop-test-results:
+  noop-codegen-results:
+    name: Codegen Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: octokit/request-action@v2.x
-        name: Noop Codegen Tests
-        with:
-          route: POST /repos/{owner}/{repo}/check-runs
-          owner: looker-open-source
-          repo: sdk-codegen
-          name: Codegen Tests
-          head_sha: ${{ github.sha }}
-          conclusion: success
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: octokit/request-action@v2.x
-        name: Noop Python Tests
-        with:
-          route: POST /repos/{owner}/{repo}/check-runs
-          owner: looker-open-source
-          repo: sdk-codegen
-          name: Python Tests
-          head_sha: ${{ github.sha }}
-          conclusion: success
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: octokit/request-action@v2.x
-        name: Noop Typescript Tests
-        with:
-          route: POST /repos/{owner}/{repo}/check-runs
-          owner: looker-open-source
-          repo: sdk-codegen
-          name: Typescript Tests
-          head_sha: ${{ github.sha }}
-          conclusion: success
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: exit 0
+
+  noop-typescript-results:
+    name: Typescript Tests
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0
+
+  noop-python-results:
+    name: Python Tests
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0
+
+  noop-apix-results:
+    name: APIX Tests
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -207,25 +207,3 @@ jobs:
           hide_comments: orphaned commits
           check_run_annotations_branch: '*'
           files: 'artifacts/python-test-results/*.xml'
-
-  # The following jobs are necessary because they are configured as required
-  # checks on PRs and would not otherwise run in this workflow. If the PR/branch
-  # triggering this workflow file also needs to actually run these tests, the
-  # other workflow files will pick it up and submit the results. In that case
-  # there will be duplicate PR check names but github handles this and requires
-  # both to be passing.
-  noop-codegen-results:
-    name: Codegen Tests
-    needs: [publish-test-results]
-    if: success() || failure()
-    runs-on: ubuntu-latest
-    steps:
-      - run: exit 0
-
-  noop-typescript-results:
-    name: Typescript Tests
-    needs: [publish-test-results]
-    if: success() || failure()
-    runs-on: ubuntu-latest
-    steps:
-      - run: exit 0

--- a/.github/workflows/tssdk-ci.yml
+++ b/.github/workflows/tssdk-ci.yml
@@ -178,25 +178,3 @@ jobs:
           hide_comments: orphaned commits
           check_run_annotations_branch: '*'
           files: 'artifacts/tssdk-test-results/*.xml'
-
-  # The following jobs are necessary because they are configured as required
-  # checks on PRs and would not otherwise run in this workflow. If the PR/branch
-  # triggering this workflow file also needs to actually run these tests, the
-  # other workflow files will pick it up and submit the results. In that case
-  # there will be duplicate PR check names but github handles this and requires
-  # both to be passing.
-  noop-codegen-results:
-    name: Codegen Tests
-    needs: [publish-test-results]
-    if: success() || failure()
-    runs-on: ubuntu-latest
-    steps:
-      - run: exit 0
-
-  noop-python-results:
-    name: Python Tests
-    needs: [publish-test-results]
-    if: success() || failure()
-    runs-on: ubuntu-latest
-    steps:
-      - run: exit 0


### PR DESCRIPTION
The benefit of having them duplicated in each workflow
file was the ability to delay their execution with the
`needs: [publish-test-results]` syntax. However, there
was buggy behavior where the python-ci workflow would
get attributed the actual jobs from the tssdk-ci workflow
and its own noop jobs would somehow fail with the
opaque `No such file or directory` error

The downside of centralizing them is losing the ability to
specify that `needs` syntax. I believe that means they
will "pass" immediately and there will be a window of
several minutes until the "real" jobs report where the PR
will satisfy all the required checks and could be
mergeable. If that is the case, I may consider hacking it
to do `sleep 300 && exit 0` which would introduce an
artifical delay that may or may not help avoid the issue
