### PR TITLE
fix: runtime error for API Explorer

### DIFF
--- a/packages/api-explorer/e2e/e2e.spec.ts
+++ b/packages/api-explorer/e2e/e2e.spec.ts
@@ -173,7 +173,7 @@ describe('API Explorer', () => {
         'ul[aria-label="spec selector"] > li:last-child'
       )
       await expect(page).toMatchElement('h2', {
-        text: 'Looker API 4.0 (Experimental) Reference',
+        text: 'Looker API 4.0 (Beta) Reference',
       })
     })
   })

--- a/packages/api-explorer/src/components/DocSDKs/DocSDKs.tsx
+++ b/packages/api-explorer/src/components/DocSDKs/DocSDKs.tsx
@@ -34,11 +34,11 @@ import type {
   KeyedCollection,
   CodeGen,
 } from '@looker/sdk-codegen'
-import { Method } from '@looker/sdk-codegen'
 import { CollapserCard, getGenerators } from '@looker/run-it'
 
 import { DocCode } from '../DocCode'
 import { selectSdkLanguage } from '../../state'
+import { isMethod } from '../../utils/path'
 import { noComment } from './utils'
 import { DocDeclarations } from './DocDeclarations'
 
@@ -59,10 +59,9 @@ const getDeclarations = (
   const declarations: KeyedCollection<string> = {}
   Object.entries(generators).forEach(([language, gen]) => {
     if (sdkLanguage === 'All' || language === sdkLanguage) {
-      const code =
-        item instanceof Method
-          ? gen.declareMethod('', item as IMethod)
-          : gen.declareType('', item as IType)
+      const code = isMethod(item)
+        ? gen.declareMethod('', item as IMethod)
+        : gen.declareType('', item as IType)
       declarations[language] = code
     }
   })

--- a/packages/api-explorer/src/utils/path.ts
+++ b/packages/api-explorer/src/utils/path.ts
@@ -25,7 +25,7 @@
  */
 
 import type { ApiModel, IMethod, IType } from '@looker/sdk-codegen'
-import { firstMethodRef, Method } from '@looker/sdk-codegen'
+import { firstMethodRef } from '@looker/sdk-codegen'
 
 /**
  * Builds a path matching the route used by MethodScene
@@ -67,6 +67,12 @@ const getMethodTag = (api: ApiModel, methodName: string) => {
 }
 
 /**
+ * Is this item a method? Check without requiring `instanceof Method`
+ * @param item to check for method or type
+ */
+export const isMethod = (item: IMethod | IType) => 'params' in item
+
+/**
  * Return the tag for a give type
  * @param api Parsed api
  * @param type to tag
@@ -89,7 +95,7 @@ export const buildPath = (
   specKey: string
 ) => {
   let path
-  if (item instanceof Method) {
+  if (isMethod(item)) {
     const tag = getMethodTag(api, item.name)
     path = buildMethodPath(specKey, tag, item.name)
   } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2358,12 +2358,22 @@
   dependencies:
     "@styled-icons/styled-icon" "^10.6.3"
 
-"@looker/sdk@21.20.0 - 2.0", "@looker/sdk@21.4.1 - 2.0":
-  version "21.20.0"
-  resolved "https://registry.yarnpkg.com/@looker/sdk/-/sdk-21.20.0.tgz#81f00b6bddc3d47406c3dc74ad2480004622a567"
-  integrity sha512-h4cmD3zACcAQZ+3P9iSO1OzXUqdNq+1iaaVO4Py8IY9LPArkwZghlTIzKMG9XAqUM+xqXDTKXI88vFmBllCy5w==
+"@looker/sdk-codegen@^21.0.12", "@looker/sdk-codegen@^21.3.1":
+  version "21.3.1"
+  resolved "https://registry.yarnpkg.com/@looker/sdk-codegen/-/sdk-codegen-21.3.1.tgz#8af443062d6948600327c5e52615751951cc906c"
+  integrity sha512-kUHs6+8DrLpMWYrJ2ACrwnjczb7HyMrvESUZuk0RqrXc8si48CcuQq5/RI+Ver+7SnzVtct4hJZa+fpSF789TA==
   dependencies:
-    "@looker/sdk-rtl" "^21.2.0"
+    "@looker/sdk-codegen-utils" "^21.0.11"
+    "@looker/sdk-rtl" "^21.3.1"
+    blueimp-md5 "^2.13.0"
+    openapi3-ts "^1.3.0"
+
+"@looker/sdk@^21.20.1", "@looker/sdk@^21.4.1":
+  version "21.20.1"
+  resolved "https://registry.yarnpkg.com/@looker/sdk/-/sdk-21.20.1.tgz#3d257309c2fe5ad1246e01837ea71aeeb7f4df22"
+  integrity sha512-t54yXAMeJAIeq7uUc1Oa3SdFsE3zvQaL9S28ebXy9TrljbnHG4FsVMacfq0XQGYPDzYUIoEySShWcBOsFZ+eyw==
+  dependencies:
+    "@looker/sdk-rtl" "^21.3.1"
     ini "^1.3.8"
     readable-stream "^3.4.0"
     request "^2.88.0"


### PR DESCRIPTION
```ts
item instanceof Method
```

checks started failing for some obscure reason, so a new `isMethod()` check is now used

```sh
yarn test:apix && yarn test:apix-e2e
```

passes again. End-to-end tests needed to be updated for the `(Beta)` string also