### PR TITLE
fix: Extension Api Explorer markdown link clicks

### DIFF
--- a/packages/api-explorer/src/components/DocMarkdown/DocMarkdown.tsx
+++ b/packages/api-explorer/src/components/DocMarkdown/DocMarkdown.tsx
@@ -47,6 +47,8 @@ export const DocMarkdown: FC<DocMarkdownProps> = ({ source, specKey }) => {
   const linkClickHandler = (pathname: string, url: string) => {
     if (pathname.startsWith(`/${specKey}`)) {
       history.push(pathname)
+    } else if (url.startsWith(`/${specKey}`)) {
+      history.push(url)
     } else if (url.startsWith('https://')) {
       envAdaptor.openBrowserWindow(url)
     }

--- a/packages/code-editor/src/Markdown/Markdown.tsx
+++ b/packages/code-editor/src/Markdown/Markdown.tsx
@@ -68,7 +68,10 @@ export const Markdown: FC<MarkdownProps> = ({
       // Could be a <mark> tag wrapped by an anchor
       const a = findAnchor(e.target)
       if (a) {
-        linkClickHandler(a.pathname, a.href)
+        linkClickHandler(
+          a.getAttribute('pathname') || '',
+          a.getAttribute('href') || ''
+        )
       }
     }
   }


### PR DESCRIPTION
Clicking a link in markdown now works for extensions.

Fix is to rely on getAttribute method to get pathname and href values rather
than get pathname and href directly. Also, now tests if url begins with
the spec key as well as the pathname.

Possibly broken by markdown upgrade although why standalone was not
broken is puzzling
