### PR TITLE
chore: new method to skip required checks

### DIFF
--- a/.github/workflows/apix-ci.yml
+++ b/.github/workflows/apix-ci.yml
@@ -1,10 +1,22 @@
 name: API Explorer CI
 on:
   pull_request:
+    paths:
+      - packages/code-editor/**
+      - packages/run-it/**
+      - packages/api-explorer/**
+      - packages/extension-api-explorer/**
+      - packages/extension-utils/**
 
   push:
     branches:
       - main
+    paths:
+      - packages/code-editor/**
+      - packages/run-it/**
+      - packages/api-explorer/**
+      - packages/extension-api-explorer/**
+      - packages/extension-utils/**
 
   workflow_dispatch:
 
@@ -12,13 +24,8 @@ env:
   TS_JUNIT_OUTPUT_DIR: results/apix
 
 jobs:
-  checkfiles:
-    uses: looker-open-source/.github/.github/workflows/check-files.yml@main
-
   unit:
     name: Unit - ${{ matrix.os }} / Node ${{ matrix.node-version }}
-    needs: checkfiles
-    if: needs.checkfiles.outputs.apix == 'true'
     env:
       JEST_JUNIT_OUTPUT_DIR: results/apix
       JEST_JUNIT_OUTPUT_NAME: ${{ matrix.os }}.apix${{ matrix.node-version }}.xml
@@ -72,28 +79,6 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           path: artifacts
-
-      - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1.12
-        with:
-          # Cosmetic issue with `check_name` being associated to the wrong
-          # workflow: https://github.com/EnricoMi/publish-unit-test-result-action/issues/12
-          check_name: APIX Tests
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          report_individual_runs: true
-          hide_comments: orphaned commits
-          check_run_annotations_branch: '*'
-          files: 'artifacts/apix-test-results/*.xml'
-
-  publish-test-results-on-skip:
-    needs: checkfiles
-    if: needs.checkfiles.outputs.apix == 'false'
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Make Dummy Artifacts
-        run: |
-          mkdir -p 'artifacts/apix-test-results'
 
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1.12

--- a/.github/workflows/apix-ci.yml
+++ b/.github/workflows/apix-ci.yml
@@ -59,6 +59,23 @@ jobs:
           yarn build
           yarn dedupe:ci
 
+      # if this job fails before this point the required state check "APIX Tests"
+      #  is never set, so we will set it manually.
+      - name: Report Failure
+        run: |
+          curl --request POST \
+          --url https://api.github.com/repos/looker-open-source/sdk-codegen/check-runs \
+          --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          --header "content-type: application/json" \
+          --header "Accept: application/vnd.github.v3+json" \
+          --data '{
+            "name": "APIX Tests",
+            "head_sha": "${{ github.event.pull_request.head.sha || github.sha }}",
+            "conclusion": "failure"
+          }' \
+          --fail
+        if: failure()
+
       - name: Run unit tests
         run: yarn test:apix --reporters=default --reporters=jest-junit
 

--- a/.github/workflows/codegen-ci.yml
+++ b/.github/workflows/codegen-ci.yml
@@ -83,6 +83,23 @@ jobs:
         run: |
           ${{ github.workspace }}/.github/scripts/wait_for_looker.sh
 
+      # if this job fails before this point the required state check "Codegen Tests"
+      #  is never set, so we will set it manually.
+      - name: Report Failure
+        run: |
+          curl --request POST \
+          --url https://api.github.com/repos/looker-open-source/sdk-codegen/check-runs \
+          --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          --header "content-type: application/json" \
+          --header "Accept: application/vnd.github.v3+json" \
+          --data '{
+            "name": "Codegen Tests",
+            "head_sha": "${{ github.event.pull_request.head.sha || github.sha }}",
+            "conclusion": "failure"
+          }' \
+          --fail
+        if: failure()
+
       - name: Run unit tests
         run: yarn jest "packages/sdk-codegen(|-utils|-scripts)/src" --reporters=default --reporters=jest-junit
 

--- a/.github/workflows/codegen-ci.yml
+++ b/.github/workflows/codegen-ci.yml
@@ -1,10 +1,18 @@
 name: Codegen CI
 on:
   pull_request:
+    paths:
+      - packages/sdk-codegen/**
+      - packages/sdk-codegen-utils/**
+      - packages/sdk-codegen-scripts/**
 
   push:
     branches:
       - main
+    paths:
+      - packages/sdk-codegen/**
+      - packages/sdk-codegen-utils/**
+      - packages/sdk-codegen-scripts/**
 
   workflow_dispatch:
 
@@ -16,11 +24,7 @@ env:
   LOOKERSDK_CLIENT_SECRET: ${{ secrets.LOOKERSDK_CLIENT_SECRET__21_18 }}
 
 jobs:
-  checkfiles:
-    uses: looker-open-source/.github/.github/workflows/check-files.yml@main
   unit:
-    needs: checkfiles
-    if: needs.checkfiles.outputs.codegen == 'true'
     env:
       JEST_JUNIT_OUTPUT_DIR: results/sdk-codegen
       JEST_JUNIT_OUTPUT_NAME: ubuntu-latest.sdk-codegen15x.xml
@@ -102,28 +106,6 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           path: artifacts
-
-      - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1.12
-        with:
-          # Cosmetic issue with `check_name` being associated to the wrong
-          # workflow: https://github.com/EnricoMi/publish-unit-test-result-action/issues/12
-          check_name: Codegen Tests
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          report_individual_runs: true
-          hide_comments: orphaned commits
-          check_run_annotations_branch: '*'
-          files: 'artifacts/sdk-codegen-test-results/*.xml'
-
-  publish-test-results-on-skip:
-    needs: [checkfiles]
-    if: needs.checkfiles.outputs.codegen == 'false'
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Make Dummy Artifacts
-        run: |
-          mkdir -p 'artifacts/sdk-codegen-test-results'
 
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1.12

--- a/.github/workflows/hackathon-ci.yml
+++ b/.github/workflows/hackathon-ci.yml
@@ -1,10 +1,16 @@
 name: Hackathon CI
 on:
   pull_request:
+    paths:
+      - packages/wholly-sheet/**
+      - packages/hackathon/**
 
   push:
     branches:
       - main
+    paths:
+      - packages/wholly-sheet/**
+      - packages/hackathon/**
 
   workflow_dispatch:
 
@@ -12,12 +18,8 @@ env:
   TS_JUNIT_OUTPUT_DIR: results/hackathon
 
 jobs:
-  checkfiles:
-    uses: looker-open-source/.github/.github/workflows/check-files.yml@main
   unit:
     name: Unit - ${{ matrix.os }} / Node ${{ matrix.node-version }}
-    needs: checkfiles
-    if: needs.checkfiles.outputs.hackathon == 'true'
     env:
       JEST_JUNIT_OUTPUT_DIR: results/hackathon
       JEST_JUNIT_OUTPUT_NAME: ${{ matrix.os }}.apix${{ matrix.node-version }}.xml

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -39,6 +39,23 @@ jobs:
       - run: pip install mypy types-requests
       - run: mypy looker_sdk/
 
+      # if this job fails the required state check "Python Tests" is never
+      # set, so we will set it manually.
+      - name: Report Failure
+        run: |
+          curl --request POST \
+          --url https://api.github.com/repos/looker-open-source/sdk-codegen/check-runs \
+          --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          --header "content-type: application/json" \
+          --header "Accept: application/vnd.github.v3+json" \
+          --data '{
+            "name": "Python Tests",
+            "head_sha": "${{ github.event.pull_request.head.sha || github.sha }}",
+            "conclusion": "failure"
+          }' \
+          --fail
+        if: failure()
+
   unit:
     needs: typecheck
     name: Unit - ${{ matrix.os }} / py${{ matrix.python-version }}
@@ -76,6 +93,23 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install tox
+
+      # if this job fails the required state check "Python Tests" is never
+      # set, so we will set it manually.
+      - name: Report Failure
+        run: |
+          curl --request POST \
+          --url https://api.github.com/repos/looker-open-source/sdk-codegen/check-runs \
+          --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          --header "content-type: application/json" \
+          --header "Accept: application/vnd.github.v3+json" \
+          --data '{
+            "name": "Python Tests",
+            "head_sha": "${{ github.event.pull_request.head.sha || github.sha }}",
+            "conclusion": "failure"
+          }' \
+          --fail
+        if: failure()
 
       - name: Run Unit Tests
         run: tox -e unit
@@ -196,6 +230,23 @@ jobs:
       - name: Check that Looker is ready
         run: |
           ${{ github.workspace }}/.github/scripts/wait_for_looker.sh
+
+      # if this job fails the required state check "Python Tests" is never
+      # set, so we will set it manually.
+      - name: Report Failure
+        run: |
+          curl --request POST \
+          --url https://api.github.com/repos/looker-open-source/sdk-codegen/check-runs \
+          --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          --header "content-type: application/json" \
+          --header "Accept: application/vnd.github.v3+json" \
+          --data '{
+            "name": "Python Tests",
+            "head_sha": "${{ github.event.pull_request.head.sha || github.sha }}",
+            "conclusion": "failure"
+          }' \
+          --fail
+        if: failure()
 
       - name: Run Integration Tests
         run: tox -e integration

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,10 +1,14 @@
 name: Python CI
 on:
   pull_request:
+    paths:
+      - python/**
 
   push:
     branches:
       - main
+    paths:
+      - python/**
 
   workflow_dispatch:
 
@@ -19,12 +23,8 @@ defaults:
     working-directory: python/
 
 jobs:
-  checkfiles:
-    uses: looker-open-source/.github/.github/workflows/check-files.yml@main
   typecheck:
     name: Mypy
-    needs: checkfiles
-    if: needs.checkfiles.outputs.python == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
@@ -32,18 +32,15 @@ jobs:
         with:
           access_token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v2
-
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.9.9
+          python-version: 3.9
       - run: pip install -e .
       - run: pip install mypy types-requests
       - run: mypy looker_sdk/
 
   unit:
-    needs: [checkfiles, typecheck]
-    if: needs.checkfiles.outputs.python == 'true'
-
+    needs: typecheck
     name: Unit - ${{ matrix.os }} / py${{ matrix.python-version }}
     env:
       TOX_JUNIT_OUTPUT_NAME: ${{ matrix.os }}.py${{ matrix.python-version }}
@@ -57,7 +54,7 @@ jobs:
           - macos
           - windows
         python-version:
-          - '3.9.9'
+          - '3.9'
         include:
           - python-version: '3.6'
             os: ubuntu
@@ -91,8 +88,7 @@ jobs:
           path: python/results/
 
   integration:
-    needs: [checkfiles, unit]
-    if: needs.checkfiles.outputs.python == 'true'
+    needs: unit
     name: Integration - ${{ matrix.os }} / Looker.${{ matrix.looker }}
     env:
       TOX_JUNIT_OUTPUT_NAME: ${{ matrix.os }}.Looker-${{ matrix.looker }}.py3.x
@@ -141,7 +137,7 @@ jobs:
         run: gcloud auth configure-docker us-west1-docker.pkg.dev --quiet
 
       - name: Install docker on macos
-        if: matrix.os == 'macos'
+        if: ${{ matrix.os == 'macos' }}
         uses: docker-practice/actions-setup-docker@v1
         with:
           docker_channel: stable
@@ -149,7 +145,7 @@ jobs:
           docker_cli_experimental: disabled
 
       - name: Bump docker for mac memory
-        if: matrix.os == 'macos'
+        if: ${{ matrix.os == 'macos' }}
         run: |
           osascript -e 'quit app "Docker"'
           sed -i'.original' -e's/  "memoryMiB" : 2048/  "memoryMiB" : 8192/' ~/Library/Group\ Containers/group.com.docker/settings.json
@@ -179,7 +175,7 @@ jobs:
           pip install tox
 
       - name: Determine credentials version
-        # Prior to 21_18, each version had different credentials and a
+        # Prior to 21_18, each version had different credentials and a 
         # different secret. 21_20 and later all use the same credentials
         # as 21_18. The parse_version.sh script parses the version and
         # yields 21_12, 21_14, 21_16 etc for those versions but 21_18 for
@@ -212,15 +208,13 @@ jobs:
           path: python/results/
 
   twine:
-    needs: [checkfiles, integration]
-    if: needs.checkfiles.outputs.python == 'true'
+    needs: integration
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.9.9
+          python-version: 3.9
       - name: Twine upload check
         run: |
           pip install wheel twine
@@ -237,32 +231,6 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           path: artifacts
-
-      - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1.12
-        with:
-          # Cosmetic issue with `check_name` being associated to the wrong
-          # workflow: https://github.com/EnricoMi/publish-unit-test-result-action/issues/12
-          check_name: Python Tests
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          report_individual_runs: true
-          hide_comments: orphaned commits
-          check_run_annotations_branch: '*'
-          files: 'artifacts/python-test-results/*.xml'
-
-  publish-test-results-on-skip:
-    defaults:
-      run:
-        shell: bash
-        working-directory: .
-    needs: checkfiles
-    if: needs.checkfiles.outputs.python == 'false'
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Make Dummy Artifacts
-        run: |
-          mkdir -p 'artifacts/python-test-results'
 
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1.12

--- a/.github/workflows/required-checks-hack-ci.yml
+++ b/.github/workflows/required-checks-hack-ci.yml
@@ -1,0 +1,120 @@
+# The jobs in this workflow are necessary because they are configured as
+# required checks on PRs. Github does not currently support configuring required
+# checks per workflow. A PR that only triggers codegen-ci.yml jobs will only
+# report back with the "Codegen Tests" check. But because there is only a global
+# option for required PR checks, that PR would otherwise never satisfy the
+# "Typescript/Python/APIX Tests" checks without these noop jobs.
+#
+# References:
+# https://github.community/t/github-actions-and-required-checks-in-a-monorepo-using-paths-to-limit-execution/16586
+# https://github.community/t/feature-request-conditional-required-checks/16761/6
+#
+# Each job actually has a corresponding "real" job
+# definition in a different workflow file:
+#
+# codegen-ci.yml: Codegen Tests
+# tssdk-ci.yml: Typescript Tests
+# python-ci.yml: Python Tests
+# apix-ci.yml: APIX Tests
+#
+
+name: Required Checks Hack
+on:
+  pull_request:
+
+jobs:
+  checkfiles:
+    runs-on: ubuntu-latest
+    outputs:
+      filters: ${{ toJSON(steps.filter.outputs) }}
+      apix: ${{ steps.filter.outputs.apix }}
+      codegen: ${{ steps.filter.outputs.codegen }}
+      hackathon: ${{ steps.filter.outputs.hackathon }}
+      python: ${{ steps.filter.outputs.python }}
+      resources: ${{ steps.filter.outputs.resources }}
+      tssdk: ${{ steps.filter.outputs.tssdk }}
+
+    steps:
+      - name: Repo Checkout
+        uses: actions/checkout@v2
+
+      - uses: tony84727/changed-file-filter@v0.2.0
+        id: filter
+        with:
+        # head: optional head commit SHA, default to ${{ github.event.pull_request.head.sha || github.sha }}
+        # base: optional base commit SHA, default to ${{ github.event.pull_request.base.sha }}
+        # or HEAD^ if not triggered by pull_request
+
+        # filter rules in YAML format
+        # <rule-name>:
+        #  - <glob expression>
+          filters: |
+            apix:
+              - packages/code-editor/**
+              - packages/run-it/**
+              - packages/api-explorer/**
+              - packages/extension-api-explorer/**
+              - packages/extension-utils/**
+            codegen:
+              - packages/sdk-codegen/**
+              - packages/sdk-codegen-utils/**
+              - packages/sdk-codegen-scripts/**
+            hackathon:
+              - packages/wholly-sheet/**
+              - packages/hackathon/**
+            python:
+              - python/**
+            resources:
+              - bin/looker-resources-index/**
+              - docs/resources/**
+            tssdk:
+              - packages/sdk/**
+              - packages/sdk-rtl/**
+              - packages/sdk-node/**
+              - packages/extension-sdk/**
+              - packages/extension-sdk-react/**
+              - packages/extension-utils/**
+      - run: |
+          echo "${{ toJSON(steps.filter.outputs) }}"
+          echo "apix: ${{ steps.filter.outputs.apix }}"
+          echo "codegen: ${{ steps.filter.outputs.codegen }}"
+          echo "hackathon: ${{ steps.filter.outputs.hackathon }}"
+          echo "python: ${{ steps.filter.outputs.python }}"
+          echo "resources: ${{ steps.filter.outputs.resources }}"
+          echo "tssdk: ${{ steps.filter.outputs.tssdk }}"
+
+  noop-codegen-results:
+    name: Codegen Tests
+    needs: checkfiles
+    if: needs.checkfiles.outputs.codegen == 'false'
+
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0
+
+  noop-typescript-results:
+    name: Typescript Tests
+    needs: checkfiles
+    if: needs.checkfiles.outputs.tssdk == 'false'
+
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0
+
+  noop-python-results:
+    name: Python Tests
+    needs: checkfiles
+    if: needs.checkfiles.outputs.python == 'false'
+
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0
+
+  noop-apix-results:
+    name: APIX Tests
+    needs: checkfiles
+    if: needs.checkfiles.outputs.apix == 'false'
+
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0

--- a/.github/workflows/required-checks-hack-ci.yml
+++ b/.github/workflows/required-checks-hack-ci.yml
@@ -118,3 +118,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: exit 0
+
+  noop-hackathon-results:
+    name: Hackathon Tests
+    needs: checkfiles
+    if: needs.checkfiles.outputs.hackathon == 'false'
+
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0
+
+  noop-resources-results:
+    name: Resources Tests
+    needs: checkfiles
+    if: needs.checkfiles.outputs.resources == 'false'
+
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0

--- a/.github/workflows/required-checks-hack-ci.yml
+++ b/.github/workflows/required-checks-hack-ci.yml
@@ -41,13 +41,6 @@ jobs:
       - uses: tony84727/changed-file-filter@v0.2.0
         id: filter
         with:
-        # head: optional head commit SHA, default to ${{ github.event.pull_request.head.sha || github.sha }}
-        # base: optional base commit SHA, default to ${{ github.event.pull_request.base.sha }}
-        # or HEAD^ if not triggered by pull_request
-
-        # filter rules in YAML format
-        # <rule-name>:
-        #  - <glob expression>
           filters: |
             apix:
               - packages/code-editor/**
@@ -86,38 +79,106 @@ jobs:
   noop-codegen-results:
     name: Codegen Tests
     needs: checkfiles
-    if: needs.checkfiles.outputs.codegen == 'false'
 
     runs-on: ubuntu-latest
     steps:
-      - run: exit 0
+      - run: echo "Codegen Tests not required"
+        if: needs.checkfiles.outputs.codegen == 'false'
+
+      - name: Wait for codegen-ci to succeed
+        if: needs.checkfiles.outputs.codegen == 'true'
+        uses: fountainhead/action-wait-for-check@v1.0.0
+        id: wait-for-check
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: Codegen Tests
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Do something with a passing build
+        if: steps.wait-for-check.outputs.conclusion == 'success'
+        run: exit 0
+
+      - name: Do something with a failing build
+        if: steps.wait-for-check.outputs.conclusion == 'failure'
+        run: exit 1
 
   noop-typescript-results:
     name: Typescript Tests
     needs: checkfiles
-    if: needs.checkfiles.outputs.tssdk == 'false'
 
     runs-on: ubuntu-latest
     steps:
-      - run: exit 0
+      - run: echo "Typescript Tests not required"
+        if: needs.checkfiles.outputs.tssdk == 'false'
+
+      - name: Wait for codegen-ci to succeed
+        if: needs.checkfiles.outputs.tssdk == 'true'
+        uses: fountainhead/action-wait-for-check@v1.0.0
+        id: wait-for-check
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: Typescript Tests
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Do something with a passing build
+        if: steps.wait-for-check.outputs.conclusion == 'success'
+        run: exit 0
+
+      - name: Do something with a failing build
+        if: steps.wait-for-check.outputs.conclusion == 'failure'
+        run: exit 1
 
   noop-python-results:
     name: Python Tests
     needs: checkfiles
-    if: needs.checkfiles.outputs.python == 'false'
 
     runs-on: ubuntu-latest
     steps:
-      - run: exit 0
+      - run: echo "Python Tests not required"
+        if: needs.checkfiles.outputs.python == 'false'
+
+      - name: Wait for python-ci to succeed
+        if: needs.checkfiles.outputs.python == 'true'
+        uses: fountainhead/action-wait-for-check@v1.0.0
+        id: wait-for-check
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: Python Tests
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Do something with a passing build
+        if: steps.wait-for-check.outputs.conclusion == 'success'
+        run: exit 0
+
+      - name: Do something with a failing build
+        if: steps.wait-for-check.outputs.conclusion == 'failure'
+        run: exit 1
 
   noop-apix-results:
     name: APIX Tests
     needs: checkfiles
-    if: needs.checkfiles.outputs.apix == 'false'
 
     runs-on: ubuntu-latest
     steps:
-      - run: exit 0
+      - run: echo "APIX Tests not required"
+        if: needs.checkfiles.outputs.apix == 'false'
+
+      - name: Wait for apix-ci to succeed
+        if: needs.checkfiles.outputs.apix == 'true'
+        uses: fountainhead/action-wait-for-check@v1.0.0
+        id: wait-for-check
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: APIX Tests
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Do something with a passing build
+        if: steps.wait-for-check.outputs.conclusion == 'success'
+        run: exit 0
+
+      - name: Do something with a failing build
+        if: steps.wait-for-check.outputs.conclusion == 'failure'
+        run: exit 1
 
   noop-hackathon-results:
     name: Hackathon Tests
@@ -126,7 +187,25 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - run: exit 0
+      - run: echo "Codegen Tests not required"
+        if: needs.checkfiles.outputs.hackathon == 'false'
+
+      - name: Wait for hackathon-ci to succeed
+        if: needs.checkfiles.outputs.hackathon == 'true'
+        uses: fountainhead/action-wait-for-check@v1.0.0
+        id: wait-for-check
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: Hackathon Tests
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Do something with a passing build
+        if: steps.wait-for-check.outputs.conclusion == 'success'
+        run: exit 0
+
+      - name: Do something with a failing build
+        if: steps.wait-for-check.outputs.conclusion == 'failure'
+        run: exit 1
 
   noop-resources-results:
     name: Resources Tests
@@ -135,4 +214,22 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - run: exit 0
+      - run: echo "Resources Tests not required"
+        if: needs.checkfiles.outputs.resources == 'false'
+
+      - name: Wait for resources-ci to succeed
+        if: needs.checkfiles.outputs.resources == 'true'
+        uses: fountainhead/action-wait-for-check@v1.0.0
+        id: wait-for-check
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: Resources Tests
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Do something with a passing build
+        if: steps.wait-for-check.outputs.conclusion == 'success'
+        run: exit 0
+
+      - name: Do something with a failing build
+        if: steps.wait-for-check.outputs.conclusion == 'failure'
+        run: exit 1

--- a/.github/workflows/required-checks-hack-ci.yml
+++ b/.github/workflows/required-checks-hack-ci.yml
@@ -22,18 +22,15 @@ name: Required Checks Hack
 on:
   pull_request:
 
-jobs:
-  checkfiles:
-    runs-on: ubuntu-latest
-    outputs:
-      filters: ${{ toJSON(steps.filter.outputs) }}
-      apix: ${{ steps.filter.outputs.apix }}
-      codegen: ${{ steps.filter.outputs.codegen }}
-      hackathon: ${{ steps.filter.outputs.hackathon }}
-      python: ${{ steps.filter.outputs.python }}
-      resources: ${{ steps.filter.outputs.resources }}
-      tssdk: ${{ steps.filter.outputs.tssdk }}
+  push:
+    branches:
+      - main
 
+jobs:
+  satisfy-required-checks:
+    name: Satisfy Required Checks
+
+    runs-on: ubuntu-latest
     steps:
       - name: Repo Checkout
         uses: actions/checkout@v2
@@ -67,7 +64,8 @@ jobs:
               - packages/extension-sdk/**
               - packages/extension-sdk-react/**
               - packages/extension-utils/**
-      - run: |
+      - name: Debug info
+        run: |
           echo "${{ toJSON(steps.filter.outputs) }}"
           echo "apix: ${{ steps.filter.outputs.apix }}"
           echo "codegen: ${{ steps.filter.outputs.codegen }}"
@@ -76,160 +74,62 @@ jobs:
           echo "resources: ${{ steps.filter.outputs.resources }}"
           echo "tssdk: ${{ steps.filter.outputs.tssdk }}"
 
-  noop-codegen-results:
-    name: Codegen Tests
-    needs: checkfiles
+      - name: Create Codegen check
+        if: steps.filter.outputs.codegen == 'false'
+        run: |
+          curl --request POST \
+          --url https://api.github.com/repos/looker-open-source/sdk-codegen/check-runs \
+          --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          --header "content-type: application/json" \
+          --header "Accept: application/vnd.github.v3+json" \
+          --data '{
+            "name": "Codegen Tests",
+            "head_sha": "${{ github.event.pull_request.head.sha || github.sha }}",
+            "conclusion": "success"
+          }' \
+          --fail
 
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Codegen Tests not required"
-        if: needs.checkfiles.outputs.codegen == 'false'
+      - name: Create Typescript check
+        if: steps.filter.outputs.tssdk == 'false'
+        run: |
+          curl --request POST \
+          --url https://api.github.com/repos/looker-open-source/sdk-codegen/check-runs \
+          --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          --header "content-type: application/json" \
+          --header "Accept: application/vnd.github.v3+json" \
+          --data '{
+            "name": "Typescript Tests",
+            "head_sha": "${{ github.event.pull_request.head.sha || github.sha }}",
+            "conclusion": "success"
+          }' \
+          --fail
 
-      - name: Wait for codegen-ci to succeed
-        if: needs.checkfiles.outputs.codegen == 'true'
-        uses: fountainhead/action-wait-for-check@v1.0.0
-        id: wait-for-check
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          checkName: Codegen Tests
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Create Python check
+        if: steps.filter.outputs.python == 'false'
+        run: |
+          curl --request POST \
+          --url https://api.github.com/repos/looker-open-source/sdk-codegen/check-runs \
+          --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          --header "content-type: application/json" \
+          --header "Accept: application/vnd.github.v3+json" \
+          --data '{
+            "name": "Python Tests",
+            "head_sha": "${{ github.event.pull_request.head.sha || github.sha }}",
+            "conclusion": "success"
+          }' \
+          --fail
 
-      - name: Do something with a passing build
-        if: steps.wait-for-check.outputs.conclusion == 'success'
-        run: exit 0
-
-      - name: Do something with a failing build
-        if: steps.wait-for-check.outputs.conclusion == 'failure'
-        run: exit 1
-
-  noop-typescript-results:
-    name: Typescript Tests
-    needs: checkfiles
-
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Typescript Tests not required"
-        if: needs.checkfiles.outputs.tssdk == 'false'
-
-      - name: Wait for codegen-ci to succeed
-        if: needs.checkfiles.outputs.tssdk == 'true'
-        uses: fountainhead/action-wait-for-check@v1.0.0
-        id: wait-for-check
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          checkName: Typescript Tests
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Do something with a passing build
-        if: steps.wait-for-check.outputs.conclusion == 'success'
-        run: exit 0
-
-      - name: Do something with a failing build
-        if: steps.wait-for-check.outputs.conclusion == 'failure'
-        run: exit 1
-
-  noop-python-results:
-    name: Python Tests
-    needs: checkfiles
-
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Python Tests not required"
-        if: needs.checkfiles.outputs.python == 'false'
-
-      - name: Wait for python-ci to succeed
-        if: needs.checkfiles.outputs.python == 'true'
-        uses: fountainhead/action-wait-for-check@v1.0.0
-        id: wait-for-check
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          checkName: Python Tests
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Do something with a passing build
-        if: steps.wait-for-check.outputs.conclusion == 'success'
-        run: exit 0
-
-      - name: Do something with a failing build
-        if: steps.wait-for-check.outputs.conclusion == 'failure'
-        run: exit 1
-
-  noop-apix-results:
-    name: APIX Tests
-    needs: checkfiles
-
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "APIX Tests not required"
-        if: needs.checkfiles.outputs.apix == 'false'
-
-      - name: Wait for apix-ci to succeed
-        if: needs.checkfiles.outputs.apix == 'true'
-        uses: fountainhead/action-wait-for-check@v1.0.0
-        id: wait-for-check
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          checkName: APIX Tests
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Do something with a passing build
-        if: steps.wait-for-check.outputs.conclusion == 'success'
-        run: exit 0
-
-      - name: Do something with a failing build
-        if: steps.wait-for-check.outputs.conclusion == 'failure'
-        run: exit 1
-
-  noop-hackathon-results:
-    name: Hackathon Tests
-    needs: checkfiles
-    if: needs.checkfiles.outputs.hackathon == 'false'
-
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Codegen Tests not required"
-        if: needs.checkfiles.outputs.hackathon == 'false'
-
-      - name: Wait for hackathon-ci to succeed
-        if: needs.checkfiles.outputs.hackathon == 'true'
-        uses: fountainhead/action-wait-for-check@v1.0.0
-        id: wait-for-check
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          checkName: Hackathon Tests
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Do something with a passing build
-        if: steps.wait-for-check.outputs.conclusion == 'success'
-        run: exit 0
-
-      - name: Do something with a failing build
-        if: steps.wait-for-check.outputs.conclusion == 'failure'
-        run: exit 1
-
-  noop-resources-results:
-    name: Resources Tests
-    needs: checkfiles
-    if: needs.checkfiles.outputs.resources == 'false'
-
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Resources Tests not required"
-        if: needs.checkfiles.outputs.resources == 'false'
-
-      - name: Wait for resources-ci to succeed
-        if: needs.checkfiles.outputs.resources == 'true'
-        uses: fountainhead/action-wait-for-check@v1.0.0
-        id: wait-for-check
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          checkName: Resources Tests
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Do something with a passing build
-        if: steps.wait-for-check.outputs.conclusion == 'success'
-        run: exit 0
-
-      - name: Do something with a failing build
-        if: steps.wait-for-check.outputs.conclusion == 'failure'
-        run: exit 1
+      - name: Create APIX check
+        if: steps.filter.outputs.apix == 'false'
+        run: |
+          curl --request POST \
+          --url https://api.github.com/repos/looker-open-source/sdk-codegen/check-runs \
+          --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          --header "content-type: application/json" \
+          --header "Accept: application/vnd.github.v3+json" \
+          --data '{
+            "name": "APIX Tests",
+            "head_sha": "${{ github.event.pull_request.head.sha || github.sha }}",
+            "conclusion": "success"
+          }' \
+          --fail

--- a/.github/workflows/resources-ci.yml
+++ b/.github/workflows/resources-ci.yml
@@ -1,10 +1,16 @@
 name: Resources Index CI
 on:
   pull_request:
+    paths:
+      - bin/looker-resources-index/**
+      - docs/resources/**
 
   push:
     branches:
       - main
+    paths:
+      - bin/looker-resources-index/**
+      - docs/resources/**
 
 defaults:
   run:
@@ -12,12 +18,8 @@ defaults:
     working-directory: bin/looker-resources-index
 
 jobs:
-  checkfiles:
-    uses: looker-open-source/.github/.github/workflows/check-files.yml@main
   analyzebuild:
     name: Analyze and Build
-    needs: checkfiles
-    if: needs.checkfiles.outputs.resources == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/tssdk-ci.yml
+++ b/.github/workflows/tssdk-ci.yml
@@ -75,6 +75,23 @@ jobs:
           echo "verify_ssl=False" >> looker.ini
           echo "timeout=30" >> looker.ini
 
+      # if this job fails before this point the required state check "Typescript Tests"
+      #  is never set, so we will set it manually.
+      - name: Report Failure
+        run: |
+          curl --request POST \
+          --url https://api.github.com/repos/looker-open-source/sdk-codegen/check-runs \
+          --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          --header "content-type: application/json" \
+          --header "Accept: application/vnd.github.v3+json" \
+          --data '{
+            "name": "Typescript Tests",
+            "head_sha": "${{ github.event.pull_request.head.sha || github.sha }}",
+            "conclusion": "failure"
+          }' \
+          --fail
+        if: failure()
+
       - name: Run unit tests
         run: yarn jest "packages/(extension-sdk|extension-sdk-react|sdk-rtl|sdk)/src" --reporters=default --reporters=jest-junit
 

--- a/.github/workflows/tssdk-ci.yml
+++ b/.github/workflows/tssdk-ci.yml
@@ -1,10 +1,24 @@
 name: TypeScript SDK CI
 on:
   pull_request:
+    paths:
+      - packages/sdk/**
+      - packages/sdk-rtl/**
+      - packages/sdk-node/**
+      - packages/extension-sdk/**
+      - packages/extension-sdk-react/**
+      - packages/extension-utils/**
 
   push:
     branches:
       - main
+    paths:
+      - packages/sdk/**
+      - packages/sdk-rtl/**
+      - packages/sdk-node/**
+      - packages/extension-sdk/**
+      - packages/extension-sdk-react/**
+      - packages/extension-utils/**
 
   workflow_dispatch:
 
@@ -14,12 +28,8 @@ env:
   TS_JUNIT_OUTPUT_DIR: results/tssdk
 
 jobs:
-  checkfiles:
-    uses: looker-open-source/.github/.github/workflows/check-files.yml@main
   unit:
     name: Unit - ${{ matrix.os }} / Node ${{ matrix.node-version }}
-    needs: checkfiles
-    if: needs.checkfiles.outputs.tssdk == 'true'
     env:
       JEST_JUNIT_OUTPUT_DIR: results/tssdk
       JEST_JUNIT_OUTPUT_NAME: ${{ matrix.os }}.tssdkrtl${{ matrix.node-version }}.xml
@@ -79,8 +89,7 @@ jobs:
           path: results/tssdk
 
   integration:
-    needs: [checkfiles, unit]
-    if: needs.checkfiles.outputs.tssdk == 'true'
+    needs: unit
     name: Integration - ${{ matrix.os }} / Node.${{ matrix.node-version }} / Looker.${{ matrix.looker }}
     env:
       JEST_JUNIT_OUTPUT_DIR: results/tssdk
@@ -173,28 +182,6 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           path: artifacts
-
-      - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1.12
-        with:
-          # Cosmetic issue with `check_name` being associated to the wrong
-          # workflow: https://github.com/EnricoMi/publish-unit-test-result-action/issues/12
-          check_name: Typescript Tests
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          report_individual_runs: true
-          hide_comments: orphaned commits
-          check_run_annotations_branch: '*'
-          files: 'artifacts/tssdk-test-results/*.xml'
-
-  publish-test-results-on-skip:
-    needs: checkfiles
-    if: needs.checkfiles.outputs.tssdk == 'false'
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Make Dummy Artifacts
-        run: |
-          mkdir -p 'artifacts/tssdk-test-results'
 
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1.12

--- a/docs/ci-testing.md
+++ b/docs/ci-testing.md
@@ -1,0 +1,224 @@
+# Adding required ci testing
+## Create a test-area-ci workflow
+Create a workflow in `.github/workflows/`. The existing workflows can be used as an example.
+
+The new workflow should respond to pull requests, pushes, and workflow dispatch events. The
+pull requests and pushes should be filtered by one of more file paths. The start of the
+workflow will look something like this...
+
+```yaml
+name: API Explorer CI
+on:
+  pull_request:
+    paths:
+      - packages/code-editor/**
+      - packages/run-it/**
+      - packages/api-explorer/**
+      - packages/extension-api-explorer/**
+      - packages/extension-utils/**
+
+  push:
+    branches:
+      - main
+    paths:
+      - packages/code-editor/**
+      - packages/run-it/**
+      - packages/api-explorer/**
+      - packages/extension-api-explorer/**
+      - packages/extension-utils/**
+
+  workflow_dispatch:
+```
+In this example, the API Explorer (APIX for short) is being tested. That name and the
+particular file paths should be customized for the area you wish to test.
+
+The workflow will probably end with a step to report the results. This is especially 
+with a CI test that uses various combinations of Looker versions, platforms like Windows,
+Linux, MaxOS, and versions of tools like Node or Python. Each variation of a matrix test
+should report a result that is then aggregated into one overall result. That aggregate 
+reporting step might look like this...
+
+```yaml
+  publish-test-results:
+    needs: [unit]
+    if: success() || failure()
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: artifacts
+
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1.12
+        with:
+          check_name: APIX Tests
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          report_individual_runs: true
+          hide_comments: orphaned commits
+          check_run_annotations_branch: '*'
+          files: 'artifacts/apix-test-results/*.xml'
+```
+
+In particular, note the `check_name: APIX Tests`. This will publish a check back to github
+called `APIX Tests`. Of course that should be customized for the area you wish to test.
+
+Now modify the file `.github/workflows/required-checks-hack-ci.yml`. This "test" makes sure
+that success is reported if the file pattern in the pull request or push is not satisfied.
+That way if someone modifies another part of the project unrelated tests don't need to be run.
+
+Add a new filter with a unique name under the `changed-file-filter` step. Use the same filter
+as the `paths:` clause under the `push:` and `pull_requests:` for your new ci workflow.
+```yaml
+      - uses: tony84727/changed-file-filter@v0.2.0
+        id: filter
+        with:
+          filters: |
+            apix:
+              - packages/code-editor/**
+              - packages/run-it/**
+              - packages/api-explorer/**
+              - packages/extension-api-explorer/**
+              - packages/extension-utils/**
+            codegen:
+              - packages/sdk-codegen/**
+              - packages/sdk-codegen-utils/**
+              - packages/sdk-codegen-scripts/**
+```
+
+Add a new output under the checkfiles job, referencing the filter name in the filter step.
+The job output can be the same name as the step output. 
+```yaml
+  checkfiles:
+    runs-on: ubuntu-latest
+    outputs:
+      filters: ${{ toJSON(steps.filter.outputs) }}
+      apix: ${{ steps.filter.outputs.apix }}
+      codegen: ${{ steps.filter.outputs.codegen }}
+      hackathon: ${{ steps.filter.outputs.hackathon }}
+      python: ${{ steps.filter.outputs.python }}
+      resources: ${{ steps.filter.outputs.resources }}
+      tssdk: ${{ steps.filter.outputs.tssdk }}
+```
+The full set of outputs is also available in the JSON structure under the name `filters`. In
+addition to the true/false flags the list of matching files is available as an array
+like `apix_files`. The job output could be read in a workflow like
+`fromJSON(${{ needs.checkfiles.outputs.filters }}).apix`. I recommend adding the individual
+flags to the outputs for convenience and readability.
+
+The checkfiles job has a final step where the state of these flags is echoed to the logs
+for debugging. You might want to add that as well.
+
+Finally create a job `noop-subject-area-results:` with the same `name:` as the `check_name:`
+above. It should have an `if:` for the job so it only runs if the filter is 'false'.
+```yaml
+  noop-apix-results:
+    name: APIX Tests
+    needs: checkfiles
+    if: needs.checkfiles.outputs.apix == 'false'
+
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0
+```
+
+`exit 0` means success.
+
+## Example
+To illustrate this, imagine you were adding a ci workflow for `go`. Your workflow
+might be named `.github/workflows/go-ci.yml` and start with this:
+```yaml
+name: Go CI
+on:
+  pull_request:
+    paths:
+      - go/**
+
+  push:
+    branches:
+      - main
+    paths:
+      - go/**
+
+  workflow_dispatch:
+```
+
+The last step might be something like this...
+```yaml
+  publish-test-results:
+    needs: [unit]
+    if: success() || failure()
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: artifacts
+
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1.12
+        with:
+          check_name: Go Tests
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          report_individual_runs: true
+          hide_comments: orphaned commits
+          check_run_annotations_branch: '*'
+          files: 'artifacts/go-test-results/*.xml'
+```
+
+Make note of the `paths:` filter `- go/**` and the `check_name:` 'Go Tests`.
+
+In `.github/workflows/required-checks-hack-ci.yml` add a `go` filter to the
+list of defined filters with the same filter.
+```yaml
+      - uses: tony84727/changed-file-filter@v0.2.0
+        id: filter
+        with:
+          filters: |
+            apix:
+              - packages/code-editor/**
+              - packages/run-it/**
+              - packages/api-explorer/**
+              - packages/extension-api-explorer/**
+              - packages/extension-utils/**
+            codegen:
+              - packages/sdk-codegen/**
+              - packages/sdk-codegen-utils/**
+              - packages/sdk-codegen-scripts/**
+            go:
+              - go/**
+            # snipped
+```
+I add them alphabetically because it makes me happier.
+
+In `.github/workflows/required-checks-hack-ci.yml` add a `go` filter to the
+list of outputs.
+```yaml
+  checkfiles:
+    runs-on: ubuntu-latest
+    outputs:
+      filters: ${{ toJSON(steps.filter.outputs) }}
+      apix: ${{ steps.filter.outputs.apix }}
+      codegen: ${{ steps.filter.outputs.codegen }}
+      go: ${{ steps.filter.outputs.go }}
+      hackathon: ${{ steps.filter.outputs.hackathon }}
+      python: ${{ steps.filter.outputs.python }}
+      resources: ${{ steps.filter.outputs.resources }}
+      tssdk: ${{ steps.filter.outputs.tssdk }}
+```
+
+Finally in `.github/workflows/required-checks-hack-ci.yml` add the noop result,
+making sure that the job name here matches the `check-name:` defined in 
+the `.github/workflows/go-ci.yml` `publish-test-results:` job.
+```yaml
+  noop-go-results:
+    name: Go Tests
+    needs: checkfiles
+    if: needs.checkfiles.outputs.go == 'false'
+
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0
+```


### PR DESCRIPTION
The basic problem we have is that we want to make certain checks required, but the tests for them don't run on all requests. For example this test only runs if the indicated paths are changed.

```
name: TypeScript SDK CI
on:
  pull_request:
    paths:
      - packages/sdk/**
      - packages/sdk-rtl/**
      - packages/sdk-node/**
      - packages/extension-sdk/**
      - packages/extension-sdk-react/**
      - packages/extension-utils/**
```

A special `required_checks_hack_ci` workflow would run. It would just sleep then mark the required checks as succeeded if they hadn't failed by 480 seconds. Every PR had to wait 480 seconds regardless.

My first version of this was to remove the path filters on pull requests and pushes, then use the a "check-files" reusable workflow that would set a bunch of flags based on what files changed. In this snippet, the name of each filter set would be used as a name of an output to this job. So `<job-name>.outputs.apix` could equal 'true' or 'false' based on whether changed files matched the `apix` pattern.
```yaml
      - uses: tony84727/changed-file-filter@v0.2.0
        id: filter
          filters: |
            apix:
              - packages/code-editor/**
              - packages/run-it/**
              - packages/api-explorer/**
              - packages/extension-api-explorer/**
              - packages/extension-utils/**
            codegen:
              - packages/sdk-codegen/**
              - packages/sdk-codegen-utils/**
              - packages/sdk-codegen-scripts/**
            hackathon:
              - packages/wholly-sheet/**
              - packages/hackathon/**
            python:
              - python/**
            resources:
              - bin/looker-resources-index/**
              - docs/resources/**
            tssdk:
              - packages/sdk/**
              - packages/sdk-rtl/**
              - packages/sdk-node/**
              - packages/extension-sdk/**
              - packages/extension-sdk-react/**
              - packages/extension-utils/**
```

Then I would check the flags and skip the certain jobs with code like `if: needs.check_files.outputs.tssdk == 'true'`. I would generate an alternate success message for `if: needs.check_files.outputs.tssdk == 'false'`. Now every test runs every time, generating lots of output when it isn't really needed.

@jeremytchang made the point that this generates lots of noise that is confusing.

To hopefully fix this I reset the state of the CI tests so they have the `path:` filters on pushes and pull requests again. That was commit 378df7694a7d9b02f1d4c67061dddda576883bfd. Now tests once again only run if they are needed. Then I modified the `required_checks_hack_ci` workflow to use the `check-files` logic. If the push or pull_request does not have a file pattern that triggers the actual test, the expression like `if: needs.check_files.outputs.tssdk == 'false'` will succeed and the noop job will run, causing the unneeded required checks to pass almost immediately instead of after 480 seconds.

My one major regret with this pattern is that the file patterns for the checks are defined in two places. I'm not sure if github workflows can work around that, however.