### PR TITLE
fix: Made Go SDK json decoding fuzzy

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -2,4 +2,7 @@ module github.com/looker-open-source/sdk-codegen/go
 
 go 1.14
 
-require gopkg.in/ini.v1 v1.61.0
+require (
+	github.com/json-iterator/go v1.1.12
+	gopkg.in/ini.v1 v1.61.0
+)

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,2 +1,14 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
+github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 h1:ZqeYNhU3OHLH3mGKHDcjJRFFRrJa6eAM5H+CtDdOsPc=
+github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
+github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 gopkg.in/ini.v1 v1.61.0 h1:LBCdW4FmFYL4s/vDZD1RQYX7oAR6IjujCYgMdbHBR10=
 gopkg.in/ini.v1 v1.61.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=

--- a/go/rtl/auth.go
+++ b/go/rtl/auth.go
@@ -3,7 +3,6 @@ package rtl
 import (
 	"bytes"
 	"crypto/tls"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -11,6 +10,9 @@ import (
 	"os"
 	"reflect"
 	"time"
+
+	json "github.com/json-iterator/go"
+	extra "github.com/json-iterator/go/extra"
 )
 
 type AccessToken struct {
@@ -137,6 +139,7 @@ func (s *AuthSession) Do(result interface{}, method, ver, path string, reqPars m
 		return fmt.Errorf("response error: %s", res.Status)
 	}
 
+	extra.RegisterFuzzyDecoders()
 	err = json.NewDecoder(res.Body).Decode(&result)
 
 	return nil

--- a/go/rtl/auth_test.go
+++ b/go/rtl/auth_test.go
@@ -1,10 +1,15 @@
 package rtl
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
 	"time"
 )
+
 
 func TestNewAccessToken(t *testing.T) {
 	type args struct {
@@ -52,47 +57,181 @@ func TestNewAccessToken(t *testing.T) {
 	}
 }
 
-func TestAuthSession_login(t *testing.T) {
-	cfg, err := NewSettingsFromFile("../../looker.ini", nil)
-	if err != nil {
-		t.Error(err)
-	}
-	type fields struct {
-		config ApiSettings
-		token  AccessToken
-	}
-	type args struct {
-		id *string
-	}
+func TestAuthSession_Authenticate(t *testing.T) {
+	const apiVersion = "/4.0"
 	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		wantErr bool
+		name			string
+		originalTokan 	AccessToken
+		loginStatusCode	int
+		loginToken  	AccessToken
+		wantHeader 		string
+		wantErr 		bool
 	}{
 		{
-			name: "basic",
-			fields: fields{
-				config: cfg,
-				token:  AccessToken{},
+			name: "Authenticate() sets header with current AccessToken if not expired",
+			loginStatusCode: http.StatusOK,
+			originalTokan: AccessToken{
+				AccessToken: "testToken",
+				TokenType:   "testTokenType",
+				ExpireTime:  time.Now().AddDate(1, 0, 0),
 			},
-			args: args{
-				id: nil,
+			loginToken:  	AccessToken{},
+			wantHeader:		"token testToken",
+			wantErr: 		false,
+		},
+		{
+			name: "Authenticate() fetches new Access Token from /login and sets header with it if old AccessToken is expired",
+			loginStatusCode: http.StatusOK,
+			originalTokan: AccessToken{
+				AccessToken: "testToken",
+				TokenType:   "testTokenType",
+				ExpireTime:  time.Now().AddDate(-1, 0, 0),
 			},
-			wantErr: false,
+			loginToken: AccessToken{
+				AccessToken: "newToken",
+				TokenType:   "testTokenType",
+				ExpiresIn:  31536000, // in a year
+			},
+			wantHeader:		"token newToken",
+			wantErr: 		false,
+		},
+		{
+			name: "Authenticate() errors if /login errors when fetching new Access Token if old AccessToken is expired",
+			loginStatusCode: http.StatusUnauthorized,
+			originalTokan: AccessToken{
+				AccessToken: "testToken",
+				TokenType:   "testTokenType",
+				ExpireTime:  time.Now().AddDate(-1, 0, 0),
+			},
+			loginToken: AccessToken{},
+			wantErr: 		true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			server := httptest.NewServer(mux)
+			defer server.Close()
+
+			mux.HandleFunc("/api" + apiVersion + "/login", func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.loginStatusCode)
+				s, _ := json.Marshal(tt.loginToken)
+				fmt.Fprint(w, string(s))
+			})
+
 			s := &AuthSession{
-				Config: tt.fields.config,
-				token:  tt.fields.token,
+				Config: ApiSettings{
+					BaseUrl: server.URL,
+					ApiVersion:  apiVersion,
+				},
+				token: tt.originalTokan,
 			}
-			if err := s.login(tt.args.id); (err != nil) != tt.wantErr {
-				t.Errorf("login() error = %v, wantErr %v", err, tt.wantErr)
+
+			req, _ := http.NewRequest("GET", "URL", nil)
+			err := s.Authenticate(req)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("case: %s, wanted error, did not get error", tt.name)
+				}
+			} else {
+				if req.Header["Authorization"][0] != tt.wantHeader {
+					t.Errorf("case: %s, wanted Authorization header: \"%s\", got: \"%s\"", tt.name, tt.wantHeader, req.Header["Authorization"][0])
+				}
 			}
 		})
 	}
+}
+
+func TestAuthSession_Do(t *testing.T) {
+	type stringStruct struct {
+		Field *string `json:"field"`
+	}
+
+	type numStruct struct {
+		Field *int64 `json:"field"`
+	}
+
+	var numField int64 = 12345
+	var stringField = "12345"
+	const path  = "/someMethod"
+	const apiVersion = "/4.0"
+	const maxTime int32 = 2147483647
+
+	t.Run("Do() unmarshals num type field to string type field",func(t *testing.T) {
+		mux := http.NewServeMux()
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		mux.HandleFunc("/api" + apiVersion + "/login", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			s, _ := json.Marshal(AccessToken{
+				ExpiresIn: maxTime,
+			})
+			fmt.Fprint(w, string(s))
+		})
+
+		mux.HandleFunc("/api" + apiVersion + path, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			s, _ := json.Marshal(numStruct{
+				Field: &numField,
+			})
+			fmt.Fprint(w, string(s))
+		})
+
+		s := &AuthSession{
+			Config: ApiSettings{
+				BaseUrl: server.URL,
+				ApiVersion:  apiVersion,
+			},
+		}
+
+		var result stringStruct
+		s.Do(&result, "GET", apiVersion, path, nil, nil, nil)
+
+		if *result.Field != stringField {
+			t.Error("num type field was not unmarshaled correctly into string type field")
+		}
+	})
+
+	t.Run("Do() unmarshals string type field to num type field",func(t *testing.T) {
+		mux := http.NewServeMux()
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		mux.HandleFunc("/api" + apiVersion + "/login", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			s, _ := json.Marshal(AccessToken{
+				ExpiresIn: maxTime,
+			})
+			fmt.Fprint(w, string(s))
+		})
+
+		mux.HandleFunc("/api" + apiVersion + path, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			s, _ := json.Marshal(stringStruct{
+				Field: &stringField,
+			})
+			fmt.Fprint(w, string(s))
+		})
+
+		s := &AuthSession{
+			Config: ApiSettings{
+				BaseUrl: server.URL,
+				ApiVersion:  apiVersion,
+			},
+		}
+
+		var result numStruct
+		s.Do(&result, "GET", apiVersion, path, nil, nil, nil)
+
+		if *result.Field != numField {
+			t.Error("string type field was not unmarshaled correctly into num type field")
+		}
+	})
 }
 
 func TestSetQuery(t *testing.T) {

--- a/go/rtl/types.go
+++ b/go/rtl/types.go
@@ -1,10 +1,11 @@
 package rtl
 
 import (
-	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
+
+	json "github.com/json-iterator/go"
 )
 
 // type alias to string slice, this is needed for custom serialization


### PR DESCRIPTION
Go SDK now supports unmarshaling string type -> num type and num type -> string type.

- Replaced std json with json-iterator to make use of its decoding extensibility
- Added unit test around fuzzy unmarshaling
- Updated unit tests to not depend on looker instance or looker.ini to facilitate CI builds.
- Replaced login() private method tests with Authenticate() public method tests and made them more comprehensive.

Will follow up with styling updates and CI workflow after this PR is merged.