### PR TITLE
feat: simplify apix dev portal navigation toggle

### DIFF
--- a/packages/api-explorer/src/ApiExplorer.tsx
+++ b/packages/api-explorer/src/ApiExplorer.tsx
@@ -24,14 +24,7 @@
 
  */
 
-import React, {
-  FC,
-  useReducer,
-  useState,
-  useEffect,
-  useRef,
-  useCallback,
-} from 'react'
+import React, { FC, useReducer, useState, useEffect, useCallback } from 'react'
 import { useLocation } from 'react-router'
 import styled, { createGlobalStyle } from 'styled-components'
 import { Aside, ComponentsProvider, Layout, Page } from '@looker/components'
@@ -92,30 +85,21 @@ const ApiExplorer: FC<ApiExplorerProps> = ({
   const toggleNavigation = (target?: boolean) =>
     setHasNavigation(target || !hasNavigation)
 
-  const hasNavigationRef = useRef<boolean>(hasNavigation)
-  const hasNavigationRefToggle = useCallback((e: MessageEvent<any>) => {
+  const hasNavigationToggle = useCallback((e: MessageEvent<any>) => {
     if (e.origin === window.origin && e.data.action === 'toggle_sidebar') {
-      // Use the current navigation value stored in the ref
-      // (this function is called outside of the scope of a hook
-      // so cannot see state).
-      setHasNavigation(!hasNavigationRef.current)
+      setHasNavigation((currentHasNavigation) => !currentHasNavigation)
     }
   }, [])
   useEffect(() => {
     if (headless) {
-      window.addEventListener('message', hasNavigationRefToggle)
+      window.addEventListener('message', hasNavigationToggle)
     }
     return () => {
       if (headless) {
-        window.removeEventListener('message', hasNavigationRefToggle)
+        window.removeEventListener('message', hasNavigationToggle)
       }
     }
   }, [])
-  useEffect(() => {
-    // Store current toggle value in a ref so window message
-    // listener knows what it is.
-    hasNavigationRef.current = hasNavigation
-  }, [hasNavigation])
 
   useEffect(() => {
     getLoded(exampleLodeUrl, declarationsLodeUrl).then((resp) => setLode(resp))


### PR DESCRIPTION
While walking the dog I realized that it was not necessary to use useRef to hold the current value of the toggle. The alternative is to pass a function to setState that accepts the current value. This change does that.
