### PR TITLE
chore: Added bundle step and cleaned up hackathon CI

### DIFF
--- a/.github/workflows/hackathon-ci.yml
+++ b/.github/workflows/hackathon-ci.yml
@@ -48,7 +48,18 @@ jobs:
       - name: Install dependencies
         run: |
           yarn
+
+      - name: Lint
+        run: |
           yarn lint:es --quiet
           yarn lint:ts
+
+      - name: Build all
+        run: |
           yarn build
           yarn dedupe:ci
+
+      - name: Bundle hackathon
+        run: |
+          yarn bundle
+        working-directory: packages/hackathon


### PR DESCRIPTION
- Added `yarn bundle` step to make sure hackathon can always be bundled
- Renamed and split up steps to be more descriptive