### PR TITLE
fix: remove body from REST call if no body elements are defined

### DIFF
--- a/packages/run-it/src/utils/RunItSDK.ts
+++ b/packages/run-it/src/utils/RunItSDK.ts
@@ -39,7 +39,7 @@ import { RunItConfigKey } from '../components'
 const settings = {
   ...DefaultSettings(),
   base_url: 'https://self-signed.looker.com:19999',
-  agentTag: 'RunIt 0.5',
+  agentTag: 'RunIt 0.8',
 } as IApiSettings
 
 /**

--- a/packages/run-it/src/utils/requestUtils.spec.ts
+++ b/packages/run-it/src/utils/requestUtils.spec.ts
@@ -95,6 +95,26 @@ describe('requestUtils', () => {
       }),
     }
 
+    const noBody = {
+      result_format: 'json',
+      cache: true,
+      body: '{}',
+    }
+
+    test('empty json body is removed', () => {
+      const [pathParams, queryParams, body] = createRequestParams(
+        inputs,
+        noBody
+      )
+      expect(pathParams).toEqual({
+        result_format: noBody.result_format,
+      })
+      expect(queryParams).toEqual({
+        cache: noBody.cache,
+      })
+      expect(body).not.toBeDefined()
+    })
+
     test('it correctly identifies requestContent params location', () => {
       const [pathParams, queryParams, body] = createRequestParams(
         inputs,

--- a/packages/run-it/src/utils/requestUtils.ts
+++ b/packages/run-it/src/utils/requestUtils.ts
@@ -71,7 +71,15 @@ export const prepareInputs = (
     const name = input.name
     if (input.location === 'body') {
       try {
-        result[name] = JSON.parse(result[name])
+        const parsed = JSON.parse(result[name])
+        // Keys call works for both objects and arrays if there are any values
+        const keys = Object.keys(parsed)
+        if (keys.length > 0) {
+          result[name] = parsed
+        } else {
+          // Remove body arg
+          delete result[name]
+        }
       } catch (e) {
         /** Treat as x-www-form-urlencoded */
         result[name] = requestContent[name]


### PR DESCRIPTION
Fixes the sporadic scenario where a `body` value of `{}` is sent to an endpoint. This update removes any "empty" body from the RunIt request submission
