### PR TITLE
chore: test JSON deserialization for Look#

### DIFF
--- a/csharp/csharp.csproj
+++ b/csharp/csharp.csproj
@@ -1,8 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+    <LangVersion>10</LangVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <OutputPath>bin\Debug/net6.0/</OutputPath>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />

--- a/csharp/rtl.Tests/TestUtils.cs
+++ b/csharp/rtl.Tests/TestUtils.cs
@@ -11,20 +11,20 @@ namespace sdkrtl.Tests
         /// Name of the root looker.ini file
         /// </summary>
         string IniFileName { get; set; }
-        
+
         /// <summary>
         /// Name of the test data file
         /// </summary>
         string TestFileName { get; set; }
-        
+
         string HtmlTestUrl { get; set; }
-        
+
         string HtmlTestContent { get; set; }
         /// <summary>
         /// Test data parsed from <c>/test/data.yml.json</c>
         /// </summary>
         dynamic TestData { get; set; }
-        
+
         /// <summary>
         /// API settings read from <c>IniFileName</c>
         /// </summary>
@@ -49,7 +49,7 @@ namespace sdkrtl.Tests
             HtmlTestUrl = "https://github.com/looker-open-source/sdk-codegen";
             HtmlTestContent = "One SDK to rule them all";
 
-            var rootPath = Path.GetFullPath("../../../../");
+            var rootPath = Path.GetFullPath("../../../../../");
             IniFileName = iniFile ?? Environment.GetEnvironmentVariable("LOOKERSDK_INI") ??
                 Path.Combine(rootPath, "looker.ini");
             TestFileName = Path.Combine(rootPath, "test/data.yml.json");

--- a/csharp/rtl/Transport.cs
+++ b/csharp/rtl/Transport.cs
@@ -27,7 +27,7 @@ namespace Looker.RTL
         /// request timeout in seconds. Default to 30
         int Timeout { get; set; }
 
-        /// agent tag to use for the SDK requests 
+        /// agent tag to use for the SDK requests
         string AgentTag { get; set; }
     }
 
@@ -84,11 +84,11 @@ namespace Looker.RTL
     /// </summary>
     /// <remarks>
     /// The <c>Ok</c> property is read-only, determining its value by checking <c>StatusCode</c>.
-    /// </remarks> 
+    /// </remarks>
     public struct RawResponse : IRawResponse
     {
         public bool Ok => (StatusCode >= HttpStatusCode.OK && StatusCode < HttpStatusCode.Ambiguous);
-
+        public HttpMethod Method { get; set; }
         public HttpStatusCode StatusCode { get; set; }
         public string StatusMessage { get; set; }
         public string ContentType { get; set; }
@@ -166,7 +166,7 @@ namespace Looker.RTL
             // {
             //     DateFormatHandling = DateFormatHandling.IsoDateFormat,
             //     DateTimeZoneHandling = DateTimeZoneHandling.Utc
-            // };            
+            // };
         }
 
         public Transport(ITransportSettings settings, HttpClient client = null)
@@ -196,6 +196,7 @@ namespace Looker.RTL
             var raw = new RawResponse();
             if (response != null)
             {
+                raw.Method = response.RequestMessage.Method;
                 raw.StatusCode = response.StatusCode;
                 raw.StatusMessage = response.ReasonPhrase;
                 response.Content.Headers.TryGetValues("Content-Type", out var values);
@@ -288,7 +289,7 @@ namespace Looker.RTL
             {
                 return new SdkResponse<TSuccess, TError> { Error = response.Body as TError};
             }
-            
+
             switch (SdkUtils.ResponseMode(response.ContentType))
             {
                 case ResponseMode.Binary:


### PR DESCRIPTION
Look# SDK is forward and backward compatible for numeric/string id payloads
