### PR TITLE
fix: Fixed issue with parsing fuzzy json

### DIFF
--- a/go/rtl/auth.go
+++ b/go/rtl/auth.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"reflect"
+	"sync"
 	"time"
 
 	json "github.com/json-iterator/go"
@@ -21,6 +22,8 @@ type AccessToken struct {
 	ExpiresIn   int32  `json:"expires_in"`
 	ExpireTime  time.Time
 }
+
+var mutex = sync.Mutex{}
 
 func (t AccessToken) IsExpired() bool {
 	return t.ExpireTime.IsZero() || time.Now().After(t.ExpireTime)
@@ -155,9 +158,12 @@ func (s *AuthSession) Do(result interface{}, method, ver, path string, reqPars m
 			}
 			*v = string(b)
 	default:
+		mutex.Lock()
 		extra.RegisterFuzzyDecoders()
+		mutex.Unlock()
 		return json.NewDecoder(res.Body).Decode(&result)
 	}
+
 
 	return nil
 }


### PR DESCRIPTION
I just added `Mutex.Lock` to prevent concurrent map write error to `FuzzyDecoders`.

In my use case of [terraform-provider-looker](https://github.com/hirosassa/terraform-provider-looker), currently occurred following error:

```log
Stack trace from the terraform-provider-looker plugin:

fatal error: concurrent map writes
fatal error: concurrent map writes
fatal error: concurrent map writes

goroutine 216 [running]:
runtime.throw({0x18d539c, 0xc0006390e8})
	/Users/hirohito.sasakawa/homebrew/Cellar/go/1.17.2/libexec/src/runtime/panic.go:1198 +0x71 fp=0xc000639060 sp=0xc000639030 pc=0x1034b31
runtime.mapassign_faststr(0x17cc040, 0xc000347050, {0x18c9c38, 0x6})
	/Users/hirohito.sasakawa/homebrew/Cellar/go/1.17.2/libexec/src/runtime/map_faststr.go:294 +0x38b fp=0xc0006390c8 sp=0xc000639060 pc=0x101420b
github.com/json-iterator/go.RegisterTypeDecoder(...)
	/Users/hirohito.sasakawa/go/pkg/mod/github.com/json-iterator/go@v1.1.12/reflect_extension.go:205
github.com/json-iterator/go/extra.RegisterFuzzyDecoders()
	/Users/hirohito.sasakawa/go/pkg/mod/github.com/json-iterator/go@v1.1.12/extra/fuzzy_decoder.go:23 +0xd5 fp=0xc000639120 sp=0xc0006390c8 pc=0x16a7db5
github.com/looker-open-source/sdk-codegen/go/rtl.(*AuthSession).Do(0xc0000d83c0, {0x1768120, 0xc000392e80}, {0x18c75bd, 0x3}, {0x18c78c2, 0x4}, {0xc00058ad90, 0xe}, 0xc000639330, ...)
	/Users/hirohito.sasakawa/go/pkg/mod/github.com/looker-open-source/sdk-codegen/go@v0.0.2-0.20220324185106-8f79913c70dc/rtl/auth.go:158 +0x4dc fp=0xc000639280 sp=0xc000639120 pc=0x16ab0dc
github.com/looker-open-source/sdk-codegen/go/sdk/v4.(*LookerSDK).ModelSet(0xc0004981d8, {0xc00058ab9e, 0xc0005897a0}, {0x0, 0x0}, 0x19e0080)
	/Users/hirohito.sasakawa/go/pkg/mod/github.com/looker-open-source/sdk-codegen/go@v0.0.2-0.20220324185106-8f79913c70dc/sdk/v4/methods.go:5428 +0x249 fp=0xc0006394b8 sp=0xc000639280 pc=0x16dcf09
github.com/hirosassa/terraform-provider-looker/pkg/looker.resourceModelSetRead({0x19e0080, 0xc0002fe750}, 0xc0004bd780, {0x18c5960, 0xc0004981d8})
	/Users/hirohito.sasakawa/Dev/terraform-provider-looker/pkg/looker/resource_model_set.go:66 +0x111 fp=0xc000639578 sp=0xc0006394b8 pc=0x170d051
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).read(0xc0000c2a80, {0x19e0080, 0xc0002fe750}, 0xd, {0x18c5960, 0xc0004981d8})
	/Users/hirohito.sasakawa/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.13.0/helper/schema/resource.go:725 +0x12e fp=0xc0006395f0 sp=0xc000639578 pc=0x162642e
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).RefreshWithoutUpgrade(0xc0000c2a80, {0x19e0080, 0xc0002fe750}, 0xc000551520, {0x18c5960, 0xc0004981d8})
```

To prevent this error, I added Lock procedure on `extra.RegisterFuzzyDecoders()`.

## Developer Checklist [ℹ️](https://github.com/looker-open-source/sdk-codegen/blob/main/CONTRIBUTING.md#developer-checklist)

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/looker-open-source/sdk-codegen/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
