### PR TITLE
fix: remove python setup.py author_email

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -76,11 +76,6 @@ jobs:
           pip install tox
       - name: Run Unit Tests
         run: tox -e unit
-      - name: Twine upload check
-        run: |
-          pip install wheel twine
-          python setup.py sdist bdist_wheel
-          twine check dist/*
       - name: Upload pytest test results
         if: ${{ always() }}
         uses: actions/upload-artifact@v2
@@ -187,8 +182,22 @@ jobs:
           name: python-test-results
           path: python/results/
 
+  twine:
+    needs: integration
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+      - name: Twine upload check
+        run: |
+          pip install wheel twine
+          python setup.py sdist bdist_wheel
+          twine check dist/*
+
   publish-test-results:
-    needs: [unit, integration]
+    needs: [unit, integration, twine]
     if: success() || failure()
     runs-on: ubuntu-latest
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -45,13 +45,12 @@ REQUIRES = [
 
 setup(
     author="Looker Data Sciences, Inc.",
-    author_email="Looker Team <https://help.looker.com>",
-    description="Looker API 3.1",
+    description="Looker REST API",
     install_requires=REQUIRES,
     license="MIT",
     long_description=open("README.rst").read(),
     long_description_content_type="text/x-rst",
-    keywords=["Looker", "Looker API", "looker_sdk", "Looker API 3.1"],
+    keywords=["Looker", "Looker API", "looker_sdk", "Looker API 3.1", "Looker API 4.0"],
     name=NAME,
     package_data={"looker_sdk": ["py.typed", "looker_sdk/looker-sample.ini"]},
     packages=find_packages(),


### PR DESCRIPTION
we no longer have support@looker.com and this field only accepts
a valid email address. sadly twine check does not catch this error
yet, hopefully it will some day.

Factored the twine check out of the unit matrix: it only needs to run once