### PR TITLE
chore: leave extension-utils as semver

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,7 +10,7 @@
     "packages/extension-api-explorer": { },
     "packages/extension-sdk": { },
     "packages/extension-sdk-react": { },
-    "packages/extension-utils": { },
+    "packages/extension-utils": { "release-as": "" },
     "packages/hackathon": { },
     "packages/run-it": { "release-as": "" },
     "packages/sdk": { },


### PR DESCRIPTION
`@looker/extension-utils` should be semver for now