### PR TITLE
fix: encodeParam returned [object Object] for object types

### DIFF
--- a/packages/sdk-rtl/src/transport.spec.ts
+++ b/packages/sdk-rtl/src/transport.spec.ts
@@ -61,5 +61,8 @@ describe('Transport', () => {
     expect(encodeParam('foo/bar')).toEqual('foo%2Fbar')
     expect(encodeParam(true)).toEqual('true')
     expect(encodeParam(2.3)).toEqual('2.3')
+    expect(encodeParam({ created_date: 'this year to second' })).toEqual(
+      '{"created_date":"this year to second"}'
+    )
   })
 })

--- a/packages/sdk-rtl/src/transport.spec.ts
+++ b/packages/sdk-rtl/src/transport.spec.ts
@@ -26,6 +26,7 @@
 
 import { TestConfig } from './testUtils'
 import { encodeParam, ResponseMode, responseMode } from './transport'
+import { DelimArray } from './delimArray'
 
 const config = TestConfig()
 const binaryTypes = config.testData.content_types.binary as [string]
@@ -56,6 +57,8 @@ describe('Transport', () => {
 
   it('encodeParam', () => {
     const today = new Date('01 January 2020 14:48 UTC')
+    const ra = new DelimArray([1, 2, 3])
+    expect(encodeParam(ra)).toEqual('1%2C2%2C3')
     expect(encodeParam(today)).toEqual('2020-01-01T14%3A48%3A00.000Z')
     expect(encodeParam('foo%2Fbar')).toEqual('foo%2Fbar')
     expect(encodeParam('foo/bar')).toEqual('foo%2Fbar')

--- a/packages/sdk-rtl/src/transport.ts
+++ b/packages/sdk-rtl/src/transport.ts
@@ -380,7 +380,9 @@ export function encodeParam(value: any) {
   if (value instanceof Date) {
     value = value.toISOString()
   }
-  let encoded = value.toString()
+  // check for object type to prevent "[object Object]" as the value.toString()
+  let encoded =
+    typeof value === 'object' ? JSON.stringify(value) : value.toString()
 
   // decodeURIComponent throws URIError if there is a % character
   // without it being part of an encoded

--- a/packages/sdk-rtl/src/transport.ts
+++ b/packages/sdk-rtl/src/transport.ts
@@ -28,6 +28,7 @@ import type { Agent } from 'https'
 import type { Headers } from 'request'
 import type { Readable } from 'readable-stream'
 import { matchCharsetUtf8, matchModeBinary, matchModeString } from './constants'
+import { DelimArray } from './delimArray'
 
 export const agentPrefix = 'TS-SDK'
 export const LookerAppId = 'x-looker-appid'
@@ -379,6 +380,8 @@ export type Values = { [key: string]: any } | null | undefined
 export function encodeParam(value: any) {
   if (value instanceof Date) {
     value = value.toISOString()
+  } else if (value instanceof DelimArray) {
+    value = value.toString()
   }
   // check for object type to prevent "[object Object]" as the value.toString()
   let encoded =


### PR DESCRIPTION
`@looker/sdk-rtl` was encoding object values like

```ts
{ created_date: 'this year to second' }
```

as 
```ts
[object Object]
```

and now the value is JSON stringified instead