### PR TITLE
fix: do not "reserve" type names ending in []

### DIFF
--- a/packages/sdk-codegen/src/sdkModels.ts
+++ b/packages/sdk-codegen/src/sdkModels.ts
@@ -50,7 +50,7 @@ const lookerValuesTag = 'x-looker-values'
 const enumTag = 'enum'
 
 /** simple symbol name pattern */
-const simpleName = /^[a-z_][a-z_\d]*$/im
+const simpleName = /^[a-z_][a-z_\d]*(\[])?$/im
 
 /**
  * Convenience enum for exploring types
@@ -94,7 +94,7 @@ export const typeOfType = (type: IType): TypeOfType => {
 /**
  * Does this name have special characters?
  * @param name to name check
- * @returns true if the name isn't a standard variable name
+ * @returns true if the name isn't a standard variable name, optionally ending with []
  */
 export const isSpecialName = (name: string) => {
   if (!name) return false

--- a/packages/sdk-codegen/src/typescript.gen.spec.ts
+++ b/packages/sdk-codegen/src/typescript.gen.spec.ts
@@ -980,6 +980,11 @@ body: ICreateDashboardRenderTask`)
         expect(actual['a-three']).toEqual(3)
       })
 
+      it('does not reserve body param array type names', () => {
+        const actual = gen.reserve('IProjectGeneratorTable[]')
+        expect(actual).toEqual('IProjectGeneratorTable[]')
+      })
+
       it('reserves special names in method parameters', () => {
         const method = apiTestModel.methods.me
         const save = method.params[0].name


### PR DESCRIPTION
Before this fix, a body type name that was an array was being "reserved" by TypeScript, so the generator would write

```ts
body: 'IProjectGeneratorTable[]'
```

instead of
```ts
body: IProjectGeneratorTable[]
```
