### PR TITLE
chore: update search highlighting style

### DIFF
--- a/packages/code-editor/src/CodeDisplay/CodeWrapper.tsx
+++ b/packages/code-editor/src/CodeDisplay/CodeWrapper.tsx
@@ -43,7 +43,8 @@ const Pre = styled.pre`
 
   // selector for search matches
   .match {
-    border: 1px yellow solid;
+    border: 1px #949ff9 solid;
+    background-color: #484c6f;
     border-radius: 4px;
   }
 `

--- a/packages/code-editor/src/Markdown/Markdown.tsx
+++ b/packages/code-editor/src/Markdown/Markdown.tsx
@@ -147,4 +147,8 @@ const MarkdownWrapper = styled.div`
     padding-left: 20px;
     list-style: decimal outside;
   }
+  & mark {
+    background-color: #c2deff;
+    font-weight: bold;
+  }
 `


### PR DESCRIPTION
No longer using the default yellow highlighting for search result matches in markdown text and code results

# Screenshot

![image](https://user-images.githubusercontent.com/6099714/133529712-9d1e4d9f-60f5-44c5-8d6c-5e501cfc3d5f.png)
