### PR TITLE
fix: validateBody for API Explorer

### DIFF
--- a/packages/run-it/src/components/RequestForm/formUtils.spec.tsx
+++ b/packages/run-it/src/components/RequestForm/formUtils.spec.tsx
@@ -264,6 +264,11 @@ describe('Complex Item', () => {
   describe('validateBody', () => {
     test.each`
       value                                                      | error
+      ${{
+  model: 'thelook',
+  view: 'users',
+  fields: ['users.id', 'users.first_name'],
+}} | ${''}
       ${'na.-_me=Vapor&age=3&luckyNumbers[]=5&luckyNumbers[]=7'} | ${''}
       ${'name=Vapor&age=3&luckyNumbers[]=5&luckyNumbers[]7'}     | ${'luckyNumbers[]7'}
       ${'{'}                                                     | ${'Unexpected end of JSON input'}

--- a/packages/run-it/src/components/RequestForm/formUtils.tsx
+++ b/packages/run-it/src/components/RequestForm/formUtils.tsx
@@ -323,9 +323,9 @@ export const validateEncodedValues = (body: string) => {
  *
  * @param body string to validate
  */
-export const validateBody = (body: string) => {
+export const validateBody = (body: string | Record<string, any>) => {
   let result = ''
-  if (body) {
+  if (body && typeof body === 'string') {
     if (/^[[{}"]/.test(body)) {
       // most likely JSON
       try {

--- a/packages/sdk-node/test/methods.spec.ts
+++ b/packages/sdk-node/test/methods.spec.ts
@@ -865,6 +865,52 @@ describe('LookerNodeSDK', () => {
       },
       testTimeout
     )
+
+    it(
+      'parses a query with no results',
+      async () => {
+        const sdk = new LookerSDK(session)
+        const query = await sdk.ok(
+          // sdk.create_query({
+          //   model: 'thelook',
+          //   view: 'users',
+          //   fields: ['users.id', 'users.first_name'],
+          //   // filters: { 'users.id': '-1' },
+          // })
+          sdk.create_query({
+            model: 'system__activity',
+            view: 'dashboard',
+            limit: '2',
+            fields: ['dashboard.id', 'dashboard.title'],
+            filters: { 'dashboard.id': '-1' },
+          })
+        )
+        expect(query).toBeDefined()
+        expect(query.id).toBeDefined()
+        for (const format of ['csv', 'json', 'json_detail', 'txt', 'md']) {
+          let failed = ''
+          try {
+            const live = await sdk.ok(
+              sdk.run_query({ query_id: query.id!, result_format: format })
+            )
+            const cached = await sdk.ok(
+              sdk.run_query({
+                query_id: query.id!,
+                result_format: format,
+                cache: true,
+              })
+            )
+            expect(live).not.toEqual('{}')
+            expect(cached).not.toEqual('{}')
+          } catch (e: any) {
+            failed = e.message
+          }
+          expect(failed).toEqual('')
+        }
+        await sdk.authSession.logout()
+      },
+      testTimeout
+    )
   })
 
   describe('Dashboard endpoints', () => {

--- a/packages/sdk-node/test/methods.spec.ts
+++ b/packages/sdk-node/test/methods.spec.ts
@@ -871,12 +871,6 @@ describe('LookerNodeSDK', () => {
       async () => {
         const sdk = new LookerSDK(session)
         const query = await sdk.ok(
-          // sdk.create_query({
-          //   model: 'thelook',
-          //   view: 'users',
-          //   fields: ['users.id', 'users.first_name'],
-          //   // filters: { 'users.id': '-1' },
-          // })
           sdk.create_query({
             model: 'system__activity',
             view: 'dashboard',


### PR DESCRIPTION
Body values that were already parsed were failing to parse (obviously) so the validation was failing.

I completely missed that scenario

This needs to be merged before  API Explorer is deployed because RunIt will not work for any endpoint with a body

Definitely need to add e2e tests for RunIt!