### PR TITLE
feat: Use agenda data for the Hackathon home page

### DIFF
--- a/packages/hackathon/README.md
+++ b/packages/hackathon/README.md
@@ -30,14 +30,18 @@ application: hackathon_app {
     local_storage: no
     navigation: yes
     new_window: yes
+    new_window_external_urls: []
     use_form_submit: yes
     use_embeds: no
+    use_iframes: no
+    use_clipboard: no
     external_api_urls: ["http://localhost:8081/*", "https://sheets.googleapis.com/*"]
     core_api_methods: ["me", "all_roles", "all_user_attributes", "delete_user_attribute", "create_user_attribute", "search_groups", "search_users", "user_roles", "role_users"]
+    core_api_methods: ["me", "user_roles", "all_user_attributes", "delete_user_attribute", "create_user_attribute", "search_groups", "search_users", "all_roles"]
+    oauth2_urls: []
     scoped_user_attributes: ["sheet_id", "token_server_url"]
   }
 }
-
 ```
 
 **Note** that http://localhost:8081/\* points to the access token server. Change to the access token server URL you are using.

--- a/packages/hackathon/package.json
+++ b/packages/hackathon/package.json
@@ -34,13 +34,14 @@
     "watch": "yarn lerna exec --scope @looker/wholly-sheet --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib/esm --source-maps --extensions .ts,.tsx --no-comments --watch'"
   },
   "dependencies": {
+    "@looker/sdk": "*",
+    "@looker/sdk-rtl": "*",
+    "@looker/code-editor": "*",
+    "@looker/wholly-sheet": "*",
     "@looker/components": "^2.2.1",
-    "@looker/extension-sdk": "^21.14.0",
-    "@looker/extension-sdk-react": "^21.14.0",
     "@looker/icons": "1.3.0",
-    "@looker/sdk": "^21.14.0",
-    "@looker/sdk-rtl": "^21.0.20",
-    "@looker/wholly-sheet": "^0.5.16",
+    "@looker/extension-sdk": "*",
+    "@looker/extension-sdk-react": "*",
     "@styled-icons/material": "^10.28.0",
     "@styled-icons/material-outlined": "^10.28.0",
     "@styled-icons/material-rounded": "^10.28.0",
@@ -53,7 +54,9 @@
     "redux": "^4.0.5",
     "redux-saga": "^1.1.3",
     "styled-components": "^5.2.1",
-    "styled-system": "^5.1.2"
+    "styled-system": "^5.1.2",
+    "moment": "^2.29.1",
+    "moment-timezone": "^0.5.33"
   },
   "devDependencies": {
     "@looker/components-test-utils": "^1.4.2",

--- a/packages/hackathon/src/scenes/HomeScene/agenda.ts
+++ b/packages/hackathon/src/scenes/HomeScene/agenda.ts
@@ -1,0 +1,94 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2021 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+
+export interface IAgendaItem {
+  /** Start datetime of agenda item */
+  start: number
+  /** End of agenda item. If not specified, the next chronological event will be its end time */
+  stop?: number
+  /** Markdown describing item */
+  description: string
+}
+
+export type Agenda = Array<IAgendaItem>
+/*
+| Start Time      | End Time        | Description                         |
+| --------------- | --------------- | ----------------------------------- |
+| Nov 10 9:00 am  | Nov 10 9:15 am  | Kick off                            |
+| Nov 10 9:15 am  | Nov 10 10:10 am | Start hacking, and don't stop!      |
+| Nov 10 10:00 am | Nov 10 11:00 am | Looker staff office hour            |
+| Nov 11 4:00 pm  | Nov 11 6:00 pm  | Hackathon judging (projects locked) |
+| Nov 11 6:00 pm  | Nov 11 7:00 pm  | Hackathon award ceremony            |
+
+ */
+
+export const agendaEn: Agenda = [
+  {
+    start: Date.parse('10 Nov 2021 08:00:00 GMT'),
+    description: 'Hack@Home 20201 kick-off',
+  },
+  {
+    start: Date.parse('10 Nov 2021 08:30:00 GMT'),
+    description: `Start hacking, and don't stop until judging begins!`,
+  },
+  {
+    start: Date.parse('10 Nov 2021 09:00:00 GMT'),
+    description: `Looker staff office Hour`,
+  },
+  {
+    start: Date.parse('11 Nov 2021 10:00:00 GMT'),
+    description: `Judging begins (projects locked)`,
+  },
+  {
+    start: Date.parse('11 Nov 2021 20:00:00 GMT'),
+    stop: Date.parse('11 Nov 2021 21:30:00 GMT'),
+    description: `Awards ceremony and closing`,
+  },
+]
+
+export const agendaJa: Agenda = [
+  {
+    start: Date.parse('10 Nov 2021 08:00:00 GMT'),
+    description: '日本 Hack@Home 20201 kick-off',
+  },
+  {
+    start: Date.parse('10 Nov 2021 08:30:00 GMT'),
+    description: `日本 hacking, and don't stop until judging begins!`,
+  },
+  {
+    start: Date.parse('10 Nov 2021 09:00:00 GMT'),
+    description: `日本 Looker staff office Hour`,
+  },
+  {
+    start: Date.parse('11 Nov 2021 10:00:00 GMT'),
+    description: `日本 Judging begins (projects locked)`,
+  },
+  {
+    start: Date.parse('11 Nov 2021 20:00:00 GMT'),
+    stop: Date.parse('11 Nov 2021 21:30:00 GMT'),
+    description: `日本 Awards ceremony and closing`,
+  },
+]

--- a/yarn.lock
+++ b/yarn.lock
@@ -10633,6 +10633,18 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
+moment-timezone@^0.5.33:
+  version "0.5.33"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.33.tgz#b252fd6bb57f341c9b59a5ab61a8e51a73bbd22c"
+  integrity sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==
+  dependencies:
+    moment ">= 2.9.0"
+
+"moment@>= 2.9.0", moment@^2.29.1:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+
 moo-color@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/moo-color/-/moo-color-1.0.2.tgz#837c40758d2d58763825d1359a84e330531eca64"


### PR DESCRIPTION
This is a hacky change for Hack@Home 2021

Perfect for a hackathon

There's a hand-coded Agenda table in agenda.ts that can be localized for Japanese and an English/Japanese language selector to switch agenda display.

- the agenda date times is displayed in either Pacific or Tokyo time
- this is just a draft agenda to check out the functionality, which is working. We'll have to put the **real** agenda into `agenda.ts`, rebuild, and redeploy to hack.looker.com
- formatting of the table sucks. I'll get some design help on Monday.