### PR TITLE
refactor: improve ExploreType.tsx UI/UX

### DIFF
--- a/packages/api-explorer/src/components/ExploreType/ExploreProperty.tsx
+++ b/packages/api-explorer/src/components/ExploreType/ExploreProperty.tsx
@@ -24,9 +24,9 @@
 
  */
 
-import React, { FC, ReactNode } from 'react'
+import React, { FC } from 'react'
 import {
-  FlexItem,
+  Box,
   IconType,
   Icon,
   Tree,
@@ -148,20 +148,17 @@ export const ExplorePropertyReadOnly: FC<ExplorePropertyProps> = ({
  * @param property to describe
  * @constructor
  */
-export const ExplorePropertyDescription: FC<ExplorePropertyProps> = ({
-  property,
-}) => {
-  const p = ({ children }: { children: ReactNode }) => (
-    <Paragraph fontSize="small">{children}</Paragraph>
-  )
-  return (
-    <>
-      {property.description && (
-        <Markdown source={property.description} paragraphOverride={p} />
-      )}
-    </>
-  )
-}
+const DescriptionParagraph: FC = (props) => (
+  <Paragraph fontSize="small" m="none" {...props} />
+)
+
+const ExplorePropertyDescription: FC<ExplorePropertyProps> = ({ property }) =>
+  property.description ? (
+    <Markdown
+      source={property.description}
+      paragraphOverride={DescriptionParagraph}
+    />
+  ) : null
 
 /**
  * Show the details of the property
@@ -172,17 +169,17 @@ export const ExplorePropertyDetail: FC<ExplorePropertyProps> = ({
   property,
 }) => (
   <Space style={{ fontSize: 'small', marginLeft: '10rem' }}>
-    <FlexItem width="10rem">
+    <Box width="10rem">
       <ExploreTypeLink type={property.type} />
-    </FlexItem>
-    <FlexItem width="5rem">
+    </Box>
+    <Box width="5rem">
       <ExplorePropertyRequired property={property} />
       <ExplorePropertyReadOnly property={property} />
       <ExplorePropertyDeprecated property={property} />
-    </FlexItem>
-    <FlexItem width="30rem">
+    </Box>
+    <Box width="30rem">
       <ExplorePropertyDescription property={property} />
-    </FlexItem>
+    </Box>
   </Space>
 )
 

--- a/packages/api-explorer/src/components/ExploreType/ExploreType.tsx
+++ b/packages/api-explorer/src/components/ExploreType/ExploreType.tsx
@@ -26,7 +26,6 @@
 
 import React, { FC } from 'react'
 import { Code, Tree, TreeItem } from '@looker/components'
-import styled from 'styled-components'
 import { NavLink } from 'react-router-dom'
 import { IType, TypeOfType, typeOfType } from '@looker/sdk-codegen'
 import { useLocation } from 'react-router'
@@ -94,7 +93,7 @@ export const ExploreType: FC<ExploreTypeProps> = ({
   const nest = maxDepth === -1 || level < maxDepth
   const legend = typeIcon(type)
   return (
-    <TreeFix
+    <Tree
       border
       label={type.name}
       icon={legend.icon}
@@ -119,12 +118,6 @@ export const ExploreType: FC<ExploreTypeProps> = ({
             openAll={openAll}
           />
         ))}
-    </TreeFix>
+    </Tree>
   )
 }
-
-export const TreeFix = styled(Tree)`
-  & ul {
-    height: auto;
-  }
-`

--- a/packages/api-explorer/src/components/ExploreType/ExploreType.tsx
+++ b/packages/api-explorer/src/components/ExploreType/ExploreType.tsx
@@ -26,9 +26,9 @@
 
 import React, { FC } from 'react'
 import { Code, Tree, TreeItem } from '@looker/components'
-import { NavLink } from 'react-router-dom'
 import { IType, TypeOfType, typeOfType } from '@looker/sdk-codegen'
 import { useLocation } from 'react-router'
+import { Link } from '../Link'
 import { buildTypePath } from '../../utils'
 import { getSpecKey } from '../../reducers'
 import {
@@ -58,9 +58,9 @@ export const ExploreTypeLink: FC<ExploreTypeLinkProps> = ({ type }) => {
   return (
     <>
       {prefix}
-      <NavLink key={type.fullName} to={buildTypePath(specKey, name)}>
+      <Link key={type.fullName} to={buildTypePath(specKey, name)}>
         {name}
-      </NavLink>
+      </Link>
       {suffix}
     </>
   )

--- a/packages/api-explorer/src/components/ExploreType/index.ts
+++ b/packages/api-explorer/src/components/ExploreType/index.ts
@@ -24,7 +24,7 @@
 
  */
 
-export { ExploreType, ExploreTypeLink, TreeFix } from './ExploreType'
+export { ExploreType, ExploreTypeLink } from './ExploreType'
 export {
   ExploreProperty,
   ExplorePropertyNode,

--- a/packages/api-explorer/src/components/Header/Header.tsx
+++ b/packages/api-explorer/src/components/Header/Header.tsx
@@ -26,7 +26,6 @@
 
 import React, { FC, Dispatch } from 'react'
 import styled from 'styled-components'
-import { NavLink } from 'react-router-dom'
 import {
   Icon,
   Space,
@@ -37,8 +36,9 @@ import {
 import { LookerLogo } from '@looker/icons'
 import { ChangeHistory } from '@styled-icons/material/ChangeHistory'
 import { Menu } from '@styled-icons/material/Menu'
-
 import { SpecList } from '@looker/sdk-codegen'
+
+import { Link } from '../Link'
 import { SpecState, SpecAction } from '../../reducers'
 import { diffPath } from '../../utils'
 import { SdkLanguageSelector } from './SdkLanguageSelector'
@@ -82,7 +82,7 @@ export const HeaderLayout: FC<HeaderProps> = ({
         label="Toggle Navigation"
       />
 
-      <NavLink to={`/${spec.key}`}>
+      <Link to={`/${spec.key}`}>
         <Space gap="small">
           <Icon
             icon={<LookerLogo />}
@@ -92,19 +92,19 @@ export const HeaderLayout: FC<HeaderProps> = ({
           />
           <Heading color="key">API Explorer</Heading>
         </Space>
-      </NavLink>
+      </Link>
     </Space>
     <Space width="auto">
       <SdkLanguageSelector />
       <ApiSpecSelector specs={specs} spec={spec} specDispatch={specDispatch} />
-      <NavLink to={`/${diffPath}/${spec.key}/`}>
+      <Link to={`/${diffPath}/${spec.key}/`}>
         <IconButton
           toggle
           label="Compare Specifications"
           icon={<ChangeHistory />}
           size="small"
         />
-      </NavLink>
+      </Link>
     </Space>
   </SemanticHeader>
 )

--- a/packages/api-explorer/src/components/Link/Link.tsx
+++ b/packages/api-explorer/src/components/Link/Link.tsx
@@ -23,23 +23,18 @@
  SOFTWARE.
 
  */
-export { ApixHeading, ApixSection } from './common'
-export { DocActivityType } from './DocActivityType'
-export { DocCode } from './DocCode'
-export { DocMethodSummary } from './DocMethodSummary'
-export { DocMarkdown } from './DocMarkdown'
-export { DocPseudo } from './DocPseudo'
-export { DocRateLimited } from './DocRateLimited'
-export { DocReferences } from './DocReferences'
-export { DocResponses } from './DocResponses'
-export { DocSDKs } from './DocSDKs'
-export { DocSdkUsage } from './DocSdkUsage'
-export { DocSource } from './DocSource'
-export { DocStatus } from './DocStatus'
-export { DocTitle } from './DocTitle'
-export { Header } from './Header'
-export { SideNav } from './SideNav'
-export { ExploreType, ExploreProperty } from './ExploreType'
-export { CollapserCard } from './Collapser'
-export { DocSchema } from './DocSchema'
-export { Link } from './Link'
+
+import { NavLink } from 'react-router-dom'
+import styled from 'styled-components'
+
+export const Link = styled(NavLink)`
+  text-decoration: none;
+  color: inherit;
+
+  &:hover,
+  &:visited,
+  &:focus,
+  &.active {
+    color: inherit;
+  }
+`

--- a/packages/api-explorer/src/components/Link/index.ts
+++ b/packages/api-explorer/src/components/Link/index.ts
@@ -23,23 +23,5 @@
  SOFTWARE.
 
  */
-export { ApixHeading, ApixSection } from './common'
-export { DocActivityType } from './DocActivityType'
-export { DocCode } from './DocCode'
-export { DocMethodSummary } from './DocMethodSummary'
-export { DocMarkdown } from './DocMarkdown'
-export { DocPseudo } from './DocPseudo'
-export { DocRateLimited } from './DocRateLimited'
-export { DocReferences } from './DocReferences'
-export { DocResponses } from './DocResponses'
-export { DocSDKs } from './DocSDKs'
-export { DocSdkUsage } from './DocSdkUsage'
-export { DocSource } from './DocSource'
-export { DocStatus } from './DocStatus'
-export { DocTitle } from './DocTitle'
-export { Header } from './Header'
-export { SideNav } from './SideNav'
-export { ExploreType, ExploreProperty } from './ExploreType'
-export { CollapserCard } from './Collapser'
-export { DocSchema } from './DocSchema'
+
 export { Link } from './Link'

--- a/packages/api-explorer/src/components/SideNav/SideNavMethods.tsx
+++ b/packages/api-explorer/src/components/SideNav/SideNavMethods.tsx
@@ -34,7 +34,8 @@ import {
   Heading,
 } from '@looker/components'
 import { MethodList } from '@looker/sdk-codegen'
-import { useHistory, useRouteMatch, NavLink } from 'react-router-dom'
+import { useHistory, useRouteMatch } from 'react-router-dom'
+import { Link } from '../Link'
 import { buildMethodPath, highlightHTML } from '../../utils'
 import { SearchContext } from '../../context'
 
@@ -110,7 +111,7 @@ const AutoHeightList = styled(List)`
   height: auto;
 `
 
-const SideNavLink = styled(NavLink)`
+const SideNavLink = styled(Link)`
   &:hover,
   &:focus,
   &.active {

--- a/packages/api-explorer/src/components/SideNav/SideNavTypes.tsx
+++ b/packages/api-explorer/src/components/SideNav/SideNavTypes.tsx
@@ -28,7 +28,7 @@ import React, { FC, useContext } from 'react'
 import { Heading } from '@looker/components'
 import { TypeList, IntrinsicType } from '@looker/sdk-codegen'
 import styled from 'styled-components'
-import { NavLink } from 'react-router-dom'
+import { Link } from '../Link'
 import { buildTypePath, highlightHTML } from '../../utils'
 import { SearchContext } from '../../context'
 
@@ -60,7 +60,7 @@ export const SideNavTypes: FC<TypeProps> = ({ types, specKey }) => {
   )
 }
 
-const SideNavLink = styled(NavLink)`
+const SideNavLink = styled(Link)`
   display: block;
   padding: ${({
     theme: {

--- a/packages/api-explorer/src/index.tsx
+++ b/packages/api-explorer/src/index.tsx
@@ -27,6 +27,7 @@
 import React from 'react'
 import { BrowserRouter as Router } from 'react-router-dom'
 import ReactDOM from 'react-dom'
+import { createGlobalStyle } from 'styled-components'
 
 import { ApiModel, SpecList } from '@looker/sdk-codegen'
 import { StandaloneApiExplorer } from './StandaloneApiExplorer'
@@ -63,9 +64,16 @@ Object.values(specs).forEach((spec) => {
   spec.specContent = undefined
 })
 
+const BodyReset = createGlobalStyle`
+  body {
+    margin: 0;
+  }
+`
+
 ReactDOM.render(
   <Router>
     <StandaloneApiExplorer specs={specs} />
+    <BodyReset />
   </Router>,
   document.getElementById('container')
 )

--- a/packages/api-explorer/src/scenes/TagScene/TagScene.tsx
+++ b/packages/api-explorer/src/scenes/TagScene/TagScene.tsx
@@ -26,8 +26,8 @@
 import React, { FC, useEffect, useState } from 'react'
 import { Grid, ButtonToggle, ButtonItem } from '@looker/components'
 import { ApiModel } from '@looker/sdk-codegen'
-import { useParams, NavLink, useHistory } from 'react-router-dom'
-import { ApixSection, DocTitle, DocMethodSummary } from '../../components'
+import { useParams, useHistory } from 'react-router-dom'
+import { ApixSection, DocTitle, DocMethodSummary, Link } from '../../components'
 import { buildMethodPath } from '../../utils'
 import { getOperations } from './utils'
 
@@ -74,14 +74,14 @@ export const TagScene: FC<TagSceneProps> = ({ api }) => {
       {Object.values(methods).map(
         (method, index) =>
           (value === method.httpMethod || value === 'ALL') && (
-            <NavLink
+            <Link
               key={index}
               to={buildMethodPath(specKey, tag.name, method.name)}
             >
               <Grid columns={1} py="xsmall">
                 <DocMethodSummary key={index} method={method} />
               </Grid>
-            </NavLink>
+            </Link>
           )
       )}
     </ApixSection>

--- a/packages/code-editor/src/Markdown/Markdown.tsx
+++ b/packages/code-editor/src/Markdown/Markdown.tsx
@@ -41,7 +41,7 @@ interface MarkdownProps {
   pattern?: string
   transformLinkUri?: (url: string) => string
   linkClickHandler?: (pathname: string, href: string) => void
-  paragraphOverride?: ({ children }: { children: ReactNode }) => JSX.Element
+  paragraphOverride?: ({ children }: { children: ReactNode }) => ReactNode
 }
 
 type HeadingLevels = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'

--- a/packages/hackathon/src/components/SideNav/SideNav.tsx
+++ b/packages/hackathon/src/components/SideNav/SideNav.tsx
@@ -77,18 +77,17 @@ export const SideNav: FC<SideNavProps> = ({ authorizedRoutes }) => (
 )
 
 const Link = styled(NavLink)`
-  color:${({ theme }) => theme.colors.ui5}
-  cursor: pointer;
-  display: block;
-  padding: ${({
-    theme: {
-      space: { xsmall, large },
-    },
-  }) => `${xsmall} ${large}`};
+  text-decoration: none;
+  color: ${({ theme }) => theme.colors.ui5};
+
   &:hover,
   &:visited,
   &:focus,
   &.active {
-    color: ${({ theme }) => theme.colors.key};
+    color: inherit;
   }
+
+  cursor: pointer;
+  display: block;
+  padding: ${({ theme: { space } }) => `${space.xsmall} ${space.large}`};
 `


### PR DESCRIPTION
Improvements to the Looker Tree and NavLink components can be used to clean up the Type Explorer

Changes may include but may exceed:
- left nav
- `ExploreType`
- `ExploreTypeLink`
- `ExploreProperty`
- other `ExplorerProperty*` components