### PR TITLE
chore: make Swift SDK agentTag customizable

### DIFF
--- a/swift/looker/rtl/transport.swift
+++ b/swift/looker/rtl/transport.swift
@@ -28,7 +28,8 @@
 
 import Foundation
 
-public let agentTag = "Swift-SDK \(Constants.sdkVersion)"
+/** agentTag may be modified to identify the application using the Swift SDK */
+public var agentTag = "Swift-SDK \(Constants.sdkVersion)"
 
 /**
  * ResponseMode for an HTTP request - either binary or "string"


### PR DESCRIPTION
The mobile team wants to modify the agent tag for the Swift SDK