### PR TITLE
chore: Explicitly call tsc with yarn lint:ts in apix CI

### DIFF
--- a/.github/workflows/apix-ci.yml
+++ b/.github/workflows/apix-ci.yml
@@ -55,8 +55,8 @@ jobs:
         run: |
           yarn
           yarn lint:es --quiet
+          yarn lint:ts
           yarn build
-          yarn build-extensions
           yarn dedupe:ci
 
       - name: Run unit tests


### PR DESCRIPTION
Replaced apix ci call to `yarn build-extensions` with call to
`yarn lint:ts` to trigger TSC to catch typescript compilation errors.

Previously we called to `yarn build-extensions` to trigger tsc.
