### PR TITLE
fix: api explorer initialization 

### DIFF
--- a/packages/api-explorer/src/state/settings/sagas.ts
+++ b/packages/api-explorer/src/state/settings/sagas.ts
@@ -37,8 +37,7 @@ function* serializeToLocalStorageSaga() {
   const settings = yield* select((state: RootState) => ({
     sdkLanguage: state.settings.sdkLanguage,
   }))
-  yield* call(
-    envAdaptor.localStorageSetItem,
+  envAdaptor.localStorageSetItem(
     EnvAdaptorConstants.LOCALSTORAGE_SETTINGS_KEY,
     JSON.stringify(settings)
   )
@@ -47,10 +46,9 @@ function* serializeToLocalStorageSaga() {
 /**
  * Returns default settings overridden with any persisted state in local storage
  */
-function* deserializeLocalStorage() {
+async function deserializeLocalStorage() {
   const envAdaptor = getEnvAdaptor()
-  const settings = yield* call(
-    envAdaptor.localStorageGetItem,
+  const settings = await envAdaptor.localStorageGetItem(
     EnvAdaptorConstants.LOCALSTORAGE_SETTINGS_KEY
   )
   return settings


### PR DESCRIPTION
The call of a saga from within another saga was resulting in issues for the extension version. This PR changes the way envAdapter methods are called from within sagas.