### PR TITLE
feat(APIError): New Python error class giving access to API response

### DIFF
--- a/python/looker_sdk/error.py
+++ b/python/looker_sdk/error.py
@@ -22,8 +22,20 @@
 
 """API error class
 """
+import json
 
 
 class SDKError(Exception):
+    """SDK error class
+    """
+
+class APIError(SDKError):
     """API error class
     """
+    def __init__(self, sdk_response, *args, **kwargs):
+        super(APIError).__init__(*args, **kwargs)
+        self._sdk_response = json.loads(sdk_response)
+    
+    @property
+    def sdk_response(self) -> dict:
+        return self._sdk_response

--- a/python/looker_sdk/error.py
+++ b/python/looker_sdk/error.py
@@ -32,10 +32,10 @@ class SDKError(Exception):
 class APIError(SDKError):
     """API error class
     """
-    def __init__(self, sdk_response: str, *args, **kwargs):
+    def __init__(self, api_response: str, *args, **kwargs):
         super(APIError).__init__(*args, **kwargs)
-        self._sdk_response = json.loads(sdk_response)
+        self._api_response = json.loads(api_response)
     
     @property
-    def sdk_response(self) -> dict:
-        return self._sdk_response
+    def api_response(self) -> dict:
+        return self._api_response

--- a/python/looker_sdk/error.py
+++ b/python/looker_sdk/error.py
@@ -32,7 +32,7 @@ class SDKError(Exception):
 class APIError(SDKError):
     """API error class
     """
-    def __init__(self, sdk_response, *args, **kwargs):
+    def __init__(self, sdk_response: str, *args, **kwargs):
         super(APIError).__init__(*args, **kwargs)
         self._sdk_response = json.loads(sdk_response)
     

--- a/python/looker_sdk/rtl/api_methods.py
+++ b/python/looker_sdk/rtl/api_methods.py
@@ -84,7 +84,7 @@ class APIMethods:
     def _return(self, response: transport.Response, structure: TStructure) -> TReturn:
         encoding = response.encoding
         if not response.ok:
-            raise error.SDKError(response.value.decode(encoding=encoding))
+            raise error.APIError(response.value.decode(encoding=encoding))
         ret: TReturn
         if structure is None:
             ret = None


### PR DESCRIPTION
This change introduces a new `APIError` class (inheriting from SDKError) which takes one argument of the `api_response` which should be the JSON payload from the Looker endpoint.

This gets loaded by the class and made accessible as the `APIError.api_response` property.

The idea is to give simpler access to the type of error that was received from the endpoint in order to take different actions.

## Developer Checklist [ℹ️](https://github.com/looker-open-source/sdk-codegen/blob/main/CONTRIBUTING.md#developer-checklist)

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [X] Make sure to open an issue as a [bug/issue](https://github.com/looker-open-source/sdk-codegen/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Appropriate docs were updated (if necessary)

Fixes #723 🦕
