### PR TITLE
fix: placate TypeScript 4.4

### DIFF
--- a/packages/sdk-rtl/package.json
+++ b/packages/sdk-rtl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@looker/sdk-rtl",
-  "version": "21.0.20",
+  "version": "21.0.19",
   "description": "Looker SDK Runtime Library",
   "main": "lib/index.js",
   "module": "lib/esm/index.js",

--- a/packages/sdk-rtl/package.json
+++ b/packages/sdk-rtl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@looker/sdk-rtl",
-  "version": "21.0.19",
+  "version": "21.0.20",
   "description": "Looker SDK Runtime Library",
   "main": "lib/index.js",
   "module": "lib/esm/index.js",

--- a/packages/sdk-rtl/src/browserTransport.ts
+++ b/packages/sdk-rtl/src/browserTransport.ts
@@ -41,6 +41,7 @@ import {
   responseMode,
   ResponseMode,
   safeBase64,
+  isErrorLike,
 } from './transport'
 import { BaseTransport } from './baseTransport'
 import { ICryptoHash } from './cryptoHash'
@@ -297,7 +298,8 @@ export class BrowserTransport extends BaseTransport {
         res
       )
       return result
-    } catch (e) {
+    } catch (e: unknown) {
+      if (!isErrorLike(e)) throw e
       const error: ISDKError = {
         message:
           typeof e.message === 'string'

--- a/packages/sdk-rtl/src/transport.ts
+++ b/packages/sdk-rtl/src/transport.ts
@@ -505,3 +505,18 @@ export function safeBase64(u8: Uint8Array) {
   const rawBase64 = btoa(String.fromCharCode(...u8))
   return rawBase64.replace(/\+/g, '-').replace(/\//g, '_')
 }
+
+/**
+ * Type predicate. Asserts that a given object is error-like.
+ * @param error a value of unknown type
+ * @return boolean true if the error has a `message` key of type string.
+ */
+export function isErrorLike<T extends unknown>(
+  error: T
+): error is T & { message: string } {
+  if (typeof error !== 'object') return false
+  if (!error) return false
+  if (!Object.prototype.hasOwnProperty.call(error, 'message')) return false
+  if (typeof (error as { message: unknown }).message !== 'string') return false
+  return true
+}


### PR DESCRIPTION
TypeScript 4.4 assigns errors the type `unknown` by default in catch clauses. This PR supplies the necessary assertions to safely extract the `message` field in `browserTransport.ts`, and rethrows the error if it fails to meet these expectations.