### PR TITLE
feat: syntax highlight application/sql responses

### DIFF
--- a/packages/extension-api-explorer/src/Loader.tsx
+++ b/packages/extension-api-explorer/src/Loader.tsx
@@ -29,7 +29,7 @@ import {
   Flex,
   FlexItem,
   Heading,
-  Spinner,
+  ProgressCircular,
 } from '@looker/components'
 import { ThemeOverrides } from '@looker/api-explorer/src/utils'
 
@@ -41,7 +41,7 @@ export const Loader: FC<LoaderProps> = ({ themeOverrides }) => (
   <ComponentsProvider {...themeOverrides}>
     <Flex flexDirection="column" justifyContent="center" mt="25%">
       <FlexItem alignSelf="center">
-        <Spinner color="key" size={150} />
+        <ProgressCircular size="large" />
       </FlexItem>
       <FlexItem mt="large" alignSelf="center">
         <Heading color="key" as="h2">

--- a/packages/hackathon/src/components/Loading/Loading.tsx
+++ b/packages/hackathon/src/components/Loading/Loading.tsx
@@ -25,7 +25,7 @@
  */
 
 import React, { FC } from 'react'
-import { Flex, Spinner, Text } from '@looker/components'
+import { Flex, ProgressCircular, Text } from '@looker/components'
 
 interface LoadingProps {
   loading: boolean
@@ -39,7 +39,7 @@ export const Loading: FC<LoadingProps> = ({
   <Flex height="40px" alignItems="center">
     {loading && (
       <>
-        <Spinner />
+        <ProgressCircular />
         <Text ml="large">{message}</Text>
       </>
     )}

--- a/packages/run-it/src/components/Loading/Loading.tsx
+++ b/packages/run-it/src/components/Loading/Loading.tsx
@@ -25,7 +25,7 @@
  */
 
 import React, { FC } from 'react'
-import { Flex, Spinner } from '@looker/components'
+import { Space, ProgressCircular, Text } from '@looker/components'
 
 interface LoadingProps {
   loading: boolean
@@ -38,10 +38,10 @@ export const Loading: FC<LoadingProps> = ({
 }) => (
   <>
     {loading && (
-      <Flex>
-        <Spinner />
-        {message}
-      </Flex>
+      <Space gap="small">
+        <ProgressCircular size="small" />
+        <Text color="text">{message}</Text>
+      </Space>
     )}
   </>
 )

--- a/packages/run-it/src/components/ShowResponse/responseUtils.spec.tsx
+++ b/packages/run-it/src/components/ShowResponse/responseUtils.spec.tsx
@@ -26,6 +26,7 @@
 import {
   testErrorResponse,
   testHtmlResponse,
+  testSqlResponse,
   testImageResponse,
   testJsonResponse,
   testTextResponse,
@@ -176,6 +177,11 @@ describe('responseUtils', () => {
     const actual = pickResponseHandler(testTextResponse)
     expect(actual).toBeDefined()
     expect(actual.label).toEqual('text')
+  })
+  test('it handles sql', () => {
+    const actual = pickResponseHandler(testSqlResponse)
+    expect(actual).toBeDefined()
+    expect(actual.label).toEqual('sql')
   })
   test('it handles html', () => {
     const actual = pickResponseHandler(testHtmlResponse)

--- a/packages/run-it/src/components/ShowResponse/responseUtils.tsx
+++ b/packages/run-it/src/components/ShowResponse/responseUtils.tsx
@@ -120,6 +120,10 @@ const ShowHTML = (response: IRawResponse) => (
   <CodeDisplay language="html" code={response.body.toString()} transparent />
 )
 
+const ShowSQL = (response: IRawResponse) => (
+  <CodeDisplay language="sql" code={response.body.toString()} transparent />
+)
+
 /**
  * A handler for unknown response types. It renders the size of the unknown response and its type.
  */
@@ -178,6 +182,11 @@ export const responseHandlers: Responder[] = [
     label: 'pdf',
     isRecognized: (contentType) => /application\/pdf/g.test(contentType),
     component: (response) => ShowPDF(response),
+  },
+  {
+    label: 'sql',
+    isRecognized: (contentType) => /application\/sql/g.test(contentType),
+    component: (response) => ShowSQL(response),
   },
   {
     label: 'text',

--- a/packages/run-it/src/test-data/index.ts
+++ b/packages/run-it/src/test-data/index.ts
@@ -26,6 +26,7 @@
 export {
   testImageResponse,
   testJsonResponse,
+  testSqlResponse,
   testTextResponse,
   testHtmlResponse,
   testUnknownResponse,

--- a/packages/run-it/src/test-data/responses.ts
+++ b/packages/run-it/src/test-data/responses.ts
@@ -58,6 +58,19 @@ export const testHtmlResponse: IRawResponse = {
   ),
 }
 
+export const testSqlResponse: IRawResponse = {
+  url: `https://some/sql`,
+  contentType: 'application/sql',
+  ok: true,
+  statusCode: 200,
+  statusMessage: 'OK',
+  body: Buffer.from(`SELECT
+    COUNT(DISTINCT products.id ) AS \`products.count\`
+FROM demo_db.inventory_items  AS inventory_items
+LEFT JOIN demo_db.products  AS products ON inventory_items.product_id = products.id
+LIMIT 500`),
+}
+
 export const testImageResponse = (contentType = 'image/png'): IRawResponse => ({
   url: `http://${contentType}`,
   contentType,


### PR DESCRIPTION
- also changed to `ProgressCircular` "processing" component

- fixed text color on RunIt response progress indicator