### PR TITLE
chore: Add nix present check to .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,3 @@
-use nix
+if has nix; then
+  use nix
+fi


### PR DESCRIPTION
I was making a similar change in the `embed-sdk` repo. It was suggested I test for nix before using nix to be nice to non nix users. Propagating that fix here.

Note, you will need to run `direnv allow` again.