### PR TITLE
fix: check HTTP status code for TS SDK "ok" toggle

### DIFF
--- a/packages/sdk-node/src/nodeTransport.spec.ts
+++ b/packages/sdk-node/src/nodeTransport.spec.ts
@@ -24,7 +24,7 @@
 
  */
 
-import { ITransportSettings } from '@looker/sdk-rtl'
+import { IRawResponse, ITransportSettings, StatusCode } from '@looker/sdk-rtl'
 import { NodeCryptoHash, NodeTransport } from './nodeTransport'
 
 describe('NodeTransport', () => {
@@ -35,7 +35,7 @@ describe('NodeTransport', () => {
   const badPath = fullPath + '_bogus'
   // const queryParams = { a: 'b c', d: false, nil: null, skip: undefined }
 
-  it('raw request retrieves fully qualified url', async () => {
+  test('raw request retrieves fully qualified url', async () => {
     const response = await xp.rawRequest('GET', fullPath)
     expect(response).toBeDefined()
     expect(response.ok).toEqual(true)
@@ -50,7 +50,7 @@ describe('NodeTransport', () => {
   })
 
   describe('transport errors', () => {
-    it('gracefully handles Node-level transport errors', async () => {
+    test('gracefully handles Node-level transport errors', async () => {
       const response = await xp.rawRequest('GET', badPath)
       const errorMessage = `GET ${badPath}`
       expect(response).toBeDefined()
@@ -62,7 +62,7 @@ describe('NodeTransport', () => {
     })
   })
 
-  it('retrieves fully qualified url', async () => {
+  test('retrieves fully qualified url', async () => {
     const response = await xp.request<string, Error>('GET', fullPath)
     expect(response).toBeDefined()
     expect(response.ok).toEqual(true)
@@ -74,8 +74,34 @@ describe('NodeTransport', () => {
     }
   })
 
+  describe('ok check', () => {
+    const raw: IRawResponse = {
+      contentType: 'application/json',
+      headers: {},
+      url: 'bogus',
+      ok: true,
+      statusCode: StatusCode.OK,
+      statusMessage: 'Mocked success',
+      body: 'body',
+    }
+
+    test('ok is ok', () => {
+      expect(xp.ok(raw)).toEqual(true)
+    })
+
+    test('All 2xx responses are ok', () => {
+      raw.statusCode = StatusCode.IMUsed
+      expect(xp.ok(raw)).toEqual(true)
+    })
+
+    test('Non-2xx responses are not ok', () => {
+      raw.statusCode = 422
+      expect(xp.ok(raw)).toEqual(false)
+    })
+  })
+
   describe('NodeCryptoHash', () => {
-    it('secureRandom', () => {
+    test('secureRandom', () => {
       const hasher = new NodeCryptoHash()
       const rand1 = hasher.secureRandom(5)
       expect(rand1.length).toEqual(10)
@@ -83,7 +109,7 @@ describe('NodeTransport', () => {
       expect(rand2.length).toEqual(64)
     })
 
-    it('sha256hash', async () => {
+    test('sha256hash', async () => {
       const hasher = new NodeCryptoHash()
       const message = 'The quick brown fox jumped over the lazy dog.'
       const hash = await hasher.sha256Hash(message)

--- a/packages/sdk-node/src/nodeTransport.ts
+++ b/packages/sdk-node/src/nodeTransport.ts
@@ -115,6 +115,8 @@ export class NodeTransport extends BaseTransport {
         statusMessage: resTyped.statusMessage,
         headers: res.headers,
       }
+      // Update OK with response statusCode check
+      rawResponse.ok = this.ok(rawResponse)
     } catch (e) {
       let statusMessage = `${method} ${path}`
       let statusCode = 404

--- a/packages/sdk-rtl/src/baseTransport.ts
+++ b/packages/sdk-rtl/src/baseTransport.ts
@@ -48,7 +48,7 @@ export abstract class BaseTransport implements ITransport {
     raw: IRawResponse
   ): Promise<SDKResponse<TSuccess, TError>>
 
-  protected ok(res: IRawResponse): boolean {
+  ok(res: IRawResponse): boolean {
     return (
       res.statusCode >= StatusCode.OK && res.statusCode <= StatusCode.IMUsed
     )

--- a/packages/sdk-rtl/src/browserTransport.ts
+++ b/packages/sdk-rtl/src/browserTransport.ts
@@ -211,6 +211,8 @@ export class BrowserTransport extends BaseTransport {
       startMark: started,
       headers,
     }
+    // Update OK with response statusCode check
+    response.ok = this.ok(response)
     return this.observer ? this.observer(response) : response
   }
 


### PR DESCRIPTION
`422` and other "not ok" statuses were being left as `ok: true` with the recent raw request observer implementation. This fixes the bug.