### PR TITLE
ci: change workflows to use reusable action for looker versions

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -65,7 +65,7 @@ jobs:
           path: ${{ env.JUNIT_OUTPUT_DIR }}
 
   setup:
-    uses: looker-open-source/reusable-actions/.github/workflows/supported-versions.yml@v0.0.1
+    uses: looker-open-source/reusable-actions/.github/workflows/supported-versions.yml@main
   integration:
     needs: [setup,unit]
     name: Integration - ${{ matrix.os }} / Looker.${{ matrix.looker }}

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -64,8 +64,10 @@ jobs:
           name: ${{ env.JUNIT_ARTIFACT_DIR }}
           path: ${{ env.JUNIT_OUTPUT_DIR }}
 
+  setup:
+    uses: looker-open-source/reusable-actions/.github/workflows/supported-versions.yml@v0.0.1
   integration:
-    needs: unit
+    needs: [setup,unit]
     name: Integration - ${{ matrix.os }} / Looker.${{ matrix.looker }}
     env:
       GO_JUNIT_OUTPUT_NAME: ${{ matrix.os }}.Looker-${{ matrix.looker }}.gointegration.xml
@@ -78,10 +80,8 @@ jobs:
       matrix:
         os:
           - ubuntu
-        looker:
-          - '21_18'
-          - '21_20'
-          - '22_0'
+        looker: ${{ fromJson(needs.setup.outputs.matrix_json) }}
+
           # TODO uncomment `include:` when either macos or windows works to satisfaction.
           #include:
           # TODO: macos matrix leg is functional but it takes ~20 minutes (compared

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -95,7 +95,7 @@ jobs:
           path: python/results/
 
   setup:
-    uses: looker-open-source/reusable-actions/.github/workflows/supported-versions.yml@v0.0.1
+    uses: looker-open-source/reusable-actions/.github/workflows/supported-versions.yml@main
   integration:
     needs: [unit,setup]
     name: Integration - ${{ matrix.os }} / Looker.${{ matrix.looker }}

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -94,8 +94,10 @@ jobs:
           name: python-test-results
           path: python/results/
 
+  setup:
+    uses: looker-open-source/reusable-actions/.github/workflows/supported-versions.yml@v0.0.1
   integration:
-    needs: unit
+    needs: [unit,setup]
     name: Integration - ${{ matrix.os }} / Looker.${{ matrix.looker }}
     env:
       TOX_JUNIT_OUTPUT_NAME: ${{ matrix.os }}.Looker-${{ matrix.looker }}.py3.x
@@ -109,11 +111,8 @@ jobs:
       matrix:
         os:
           - ubuntu
-        looker:
-          - '21_18'
-          - '21_20'
-          - '22_0'
-          - '22_2'
+        looker: ${{ fromJson(needs.setup.outputs.matrix_json) }}
+
           # TODO uncomment `include:` when either macos or windows works to satisfaction.
           #include:
           # TODO: macos matrix leg is functional but it takes ~20 minutes (compared

--- a/.github/workflows/tssdk-ci.yml
+++ b/.github/workflows/tssdk-ci.yml
@@ -106,7 +106,7 @@ jobs:
           path: results/tssdk
 
   setup:
-    uses: looker-open-source/reusable-actions/.github/workflows/supported-versions.yml@v0.0.1
+    uses: looker-open-source/reusable-actions/.github/workflows/supported-versions.yml@main
   integration:
     needs: [unit,setup]
     name: Integration - ${{ matrix.os }} / Node.${{ matrix.node-version }} / Looker.${{ matrix.looker }}

--- a/.github/workflows/tssdk-ci.yml
+++ b/.github/workflows/tssdk-ci.yml
@@ -105,8 +105,10 @@ jobs:
           name: tssdk-test-results
           path: results/tssdk
 
+  setup:
+    uses: looker-open-source/reusable-actions/.github/workflows/supported-versions.yml@v0.0.1
   integration:
-    needs: unit
+    needs: [unit,setup]
     name: Integration - ${{ matrix.os }} / Node.${{ matrix.node-version }} / Looker.${{ matrix.looker }}
     env:
       JEST_JUNIT_OUTPUT_DIR: results/tssdk
@@ -117,11 +119,7 @@ jobs:
         node-version: [12.x]
         os:
           - ubuntu
-        looker:
-          - '21_18'
-          - '21_20'
-          - '22_0'
-          - '22_2'
+        looker: ${{ fromJson(needs.setup.outputs.matrix_json) }}
 
     steps:
       - name: Repo Checkout


### PR DESCRIPTION
The looker versions for CI are all in one place now.