### PR TITLE
fix: permitting bytes type response

### DIFF
--- a/python/looker_sdk/sdk/api31/methods.py
+++ b/python/looker_sdk/sdk/api31/methods.py
@@ -5674,13 +5674,13 @@ class Looker31SDK(api_methods.APIMethods):
     # will be in the message of the 400 error response, but not as detailed as expressed in `json_detail.errors`.
     # These data formats can only carry row data, and error info is not row data.
     #
-    # GET /query_tasks/{query_task_id}/results -> str
+    # GET /query_tasks/{query_task_id}/results -> Union[str, bytes]
     def query_task_results(
         self,
         # ID of the Query Task
         query_task_id: str,
         transport_options: Optional[transport.TransportOptions] = None,
-    ) -> str:
+    ) -> Union[str, bytes]:
         """Get Async Query Results"""
         query_task_id = self.encode_path_param(query_task_id)
         response = self.get(
@@ -5688,7 +5688,7 @@ class Looker31SDK(api_methods.APIMethods):
             str,
             transport_options=transport_options,
         )
-        assert isinstance(response, str)
+        assert isinstance(response, str) or isinstance(response, bytes)
         return response
 
     # ### Get a previously created query by id.

--- a/python/looker_sdk/sdk/api40/methods.py
+++ b/python/looker_sdk/sdk/api40/methods.py
@@ -6869,13 +6869,13 @@ class Looker40SDK(api_methods.APIMethods):
     # will be in the message of the 400 error response, but not as detailed as expressed in `json_detail.errors`.
     # These data formats can only carry row data, and error info is not row data.
     #
-    # GET /query_tasks/{query_task_id}/results -> str
+    # GET /query_tasks/{query_task_id}/results -> Union[str, bytes]
     def query_task_results(
         self,
         # ID of the Query Task
         query_task_id: str,
         transport_options: Optional[transport.TransportOptions] = None,
-    ) -> str:
+    ) -> Union[str, bytes]:
         """Get Async Query Results"""
         query_task_id = self.encode_path_param(query_task_id)
         response = self.get(
@@ -6883,7 +6883,7 @@ class Looker40SDK(api_methods.APIMethods):
             str,
             transport_options=transport_options,
         )
-        assert isinstance(response, str)
+        assert isinstance(response, str) or isinstance(response, bytes)
         return response
 
     # ### Get a previously created query by id.


### PR DESCRIPTION
Fix: Permitting bytes type response for `query_task_results` method. We were trying to use async run to generate `.xlsx` files and ran into the assertion.

There are 100 other occurrences of this assertion pattern (`isinstance(response, str)`). I did not go through them as our fledgling implementation of the python SDK is pretty low-coverage and does not utilize most of the methods in these files. 

## Developer Checklist [ℹ️](https://github.com/looker-open-source/sdk-codegen/blob/main/CONTRIBUTING.md#developer-checklist)

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/looker-open-source/sdk-codegen/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Appropriate docs were updated (if necessary)

Fixes Issue: https://github.com/looker-open-source/sdk-codegen/issues/695