### PR TITLE
chore: set release-please-config for 22.0.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,23 +2,24 @@
   "plugins": ["node-workspace"],
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
+  "release-as": "22.0.0",
   "packages": {
     ".": { "release-as": "" },
     "packages/api-explorer": { "release-as": "" },
     "packages/code-editor": { "release-as": "" },
-    "packages/extension-api-explorer": { "release-as": ""},
-    "packages/extension-sdk": { "release-as": ""},
-    "packages/extension-sdk-react": { "release-as": ""},
+    "packages/extension-api-explorer": { },
+    "packages/extension-sdk": { },
+    "packages/extension-sdk-react": { },
     "packages/extension-utils": { "release-as": "" },
     "packages/hackathon": { "release-as": ""},
     "packages/run-it": { "release-as": "" },
-    "packages/sdk": { "release-as": ""},
+    "packages/sdk": { },
     "packages/sdk-codegen": { "release-as": "" },
     "packages/sdk-codegen-scripts": { "release-as": "" },
-    "packages/sdk-codegen-utils": { "release-as": ""},
-    "packages/sdk-node": { "release-as": ""},
+    "packages/sdk-codegen-utils": { "release-as": "" },
+    "packages/sdk-node": { },
     "packages/sdk-rtl": { "release-as": "" },
     "packages/wholly-sheet": { "release-as": "" },
-    "python": { "release-type": "python", "package-name": "looker_sdk", "release-as": "" }
+    "python": { "release-type": "python", "package-name": "looker_sdk" }
   }
 }


### PR DESCRIPTION
top level key set and inherited by the following packages that track
the Looker version:
- packages/extension-api-explorer
- packages/extension-sdk
- packages/extension-sdk-react
- packages/sdk
- packages/sdk-node
- looker_sdk