### PR TITLE
fix: encodeParam doc tweak to republish

### DIFF
--- a/packages/sdk-rtl/src/transport.ts
+++ b/packages/sdk-rtl/src/transport.ts
@@ -374,6 +374,9 @@ export type Values = { [key: string]: any } | null | undefined
 
 /**
  * Encode parameter if not already encoded
+ *
+ * Note: this includes recognition of Date, DelimArray, and default objects for special handling
+ *
  * @param value value of parameter
  * @returns URI encoded value
  */


### PR DESCRIPTION
Release-please versioning was incorrect so the most critical package to get published didn't get published.

Updating the source comment header which should meet the criteria for republishing
