### PR TITLE
fix: Property names with special characters in Kotlin SDK

### DIFF
--- a/packages/sdk-codegen/src/kotlin.gen.spec.ts
+++ b/packages/sdk-codegen/src/kotlin.gen.spec.ts
@@ -88,11 +88,9 @@ enum class PermissionType : Serializable {
  */
 data class HyphenType (
     var project_name: String? = null,
-    @get:JsonProperty("project-digest")
-    @param:JsonProperty("project-digest")
+    @SerializedName("project-digest")
     var project_digest: String? = null,
-    @get:JsonProperty("computation time")
-    @param:JsonProperty("computation time")
+    @SerializedName("computation time")
     var computation_time: Float? = null
 ) : Serializable`
       expect(actual).toEqual(expected)

--- a/packages/sdk-codegen/src/kotlin.gen.ts
+++ b/packages/sdk-codegen/src/kotlin.gen.ts
@@ -156,7 +156,9 @@ import java.util.*
     const optional = !property.required ? '? = null' : ''
     const type = this.typeMap(property.type)
     // handle property names with special characters
-    const attr = property.hasSpecialNeeds ? `${indent}@SerializedName("${property.jsonName}")\n` : ''
+    const attr = property.hasSpecialNeeds
+      ? `${indent}@SerializedName("${property.jsonName}")\n`
+      : ''
     const result = `${attr}${indent}var ${property.name}: ${type.name}${optional}`
     return result
   }

--- a/packages/sdk-codegen/src/kotlin.gen.ts
+++ b/packages/sdk-codegen/src/kotlin.gen.ts
@@ -155,7 +155,9 @@ import java.util.*
   declareProperty(indent: string, property: IProperty) {
     const optional = !property.required ? '? = null' : ''
     const type = this.typeMap(property.type)
-    const result = `${indent}var ${property.name}: ${type.name}${optional}`
+    // handle property names with special characters
+    const attr = property.hasSpecialNeeds ? `${indent}@SerializedName("${property.jsonName}")\n` : ''
+    const result = `${attr}${indent}var ${property.name}: ${type.name}${optional}`
     return result
   }
 


### PR DESCRIPTION
This PR fixes generation of kotlin classes which handle properties having special characters.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/looker-open-source/sdk-codegen/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Appropriate docs were updated (if necessary)

Fixes #837 🦕
