### PR TITLE
fix(typescript-sdk): stringify hashes in query parameters

### DIFF
--- a/packages/sdk-codegen/src/typescript.gen.spec.ts
+++ b/packages/sdk-codegen/src/typescript.gen.spec.ts
@@ -545,6 +545,13 @@ describe('typescript generator', () => {
       const args = gen.httpArgs('', method).trim()
       expect(args).toEqual('null, body, options')
     })
+    it('model_fieldname_suggestions', () => {
+      const method = apiTestModel.methods.model_fieldname_suggestions
+      const args = gen.httpArgs('', method).trim()
+      expect(args).toEqual(
+        '{ term: request.term, filters: JSON.stringify(request.filters) }, null, options'
+      )
+    })
   })
 
   describe('method signature', () => {

--- a/packages/sdk-codegen/src/typescript.gen.ts
+++ b/packages/sdk-codegen/src/typescript.gen.ts
@@ -571,6 +571,32 @@ export class ${this.packageName}Stream extends APIMethods {
     return `{${hash.join(this.argDelimiter)}}`
   }
 
+  private queryArgGroup(
+    _indent: string,
+    params: IParameter[],
+    prefix?: string
+  ) {
+    if (!params || params.length === 0) return this.nullStr
+    const hash: string[] = []
+    for (const param of params) {
+      const arg: Arg = param.name
+      const reserved = this.reserve(arg)
+      if (prefix) {
+        const argFullName = this.accessor(arg, prefix)
+        hash.push(
+          `${reserved}: ${
+            param.type.name === 'object'
+              ? `JSON.stringify(${argFullName})`
+              : argFullName
+          }`
+        )
+      } else {
+        hash.push(reserved)
+      }
+    }
+    return `{${hash.join(this.argDelimiter)}}`
+  }
+
   /**
    * Determine the type of accessor needed for the symbol name
    *
@@ -631,7 +657,7 @@ export class ${this.packageName}Stream extends APIMethods {
     )
     result = this.argFill(
       result,
-      this.argGroup(indent, method.queryArgs, request)
+      this.queryArgGroup(indent, method.queryParams, request)
     )
     return result
   }


### PR DESCRIPTION
Because javascript's default `toString()` turns hashes into `[object Object]` weirdness, we need to explicitly `JSON.stringify` any hash-type objects that are passed into the query string. Right now, this only applies to the `filters` parameter in the `model_fieldname_suggestions` endpoint, but this code should ensure that any future object-type query parameter will be properly stringified as well.