### PR TITLE
fix: use headless navigation mode for API Explorer as an extension

### DIFF
--- a/packages/extension-api-explorer/src/ExtensionApiExplorer.tsx
+++ b/packages/extension-api-explorer/src/ExtensionApiExplorer.tsx
@@ -72,8 +72,7 @@ export const ExtensionApiExplorer: FC = () => {
               specs={specs}
               adaptor={extensionAdaptor}
               setVersionsUrl={runItNoSet}
-              // TODO We need expand/collapse side nav for the headless extension before we enabled this
-              headless={false}
+              headless={true}
             />
           ) : (
             <Loader themeOverrides={extensionAdaptor.themeOverrides()} />


### PR DESCRIPTION
- preferred UI for embedded API Explorer
- resolves partially obscured request form buttons at the bottom of long request forms

