### PR TITLE
chore: update unit test for string ID types

### DIFF
--- a/packages/sdk-codegen-scripts/src/exampleMiner.spec.ts
+++ b/packages/sdk-codegen-scripts/src/exampleMiner.spec.ts
@@ -75,7 +75,7 @@ describe('example mining', () => {
     it('getRemoteHttpOrigin', () => {
       const actual = getRemoteHttpOrigin()
       expect(actual).toEqual(
-        'https://github.com/looker-open-source/sdk-codegen'
+        'https://github.com/looker-open-source/sdk-codegen.git'
       )
     })
   })

--- a/packages/sdk-codegen-scripts/src/exampleMiner.spec.ts
+++ b/packages/sdk-codegen-scripts/src/exampleMiner.spec.ts
@@ -74,9 +74,9 @@ describe('example mining', () => {
     })
     it('getRemoteHttpOrigin', () => {
       const actual = getRemoteHttpOrigin()
-      expect(actual).toEqual(
-        'https://github.com/looker-open-source/sdk-codegen.git'
-      )
+      expect(
+        actual.startsWith('https://github.com/looker-open-source/sdk-codegen')
+      ).toEqual(true)
     })
   })
 

--- a/packages/sdk-node/test/methods.spec.ts
+++ b/packages/sdk-node/test/methods.spec.ts
@@ -754,7 +754,7 @@ describe('LookerNodeSDK', () => {
           const query = await sdk.ok(sdk.create_query(request))
           expect(query).toBeDefined()
           expect(query.id).toBeDefined()
-          expect(query.id).toBeGreaterThan(0)
+          expect(Number(query.id)).toBeGreaterThan(0)
           if (query && query.id) {
             const sql = await sdk.ok(
               sdk.run_query({ query_id: query.id, result_format: 'sql' })

--- a/packages/sdk-node/test/methods.spec.ts
+++ b/packages/sdk-node/test/methods.spec.ts
@@ -754,7 +754,7 @@ describe('LookerNodeSDK', () => {
           const query = await sdk.ok(sdk.create_query(request))
           expect(query).toBeDefined()
           expect(query.id).toBeDefined()
-          expect(Number(query.id)).toBeGreaterThan(0)
+          expect(String(query.id).length).toBeGreaterThan(0)
           if (query && query.id) {
             const sql = await sdk.ok(
               sdk.run_query({ query_id: query.id, result_format: 'sql' })


### PR DESCRIPTION
Unit test tweak to support Looker 22.4 API type changes