### PR TITLE
fix: Fixed incorrect VerifySSL setting implementation

### DIFF
--- a/go/rtl/auth.go
+++ b/go/rtl/auth.go
@@ -44,7 +44,7 @@ type AuthSession struct {
 func NewAuthSession(config ApiSettings) *AuthSession {
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: config.VerifySsl,
+			InsecureSkipVerify: !config.VerifySsl,
 		},
 	}
 	return &AuthSession{
@@ -53,6 +53,7 @@ func NewAuthSession(config ApiSettings) *AuthSession {
 	}
 }
 
+// The transport parameter may override your VerifySSL setting
 func NewAuthSessionWithTransport(config ApiSettings, transport http.RoundTripper) *AuthSession {
 	return &AuthSession{
 		Config:    config,


### PR DESCRIPTION
The original implementation was incorrect. Also added comment/doc to help avoid confusion if someone sets custom transport setting outside of the lookersdk verify ssl setting.