### PR TITLE
fix: Remove hackathon invite only option

### DIFF
--- a/packages/hackathon/src/scenes/ProjectEditorScene/components/ProjectForm.tsx
+++ b/packages/hackathon/src/scenes/ProjectEditorScene/components/ProjectForm.tsx
@@ -209,10 +209,6 @@ export const ProjectForm: FC<ProjectFormProps> = () => {
                     label:
                       'Closed: no one other than the project creator can join',
                   },
-                  {
-                    value: 'Invite Only',
-                    label: 'Only joinable by invitation',
-                  },
                 ]}
                 onChange={(value: string) => {
                   dispatch(


### PR DESCRIPTION
Turns out invite only has not been implemented yet.
Removing UI option till it is implemented.
TODO work tracked in ticket.
