### PR TITLE
feat: lots of RunIt form cleanup

### DIFF
--- a/packages/api-explorer/src/scenes/MethodScene/utils.spec.ts
+++ b/packages/api-explorer/src/scenes/MethodScene/utils.spec.ts
@@ -29,67 +29,102 @@ import { createInputs } from './utils'
 
 describe('MethodScene utils', () => {
   describe('run-it utils', () => {
-    test('createInputs works with various param types', () => {
-      const method = api.methods.run_inline_query
-      const actual = createInputs(api, method)
-      expect(actual).toHaveLength(method.allParams.length)
+    describe('createInputs', () => {
+      test('converts delimarray to string', () => {
+        const method = api.methods.all_users
+        const actual = createInputs(api, method)
+        expect(actual).toHaveLength(method.allParams.length)
+        expect(actual[4]).toEqual({
+          name: 'ids',
+          location: 'query',
+          type: 'string',
+          required: false,
+          description: 'Optional list of ids to get specific users.',
+        })
+      })
 
-      expect(actual).toEqual(
-        expect.arrayContaining([
-          /** Boolean param */
-          {
-            name: 'cache',
-            location: 'query',
-            type: 'boolean',
-            required: false,
-            description: 'Get results from cache if available.',
+      test('converts enums in body to string', () => {
+        const method = api.methods.create_query_task
+        const actual = createInputs(api, method)
+        expect(actual).toHaveLength(method.allParams.length)
+        expect(actual[0]).toEqual({
+          name: 'body',
+          location: 'body',
+          type: {
+            query_id: 0,
+            result_format: '',
+            source: '',
+            deferred: false,
+            look_id: 0,
+            dashboard_id: '',
           },
-          /** Number param */
-          {
-            name: 'limit',
-            location: 'query',
-            type: 'int64',
-            required: false,
-            description: expect.any(String),
-          },
-          /** String param */
-          {
-            name: 'result_format',
-            location: 'path',
-            type: 'string',
-            required: true,
-            description: 'Format of result',
-          },
-          /** Body param */
-          {
-            name: 'body',
-            location: 'body',
-            type: expect.objectContaining({
-              model: '',
-              view: '',
-              fields: [],
-              pivots: [],
-              fill_fields: [],
-              filters: {},
-              filter_expression: '',
-              sorts: [],
-              limit: '',
-              column_limit: '',
-              total: false,
-              row_total: '',
-              subtotals: [],
-              vis_config: {},
-              filter_config: {},
-              visible_ui_sections: '',
-              dynamic_fields: '',
-              client_id: '',
-              query_timezone: '',
-            }),
-            required: true,
-            description: '',
-          },
-        ])
-      )
+          required: true,
+          description: '',
+        })
+      })
+
+      test('works with various param types', () => {
+        const method = api.methods.run_inline_query
+        const actual = createInputs(api, method)
+        expect(actual).toHaveLength(method.allParams.length)
+
+        expect(actual).toEqual(
+          expect.arrayContaining([
+            /** Boolean param */
+            {
+              name: 'cache',
+              location: 'query',
+              type: 'boolean',
+              required: false,
+              description: 'Get results from cache if available.',
+            },
+            /** Number param */
+            {
+              name: 'limit',
+              location: 'query',
+              type: 'int64',
+              required: false,
+              description: expect.any(String),
+            },
+            /** String param */
+            {
+              name: 'result_format',
+              location: 'path',
+              type: 'string',
+              required: true,
+              description: 'Format of result',
+            },
+            /** Body param */
+            {
+              name: 'body',
+              location: 'body',
+              type: expect.objectContaining({
+                model: '',
+                view: '',
+                fields: [],
+                pivots: [],
+                fill_fields: [],
+                filters: {},
+                filter_expression: '',
+                sorts: [],
+                limit: '',
+                column_limit: '',
+                total: false,
+                row_total: '',
+                subtotals: [],
+                vis_config: {},
+                filter_config: {},
+                visible_ui_sections: '',
+                dynamic_fields: '',
+                client_id: '',
+                query_timezone: '',
+              }),
+              required: true,
+              description: '',
+            },
+          ])
+        )
+      })
     })
   })
 })

--- a/packages/api-explorer/src/scenes/MethodScene/utils.ts
+++ b/packages/api-explorer/src/scenes/MethodScene/utils.ts
@@ -106,6 +106,11 @@ const createSampleBody = (spec: IApiModel, type: IType) => {
   return recurse(type)
 }
 
+/**
+ * Convert model type to an editable type
+ * @param spec API model for building input editor
+ * @param type to convert
+ */
 const editType = (spec: IApiModel, type: IType) => {
   if (type instanceof IntrinsicType) return type.name
   // TODO create a DelimArray editing component as part of the complex type editor

--- a/packages/api-explorer/src/scenes/MethodScene/utils.ts
+++ b/packages/api-explorer/src/scenes/MethodScene/utils.ts
@@ -32,8 +32,9 @@ import {
   IntrinsicType,
   IType,
   IMethod,
+  EnumType,
 } from '@looker/sdk-codegen'
-import { RunItInput } from '@looker/run-it'
+import { RunItInput, RunItValues } from '@looker/run-it'
 
 /**
  * Return a default value for a given type name
@@ -78,20 +79,22 @@ const createSampleBody = (spec: IApiModel, type: IType) => {
   /* eslint-disable @typescript-eslint/no-use-before-define */
   const getSampleValue = (type: IType) => {
     if (type instanceof IntrinsicType) return getTypeDefault(type.name)
+    if (type instanceof DelimArrayType)
+      return getTypeDefault(type.elementType.name)
+    if (type instanceof EnumType) return ''
     if (type instanceof ArrayType)
       return type.customType
         ? [recurse(spec.types[type.customType])]
         : getTypeDefault(type.name)
     if (type instanceof HashType)
       return type.customType ? recurse(spec.types[type.customType]) : {}
-    if (type instanceof DelimArrayType) return ''
 
     return recurse(type)
   }
   /* eslint-enable @typescript-eslint/no-use-before-define */
 
   const recurse = (type: IType) => {
-    const sampleBody: { [key: string]: any } = {}
+    const sampleBody: RunItValues = {}
     for (const prop of type.writeable) {
       const sampleValue = getSampleValue(prop.type)
       if (sampleValue !== undefined) {
@@ -103,6 +106,13 @@ const createSampleBody = (spec: IApiModel, type: IType) => {
   return recurse(type)
 }
 
+const editType = (spec: IApiModel, type: IType) => {
+  if (type instanceof IntrinsicType) return type.name
+  // TODO create a DelimArray editing component as part of the complex type editor
+  if (type instanceof DelimArrayType) return 'string'
+  return createSampleBody(spec, type)
+}
+
 /**
  * Given an SDK method create and return an array of inputs for the run-it form
  * @param spec Api spec
@@ -112,10 +122,7 @@ export const createInputs = (spec: IApiModel, method: IMethod): RunItInput[] =>
   method.allParams.map((param) => ({
     name: param.name,
     location: param.location,
-    type:
-      param.type instanceof IntrinsicType
-        ? param.type.name
-        : createSampleBody(spec, param.type),
+    type: editType(spec, param.type),
     required: param.required,
     description: param.description,
   }))

--- a/packages/code-editor/src/CodeDisplay/CodeDisplay.tsx
+++ b/packages/code-editor/src/CodeDisplay/CodeDisplay.tsx
@@ -39,6 +39,7 @@ require('prismjs/components/prism-kotlin')
 require('prismjs/components/prism-csharp')
 require('prismjs/components/prism-swift')
 require('prismjs/components/prism-ruby')
+require('prismjs/components/prism-markdown')
 
 const Line = styled(Span)`
   display: table-row;

--- a/packages/run-it/src/components/LoginForm/LoginForm.tsx
+++ b/packages/run-it/src/components/LoginForm/LoginForm.tsx
@@ -64,7 +64,9 @@ export const LoginForm: FC<LoginFormProps> = ({
 
   return (
     <Tooltip content={readyToLogin}>
-      <Button onClick={handleLogin}>Login</Button>
+      <Button key="loginButton" onClick={handleLogin}>
+        Login
+      </Button>
     </Tooltip>
   )
 }

--- a/packages/run-it/src/components/LoginForm/LoginForm.tsx
+++ b/packages/run-it/src/components/LoginForm/LoginForm.tsx
@@ -64,9 +64,7 @@ export const LoginForm: FC<LoginFormProps> = ({
 
   return (
     <Tooltip content={readyToLogin}>
-      <Button key="loginButton" onClick={handleLogin}>
-        Login
-      </Button>
+      <Button onClick={handleLogin}>Login</Button>
     </Tooltip>
   )
 }

--- a/packages/run-it/src/components/RequestForm/FormItem.tsx
+++ b/packages/run-it/src/components/RequestForm/FormItem.tsx
@@ -42,10 +42,13 @@ interface FormItemProps {
  * @param label optional label
  */
 export const FormItem: FC<FormItemProps> = ({ id, children, label = ' ' }) => {
+  const key = `space_${id}`
   return (
-    <Space id={`space_${id}`}>
-      <Box width="120px" flexShrink={0}>
-        <Label htmlFor={id}>{label}</Label>
+    <Space id={key} key={key}>
+      <Box key={`${key}_box`} width="120px" flexShrink={0}>
+        <Label key={`${key}_label_for`} htmlFor={id}>
+          {label}
+        </Label>
       </Box>
       {children}
     </Space>

--- a/packages/run-it/src/components/RequestForm/FormItem.tsx
+++ b/packages/run-it/src/components/RequestForm/FormItem.tsx
@@ -1,0 +1,53 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2021 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+import React, { FC, ReactElement } from 'react'
+import { Space, Box, Label } from '@looker/components'
+
+interface FormItemProps {
+  /** ID of input item for label */
+  id: string
+  /** Optional label. Defaults to an empty string so spacing is preserved */
+  label?: string
+  /** Nested react elements */
+  children: ReactElement
+}
+
+/**
+ * basic input form layout component
+ * @param id of input item
+ * @param children embedded react elements
+ * @param label optional label
+ */
+export const FormItem: FC<FormItemProps> = ({ id, children, label = ' ' }) => {
+  return (
+    <Space id={`space_${id}`}>
+      <Box width="120px" flexShrink={0}>
+        <Label htmlFor={id}>{label}</Label>
+      </Box>
+      {children}
+    </Space>
+  )
+}

--- a/packages/run-it/src/components/RequestForm/RequestForm.spec.tsx
+++ b/packages/run-it/src/components/RequestForm/RequestForm.spec.tsx
@@ -152,6 +152,57 @@ describe('RequestForm', () => {
     })
   })
 
+  /** Return time that matches day picker in calendar */
+  const noon = () => {
+    const now = new Date()
+    return new Date(
+      now.getFullYear(),
+      now.getMonth(),
+      now.getDate(),
+      12,
+      0,
+      0,
+      0
+    )
+  }
+
+  test('interacting with a date picker changes the request content', async () => {
+    const name = 'date_item'
+    renderWithTheme(
+      <RequestForm
+        configurator={defaultConfigurator}
+        setVersionsUrl={runItNoSet}
+        inputs={[
+          {
+            name,
+            location: 'query',
+            required: true,
+            type: 'datetime',
+            description: 'some datetime item description',
+          },
+        ]}
+        handleSubmit={handleSubmit}
+        httpMethod={'POST'}
+        requestContent={requestContent}
+        setRequestContent={setRequestContent}
+        needsAuth={false}
+        hasConfig={true}
+        sdk={mockSdk}
+        handleConfig={runItNoSet}
+      />
+    )
+
+    const button = screen.getByRole('button', { name: 'Choose' })
+    userEvent.click(button)
+    await waitFor(() => {
+      const today = noon()
+      const pickName = today.toDateString()
+      const cell = screen.getByRole('gridcell', { name: pickName })
+      userEvent.click(cell)
+      expect(setRequestContent).toHaveBeenLastCalledWith({ [name]: today })
+    })
+  })
+
   test('interactive with a number simple item changes the request content', async () => {
     const name = 'number_item'
     renderWithTheme(

--- a/packages/run-it/src/components/RequestForm/RequestForm.tsx
+++ b/packages/run-it/src/components/RequestForm/RequestForm.tsx
@@ -129,7 +129,7 @@ export const RequestForm: FC<RequestFormProps> = ({
 
   return (
     <Form onSubmit={handleSubmit}>
-      <Fieldset>
+      <Fieldset key="inputs">
         {inputs.map((input) =>
           typeof input.type === 'string'
             ? createSimpleItem(
@@ -155,20 +155,31 @@ export const RequestForm: FC<RequestFormProps> = ({
                   requestContent={requestContent}
                 />
               ) : (
-                <Tooltip content="Run the API request">
-                  <Button type="submit">Run</Button>
+                <Tooltip key="runTip" content="Run the API request">
+                  <Button key="runButton" type="submit">
+                    Run
+                  </Button>
                 </Tooltip>
               )
             ) : (
               !isExtension &&
               setHasConfig && (
-                <Tooltip content="Configure your OAuth server to Run requests">
-                  <Button onClick={handleConfig}>Configure</Button>
+                <Tooltip
+                  key="configTip"
+                  content="Configure your OAuth server to Run requests"
+                >
+                  <Button key="configureButton" onClick={handleConfig}>
+                    Configure
+                  </Button>
                 </Tooltip>
               )
             )}
-            <Tooltip content="Clear entered values">
-              <ButtonTransparent type="button" onClick={handleClear}>
+            <Tooltip key="clearTip" content="Clear entered values">
+              <ButtonTransparent
+                key="clearButton"
+                type="button"
+                onClick={handleClear}
+              >
                 Clear
               </ButtonTransparent>
             </Tooltip>

--- a/packages/run-it/src/components/RequestForm/RequestForm.tsx
+++ b/packages/run-it/src/components/RequestForm/RequestForm.tsx
@@ -129,7 +129,7 @@ export const RequestForm: FC<RequestFormProps> = ({
 
   return (
     <Form onSubmit={handleSubmit}>
-      <Fieldset key="inputs">
+      <Fieldset>
         {inputs.map((input) =>
           typeof input.type === 'string'
             ? createSimpleItem(
@@ -155,31 +155,20 @@ export const RequestForm: FC<RequestFormProps> = ({
                   requestContent={requestContent}
                 />
               ) : (
-                <Tooltip key="runTip" content="Run the API request">
-                  <Button key="runButton" type="submit">
-                    Run
-                  </Button>
+                <Tooltip content="Run the API request">
+                  <Button type="submit">Run</Button>
                 </Tooltip>
               )
             ) : (
               !isExtension &&
               setHasConfig && (
-                <Tooltip
-                  key="configTip"
-                  content="Configure your OAuth server to Run requests"
-                >
-                  <Button key="configureButton" onClick={handleConfig}>
-                    Configure
-                  </Button>
+                <Tooltip content="Configure your OAuth server to Run requests">
+                  <Button onClick={handleConfig}>Configure</Button>
                 </Tooltip>
               )
             )}
-            <Tooltip key="clearTip" content="Clear entered values">
-              <ButtonTransparent
-                key="clearButton"
-                type="button"
-                onClick={handleClear}
-              >
+            <Tooltip content="Clear entered values">
+              <ButtonTransparent type="button" onClick={handleClear}>
                 Clear
               </ButtonTransparent>
             </Tooltip>

--- a/packages/run-it/src/components/RequestForm/RequestForm.tsx
+++ b/packages/run-it/src/components/RequestForm/RequestForm.tsx
@@ -31,6 +31,7 @@ import {
   Space,
   ButtonTransparent,
   Tooltip,
+  SpaceVertical,
 } from '@looker/components'
 import type { IAPIMethods } from '@looker/sdk-rtl'
 import { RunItHttpMethod, RunItInput, RunItValues } from '../../RunIt'
@@ -128,18 +129,20 @@ export const RequestForm: FC<RequestFormProps> = ({
 
   return (
     <Form onSubmit={handleSubmit}>
-      {inputs.map((input) =>
-        typeof input.type === 'string'
-          ? createSimpleItem(
-              input,
-              handleChange,
-              handleNumberChange,
-              handleBoolChange,
-              handleDateChange,
-              requestContent
-            )
-          : createComplexItem(input, handleComplexChange, requestContent)
-      )}
+      <SpaceVertical align="start" alignContent="left">
+        {inputs.map((input) =>
+          typeof input.type === 'string'
+            ? createSimpleItem(
+                input,
+                handleChange,
+                handleNumberChange,
+                handleBoolChange,
+                handleDateChange,
+                requestContent
+              )
+            : createComplexItem(input, handleComplexChange, requestContent)
+        )}
+      </SpaceVertical>
       {httpMethod !== 'GET' && showDataChangeWarning()}
       <Space>
         <Tooltip content="Clear entered values">

--- a/packages/run-it/src/components/RequestForm/RequestForm.tsx
+++ b/packages/run-it/src/components/RequestForm/RequestForm.tsx
@@ -28,10 +28,9 @@ import React, { BaseSyntheticEvent, FC, Dispatch } from 'react'
 import {
   Button,
   Form,
-  Space,
   ButtonTransparent,
   Tooltip,
-  SpaceVertical,
+  Fieldset,
 } from '@looker/components'
 import type { IAPIMethods } from '@looker/sdk-rtl'
 import { RunItHttpMethod, RunItInput, RunItValues } from '../../RunIt'
@@ -44,6 +43,7 @@ import {
   showDataChangeWarning,
   updateNullableProp,
 } from './formUtils'
+import { FormItem } from './FormItem'
 
 /** Properties required by RequestForm */
 interface RequestFormProps {
@@ -129,7 +129,7 @@ export const RequestForm: FC<RequestFormProps> = ({
 
   return (
     <Form onSubmit={handleSubmit}>
-      <SpaceVertical align="start" alignContent="left">
+      <Fieldset>
         {inputs.map((input) =>
           typeof input.type === 'string'
             ? createSimpleItem(
@@ -142,37 +142,39 @@ export const RequestForm: FC<RequestFormProps> = ({
               )
             : createComplexItem(input, handleComplexChange, requestContent)
         )}
-      </SpaceVertical>
-      {httpMethod !== 'GET' && showDataChangeWarning()}
-      <Space>
-        <Tooltip content="Clear entered values">
-          <ButtonTransparent type="button" onClick={handleClear}>
-            Clear
-          </ButtonTransparent>
-        </Tooltip>
-        {hasConfig ? (
-          needsAuth ? (
-            <LoginForm
-              sdk={sdk}
-              setVersionsUrl={setVersionsUrl}
-              setHasConfig={setHasConfig}
-              configurator={configurator}
-              requestContent={requestContent}
-            />
-          ) : (
-            <Tooltip content="Run the API request">
-              <Button type="submit">Run</Button>
+        {httpMethod !== 'GET' && showDataChangeWarning()}
+        <FormItem id="buttonbar">
+          <>
+            {hasConfig ? (
+              needsAuth ? (
+                <LoginForm
+                  sdk={sdk}
+                  setVersionsUrl={setVersionsUrl}
+                  setHasConfig={setHasConfig}
+                  configurator={configurator}
+                  requestContent={requestContent}
+                />
+              ) : (
+                <Tooltip content="Run the API request">
+                  <Button type="submit">Run</Button>
+                </Tooltip>
+              )
+            ) : (
+              !isExtension &&
+              setHasConfig && (
+                <Tooltip content="Configure your OAuth server to Run requests">
+                  <Button onClick={handleConfig}>Configure</Button>
+                </Tooltip>
+              )
+            )}
+            <Tooltip content="Clear entered values">
+              <ButtonTransparent type="button" onClick={handleClear}>
+                Clear
+              </ButtonTransparent>
             </Tooltip>
-          )
-        ) : (
-          !isExtension &&
-          setHasConfig && (
-            <Tooltip content="Configure your OAuth server to Run requests">
-              <Button onClick={handleConfig}>Configure</Button>
-            </Tooltip>
-          )
-        )}
-      </Space>
+          </>
+        </FormItem>
+      </Fieldset>
     </Form>
   )
 }

--- a/packages/run-it/src/components/RequestForm/formUtils.spec.tsx
+++ b/packages/run-it/src/components/RequestForm/formUtils.spec.tsx
@@ -208,9 +208,13 @@ describe('Simple Items', () => {
       description: 'A simple item of type datetime',
     })
 
-    test('it creates a datetime item', () => {
+    test('it creates a datetime item', async () => {
       renderWithTheme(DateItem)
-      expect(screen.getByTestId('text-input')).toBeInTheDocument()
+      const button = screen.getByRole('button', { name: 'Choose' })
+      userEvent.click(button)
+      await waitFor(() => {
+        expect(screen.getByTestId('text-input')).toBeInTheDocument()
+      })
     })
   })
 

--- a/packages/run-it/src/components/RequestForm/formUtils.spec.tsx
+++ b/packages/run-it/src/components/RequestForm/formUtils.spec.tsx
@@ -23,6 +23,7 @@
  SOFTWARE.
 
  */
+
 import { screen, fireEvent, waitFor } from '@testing-library/react'
 import { renderWithTheme } from '@looker/components-test-utils'
 import userEvent from '@testing-library/user-event'

--- a/packages/run-it/src/components/RequestForm/formUtils.tsx
+++ b/packages/run-it/src/components/RequestForm/formUtils.tsx
@@ -30,8 +30,11 @@ import {
   Label,
   FieldCheckbox,
   Space,
+  Button,
+  Box,
+  Popover,
 } from '@looker/components'
-import { InputDate } from '@looker/components-date'
+import { DateFormat, InputDate } from '@looker/components-date'
 import { CodeEditor } from '@looker/code-editor'
 
 import { RunItInput, RunItValues } from '../../RunIt'
@@ -62,12 +65,31 @@ const createDateItem = (
   handleChange: (name: string, date?: Date) => void,
   requestContent: RunItValues
 ) => (
-  <Space align="start" alignContent="top">
+  <Space align="start" alignContent="top" key={`date_${name}`}>
     <Label>{name}</Label>
-    <InputDate
-      defaultValue={name in requestContent ? requestContent[name] : undefined}
-      onChange={handleChange.bind(null, name)}
-    />
+    <Popover
+      content={
+        <Box p="u3">
+          <InputDate
+            key={`datepick_${name}`}
+            defaultValue={
+              name in requestContent ? requestContent[name] : undefined
+            }
+            onChange={handleChange.bind(null, name)}
+          />
+        </Box>
+      }
+    >
+      <Button>
+        {name in requestContent ? (
+          <DateFormat>
+            {name in requestContent ? requestContent[name] : undefined}
+          </DateFormat>
+        ) : (
+          'Choose'
+        )}
+      </Button>
+    </Popover>
   </Space>
 )
 

--- a/packages/run-it/src/components/RequestForm/formUtils.tsx
+++ b/packages/run-it/src/components/RequestForm/formUtils.tsx
@@ -29,6 +29,7 @@ import {
   FieldToggleSwitch,
   Label,
   FieldCheckbox,
+  Space,
 } from '@looker/components'
 import { InputDate } from '@looker/components-date'
 import { CodeEditor } from '@looker/code-editor'
@@ -61,13 +62,13 @@ const createDateItem = (
   handleChange: (name: string, date?: Date) => void,
   requestContent: RunItValues
 ) => (
-  <div key={name}>
+  <Space align="start" alignContent="top">
     <Label>{name}</Label>
     <InputDate
       defaultValue={name in requestContent ? requestContent[name] : undefined}
       onChange={handleChange.bind(null, name)}
     />
-  </div>
+  </Space>
 )
 
 /**
@@ -84,19 +85,19 @@ const createBoolItem = (
   handleChange: (e: BaseSyntheticEvent) => void,
   requestContent: RunItValues
 ) => (
-  <div key={name}>
-    {description && <Label>{description}</Label>}
+  <Space>
     <FieldToggleSwitch
       name={name}
       label={name}
       onChange={handleChange}
       on={name in requestContent ? requestContent[name] : false}
     />
-  </div>
+    {description && <Label>{description}</Label>}
+  </Space>
 )
 
 /**
- *
+ * Create a field text input item based on definitions
  * @param name Form item's name
  * @param description Form item's description
  * @param required Form item's required flag
@@ -115,19 +116,17 @@ const createItem = (
   handleChange: (e: BaseSyntheticEvent) => void,
   requestContent: RunItValues
 ) => (
-  <div key={name}>
-    <FieldText
-      key={name}
-      name={name}
-      label={name}
-      required={required}
-      placeholder={`${placeholder} ${description || name}`}
-      type={inputTextType(type)}
-      value={name in requestContent ? requestContent[name] : ''}
-      onChange={handleChange}
-      width="100%"
-    />
-  </div>
+  <FieldText
+    key={name}
+    name={name}
+    label={name}
+    required={required}
+    placeholder={`${placeholder} ${description || name}`}
+    type={inputTextType(type)}
+    value={name in requestContent ? requestContent[name] : ''}
+    onChange={handleChange}
+    inline
+  />
 )
 
 /**

--- a/packages/run-it/src/components/RequestForm/formUtils.tsx
+++ b/packages/run-it/src/components/RequestForm/formUtils.tsx
@@ -54,8 +54,9 @@ const createDateItem = (
 ) => (
   <FormItem id={name} label={name}>
     <Popover
+      key={`${name}_pop`}
       content={
-        <Box p="u3">
+        <Box key={`${name}_popbox`} p="u3">
           <InputDate
             key={`datepick_${name}`}
             defaultValue={
@@ -66,9 +67,9 @@ const createDateItem = (
         </Box>
       }
     >
-      <ButtonOutline>
+      <ButtonOutline key={`${name}_pop_button`}>
         {name in requestContent ? (
-          <DateFormat>
+          <DateFormat key={`${name}_dateformat`}>
             {name in requestContent ? requestContent[name] : undefined}
           </DateFormat>
         ) : (
@@ -96,6 +97,8 @@ const createBoolItem = (
   <FormItem id={name} label={name}>
     <>
       <ToggleSwitch
+        key={name}
+        id={name}
         name={name}
         onChange={handleChange}
         on={name in requestContent ? requestContent[name] : false}
@@ -140,7 +143,9 @@ const createItem = (
 ) => (
   <FormItem id={name} label={name}>
     <InputText
+      key={name}
       id={name}
+      name={name}
       required={required}
       placeholder={`${placeholder} ${description || name}`}
       type={inputTextType(type)}
@@ -241,6 +246,7 @@ export const createComplexItem = (
 ) => (
   <FormItem id={input.name} label={input.name}>
     <CodeEditor
+      key={`code_${input.name}`}
       language="json"
       code={
         input.name in requestContent
@@ -258,8 +264,9 @@ export const createComplexItem = (
  * Creates a required checkbox form item
  */
 export const showDataChangeWarning = () => (
-  <FormItem id="warning">
+  <FormItem id="change_warning">
     <FieldCheckbox
+      name="warning"
       key="warning"
       required
       label="I understand that this API endpoint will change data."

--- a/packages/run-it/src/components/RequestForm/formUtils.tsx
+++ b/packages/run-it/src/components/RequestForm/formUtils.tsx
@@ -25,32 +25,19 @@
  */
 import React, { BaseSyntheticEvent, Fragment } from 'react'
 import {
-  FieldText,
-  FieldToggleSwitch,
+  ToggleSwitch,
   Label,
   FieldCheckbox,
-  Space,
-  Button,
+  ButtonOutline,
   Box,
   Popover,
+  InputText,
 } from '@looker/components'
 import { DateFormat, InputDate } from '@looker/components-date'
 import { CodeEditor } from '@looker/code-editor'
 
 import { RunItInput, RunItValues } from '../../RunIt'
-
-const inputTextType = (type: string) => {
-  switch (type) {
-    case 'number':
-      return 'number'
-    case 'email':
-      return 'email'
-    case 'password':
-      return 'password'
-    default:
-      return 'text'
-  }
-}
+import { FormItem } from './FormItem'
 
 /**
  * Creates a datetime form item
@@ -65,8 +52,7 @@ const createDateItem = (
   handleChange: (name: string, date?: Date) => void,
   requestContent: RunItValues
 ) => (
-  <Space align="start" alignContent="top" key={`date_${name}`}>
-    <Label>{name}</Label>
+  <FormItem id={name} label={name}>
     <Popover
       content={
         <Box p="u3">
@@ -80,7 +66,7 @@ const createDateItem = (
         </Box>
       }
     >
-      <Button>
+      <ButtonOutline>
         {name in requestContent ? (
           <DateFormat>
             {name in requestContent ? requestContent[name] : undefined}
@@ -88,9 +74,9 @@ const createDateItem = (
         ) : (
           'Choose'
         )}
-      </Button>
+      </ButtonOutline>
     </Popover>
-  </Space>
+  </FormItem>
 )
 
 /**
@@ -107,16 +93,30 @@ const createBoolItem = (
   handleChange: (e: BaseSyntheticEvent) => void,
   requestContent: RunItValues
 ) => (
-  <Space key={`bool${name}`}>
-    <FieldToggleSwitch
-      name={name}
-      label={name}
-      onChange={handleChange}
-      on={name in requestContent ? requestContent[name] : false}
-    />
-    {description && <Label>{description}</Label>}
-  </Space>
+  <FormItem id={name} label={name}>
+    <>
+      <ToggleSwitch
+        name={name}
+        onChange={handleChange}
+        on={name in requestContent ? requestContent[name] : false}
+      />
+      {description && <Label>{description}</Label>}
+    </>
+  </FormItem>
 )
+
+const inputTextType = (type: string) => {
+  switch (type) {
+    case 'number':
+      return 'number'
+    case 'email':
+      return 'email'
+    case 'password':
+      return 'password'
+    default:
+      return 'text'
+  }
+}
 
 /**
  * Create a field text input item based on definitions
@@ -138,17 +138,16 @@ const createItem = (
   handleChange: (e: BaseSyntheticEvent) => void,
   requestContent: RunItValues
 ) => (
-  <FieldText
-    key={name}
-    name={name}
-    label={name}
-    required={required}
-    placeholder={`${placeholder} ${description || name}`}
-    type={inputTextType(type)}
-    value={name in requestContent ? requestContent[name] : ''}
-    onChange={handleChange}
-    inline
-  />
+  <FormItem id={name} label={name}>
+    <InputText
+      id={name}
+      required={required}
+      placeholder={`${placeholder} ${description || name}`}
+      type={inputTextType(type)}
+      value={name in requestContent ? requestContent[name] : ''}
+      onChange={handleChange}
+    />
+  </FormItem>
 )
 
 /**
@@ -240,8 +239,7 @@ export const createComplexItem = (
   handleComplexChange: (value: string, name: string) => void,
   requestContent: RunItValues
 ) => (
-  <div key={input.name}>
-    <Label>{input.name}</Label>
+  <FormItem id={input.name} label={input.name}>
     <CodeEditor
       language="json"
       code={
@@ -253,18 +251,20 @@ export const createComplexItem = (
       onChange={handleComplexChange.bind(null, input.name)}
       transparent={true}
     />
-  </div>
+  </FormItem>
 )
 
 /**
  * Creates a required checkbox form item
  */
 export const showDataChangeWarning = () => (
-  <FieldCheckbox
-    key="warning"
-    required
-    label="I understand that this API endpoint will change data."
-  />
+  <FormItem id="warning">
+    <FieldCheckbox
+      key="warning"
+      required
+      label="I understand that this API endpoint will change data."
+    />
+  </FormItem>
 )
 
 /**

--- a/packages/run-it/src/components/RequestForm/formUtils.tsx
+++ b/packages/run-it/src/components/RequestForm/formUtils.tsx
@@ -52,7 +52,7 @@ const createDateItem = (
   handleChange: (name: string, date?: Date) => void,
   requestContent: RunItValues
 ) => (
-  <FormItem id={name} label={name}>
+  <FormItem key={`${name}_fid`} id={name} label={name}>
     <Popover
       key={`${name}_pop`}
       content={
@@ -94,7 +94,7 @@ const createBoolItem = (
   handleChange: (e: BaseSyntheticEvent) => void,
   requestContent: RunItValues
 ) => (
-  <FormItem id={name} label={name}>
+  <FormItem key={`${name}_fib`} id={name} label={name}>
     <>
       <ToggleSwitch
         key={name}
@@ -141,7 +141,7 @@ const createItem = (
   handleChange: (e: BaseSyntheticEvent) => void,
   requestContent: RunItValues
 ) => (
-  <FormItem id={name} label={name}>
+  <FormItem key={`${name}_fi`} id={name} label={name}>
     <InputText
       key={name}
       id={name}
@@ -244,7 +244,7 @@ export const createComplexItem = (
   handleComplexChange: (value: string, name: string) => void,
   requestContent: RunItValues
 ) => (
-  <FormItem id={input.name} label={input.name}>
+  <FormItem key={`${input.name}_fic`} id={input.name} label={input.name}>
     <CodeEditor
       key={`code_${input.name}`}
       language="json"
@@ -264,7 +264,7 @@ export const createComplexItem = (
  * Creates a required checkbox form item
  */
 export const showDataChangeWarning = () => (
-  <FormItem id="change_warning">
+  <FormItem key="warningfi" id="change_warning">
     <FieldCheckbox
       name="warning"
       key="warning"

--- a/packages/run-it/src/components/RequestForm/formUtils.tsx
+++ b/packages/run-it/src/components/RequestForm/formUtils.tsx
@@ -107,7 +107,7 @@ const createBoolItem = (
   handleChange: (e: BaseSyntheticEvent) => void,
   requestContent: RunItValues
 ) => (
-  <Space>
+  <Space key={`bool${name}`}>
     <FieldToggleSwitch
       name={name}
       label={name}

--- a/packages/run-it/src/components/RequestForm/formUtils.tsx
+++ b/packages/run-it/src/components/RequestForm/formUtils.tsx
@@ -55,6 +55,7 @@ const createDateItem = (
   <FormItem key={`${name}_fid`} id={name} label={name}>
     <Popover
       key={`${name}_pop`}
+      placement="bottom-start"
       content={
         <Box key={`${name}_popbox`} p="u3">
           <InputDate

--- a/packages/run-it/src/components/RequestForm/formUtils.tsx
+++ b/packages/run-it/src/components/RequestForm/formUtils.tsx
@@ -68,7 +68,7 @@ const createDateItem = (
         </Box>
       }
     >
-      <ButtonOutline key={`${name}_pop_button`}>
+      <ButtonOutline type="button" key={`${name}_pop_button`}>
         {name in requestContent ? (
           <DateFormat key={`${name}_dateformat`}>
             {name in requestContent ? requestContent[name] : undefined}

--- a/packages/run-it/src/components/ShowResponse/responseUtils.tsx
+++ b/packages/run-it/src/components/ShowResponse/responseUtils.tsx
@@ -27,7 +27,6 @@ import React, { ReactElement } from 'react'
 import { IRawResponse, ResponseMode, responseMode } from '@looker/sdk-rtl'
 import {
   Paragraph,
-  CodeBlock,
   MessageBar,
   TabList,
   Tab,
@@ -35,7 +34,7 @@ import {
   TabPanel,
   useTabs,
 } from '@looker/components'
-import { CodeDisplay, Markdown } from '@looker/code-editor'
+import { CodeCopy, Markdown } from '@looker/code-editor'
 import { DataGrid, parseCsv, json2Csv } from '../DataGrid'
 
 /**
@@ -53,6 +52,12 @@ export const allSimple = (data: any[]) => {
     }
   }
   return true
+}
+
+const copyRaw = (code: string, language = 'unknown') => {
+  return (
+    <CodeCopy language={language} code={code} lineNumbers={false} transparent />
+  )
 }
 
 /**
@@ -79,7 +84,7 @@ const ShowJSON = (response: IRawResponse) => {
   const data = json2Csv(content)
   const showGrid = isColumnar(data.data)
   const json = JSON.stringify(JSON.parse(response.body), null, 2)
-  const raw = <CodeDisplay code={json} lineNumbers={false} transparent />
+  const raw = copyRaw(json, 'json')
   if (showGrid) return <DataGrid data={data.data} raw={raw} />
   return raw
 }
@@ -88,7 +93,7 @@ const ShowJSON = (response: IRawResponse) => {
 const ShowText = (response: IRawResponse) => (
   <>
     {response.statusMessage !== 'OK' && response.statusMessage}
-    <CodeBlock>{response.body.toString()}</CodeBlock>
+    {copyRaw(response.body.toString())}
   </>
 )
 
@@ -97,14 +102,14 @@ const ShowText = (response: IRawResponse) => (
  * @param response HTTP response to parse and display
  */
 const ShowCSV = (response: IRawResponse) => {
-  const raw = <CodeBlock>{response.body.toString()}</CodeBlock>
+  const raw = copyRaw(response.body.toString())
   const data = parseCsv(response.body.toString())
   return <DataGrid data={data.data} raw={raw} />
 }
 
 const ShowMD = (response: IRawResponse) => {
   const tabs = useTabs()
-  const raw = <CodeBlock>{response.body.toString()}</CodeBlock>
+  const raw = copyRaw(response.body.toString(), 'markup')
   const data = response.body.toString()
   return (
     <>
@@ -139,13 +144,11 @@ const ShowImage = (response: IRawResponse) => {
 }
 
 /** A handler for HTTP type responses */
-const ShowHTML = (response: IRawResponse) => (
-  <CodeDisplay language="html" code={response.body.toString()} transparent />
-)
+const ShowHTML = (response: IRawResponse) =>
+  copyRaw(response.body.toString(), 'html')
 
-const ShowSQL = (response: IRawResponse) => (
-  <CodeDisplay language="sql" code={response.body.toString()} transparent />
-)
+const ShowSQL = (response: IRawResponse) =>
+  copyRaw(response.body.toString(), 'sql')
 
 /**
  * A handler for unknown response types. It renders the size of the unknown response and its type.
@@ -171,11 +174,7 @@ const ShowRaw = (response: IRawResponse) => (
     <MessageBar intent="warn" noActions>
       The response body could not be parsed. Displaying raw data.
     </MessageBar>
-    <CodeDisplay
-      language="unknown"
-      code={response?.body?.toString() || ''}
-      transparent
-    />
+    {copyRaw(response?.body?.toString() || '')}
   </>
 )
 


### PR DESCRIPTION
Made some changes to the **RunIt** form, both for layout and editing various values
 
## Bug fixes

- enum values are now a string input instead of `{}`. There is an outstanding task to support a dropdown picker for enums that will come with the next significant change for the form editor
- DelimArray values are now a string input instead of `{}`

## Design improvements

- all inputs are on a single line now, saving form space. This is particularly useful for endpoints with many input values

![image](https://user-images.githubusercontent.com/6099714/132744478-cd548230-7dd7-4148-9d6c-55e93b8bfef1.png)

- date time picker is now a pop over with a button to choose the date (but still doesn't have time picking)

![image](https://user-images.githubusercontent.com/6099714/132928125-ca1d30fa-0d52-4265-bc77-e559c9ba09b8.png)


- the default action for the form is now the first button, making it more convenient for tabbing through

![image](https://user-images.githubusercontent.com/6099714/132744727-e40cf9e2-ca85-4844-8c1a-bf576bd9680c.png)
