### PR TITLE
chore: upgrade eslint to fix header copyright year

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@babel/preset-typescript": "^7.13.0",
     "@babel/runtime": "^7.14.0",
     "@babel/runtime-corejs3": "^7.14.0",
-    "@looker/eslint-config-oss": "^1.7.1",
+    "@looker/eslint-config-oss": "1.7.14",
     "@testing-library/jest-dom": "^5.11.6",
     "@types/blueimp-md5": "^2.7.0",
     "@types/ini": "^1.3.30",

--- a/packages/api-explorer/e2e/e2e.spec.ts
+++ b/packages/api-explorer/e2e/e2e.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/e2e/helpers.ts
+++ b/packages/api-explorer/e2e/helpers.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/ApiExplorer.tsx
+++ b/packages/api-explorer/src/ApiExplorer.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -225,5 +225,6 @@ const AsideBorder = styled(Aside)<{
   headless: boolean
 }>`
   width: ${({ isOpen, headless }) =>
+    // eslint-disable-next-line no-nested-ternary
     isOpen ? '20rem' : headless ? '2.75rem' : '0rem'};
 `

--- a/packages/api-explorer/src/App.tsx
+++ b/packages/api-explorer/src/App.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/StandaloneApiExplorer.tsx
+++ b/packages/api-explorer/src/StandaloneApiExplorer.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/Banner/Banner.spec.tsx
+++ b/packages/api-explorer/src/components/Banner/Banner.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/Banner/Banner.tsx
+++ b/packages/api-explorer/src/components/Banner/Banner.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/Banner/index.ts
+++ b/packages/api-explorer/src/components/Banner/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocActivityType/DocActivityType.spec.tsx
+++ b/packages/api-explorer/src/components/DocActivityType/DocActivityType.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocActivityType/DocActivityType.tsx
+++ b/packages/api-explorer/src/components/DocActivityType/DocActivityType.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocActivityType/index.ts
+++ b/packages/api-explorer/src/components/DocActivityType/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocCode/DocCode.tsx
+++ b/packages/api-explorer/src/components/DocCode/DocCode.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocCode/index.ts
+++ b/packages/api-explorer/src/components/DocCode/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocMarkdown/DocMarkdown.spec.tsx
+++ b/packages/api-explorer/src/components/DocMarkdown/DocMarkdown.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocMarkdown/DocMarkdown.tsx
+++ b/packages/api-explorer/src/components/DocMarkdown/DocMarkdown.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocMarkdown/index.ts
+++ b/packages/api-explorer/src/components/DocMarkdown/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocMarkdown/utils.spec.ts
+++ b/packages/api-explorer/src/components/DocMarkdown/utils.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocMarkdown/utils.ts
+++ b/packages/api-explorer/src/components/DocMarkdown/utils.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocMethodSummary/DocMethodSummary.spec.tsx
+++ b/packages/api-explorer/src/components/DocMethodSummary/DocMethodSummary.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocMethodSummary/DocMethodSummary.tsx
+++ b/packages/api-explorer/src/components/DocMethodSummary/DocMethodSummary.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocMethodSummary/DocSummaryStatus.spec.tsx
+++ b/packages/api-explorer/src/components/DocMethodSummary/DocSummaryStatus.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocMethodSummary/DocSummaryStatus.tsx
+++ b/packages/api-explorer/src/components/DocMethodSummary/DocSummaryStatus.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocMethodSummary/index.tsx
+++ b/packages/api-explorer/src/components/DocMethodSummary/index.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocMethodSummary/utils.spec.tsx
+++ b/packages/api-explorer/src/components/DocMethodSummary/utils.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocMethodSummary/utils.tsx
+++ b/packages/api-explorer/src/components/DocMethodSummary/utils.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocPseudo/DocParam.spec.tsx
+++ b/packages/api-explorer/src/components/DocPseudo/DocParam.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocPseudo/DocParam.tsx
+++ b/packages/api-explorer/src/components/DocPseudo/DocParam.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocPseudo/DocParams.spec.tsx
+++ b/packages/api-explorer/src/components/DocPseudo/DocParams.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocPseudo/DocParams.tsx
+++ b/packages/api-explorer/src/components/DocPseudo/DocParams.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocPseudo/DocPrimaryResponse.spec.tsx
+++ b/packages/api-explorer/src/components/DocPseudo/DocPrimaryResponse.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocPseudo/DocPrimaryResponse.tsx
+++ b/packages/api-explorer/src/components/DocPseudo/DocPrimaryResponse.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocPseudo/DocPseudo.spec.tsx
+++ b/packages/api-explorer/src/components/DocPseudo/DocPseudo.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocPseudo/DocPseudo.tsx
+++ b/packages/api-explorer/src/components/DocPseudo/DocPseudo.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocPseudo/index.tsx
+++ b/packages/api-explorer/src/components/DocPseudo/index.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocRateLimited/DocRateLimited.spec.tsx
+++ b/packages/api-explorer/src/components/DocRateLimited/DocRateLimited.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocRateLimited/DocRateLimited.tsx
+++ b/packages/api-explorer/src/components/DocRateLimited/DocRateLimited.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocRateLimited/index.ts
+++ b/packages/api-explorer/src/components/DocRateLimited/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocReferences/DocReferences.spec.tsx
+++ b/packages/api-explorer/src/components/DocReferences/DocReferences.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocReferences/DocReferences.tsx
+++ b/packages/api-explorer/src/components/DocReferences/DocReferences.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocReferences/index.ts
+++ b/packages/api-explorer/src/components/DocReferences/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocReferences/utils.spec.tsx
+++ b/packages/api-explorer/src/components/DocReferences/utils.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocReferences/utils.tsx
+++ b/packages/api-explorer/src/components/DocReferences/utils.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocResponses/DocResponseTypes.tsx
+++ b/packages/api-explorer/src/components/DocResponses/DocResponseTypes.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocResponses/DocResponses.spec.tsx
+++ b/packages/api-explorer/src/components/DocResponses/DocResponses.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocResponses/DocResponses.tsx
+++ b/packages/api-explorer/src/components/DocResponses/DocResponses.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocResponses/index.ts
+++ b/packages/api-explorer/src/components/DocResponses/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocResponses/utils.spec.ts
+++ b/packages/api-explorer/src/components/DocResponses/utils.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocResponses/utils.ts
+++ b/packages/api-explorer/src/components/DocResponses/utils.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocSDKs/DocDeclarations.tsx
+++ b/packages/api-explorer/src/components/DocSDKs/DocDeclarations.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocSDKs/DocSDKs.spec.tsx
+++ b/packages/api-explorer/src/components/DocSDKs/DocSDKs.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocSDKs/DocSDKs.tsx
+++ b/packages/api-explorer/src/components/DocSDKs/DocSDKs.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocSDKs/index.ts
+++ b/packages/api-explorer/src/components/DocSDKs/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocSDKs/utils.spec.ts
+++ b/packages/api-explorer/src/components/DocSDKs/utils.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocSDKs/utils.ts
+++ b/packages/api-explorer/src/components/DocSDKs/utils.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocSchema/DocSchema.tsx
+++ b/packages/api-explorer/src/components/DocSchema/DocSchema.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocSchema/index.ts
+++ b/packages/api-explorer/src/components/DocSchema/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocSdkUsage/DocSdkExampleCell.tsx
+++ b/packages/api-explorer/src/components/DocSdkUsage/DocSdkExampleCell.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocSdkUsage/DocSdkUsage.spec.tsx
+++ b/packages/api-explorer/src/components/DocSdkUsage/DocSdkUsage.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocSdkUsage/DocSdkUsage.tsx
+++ b/packages/api-explorer/src/components/DocSdkUsage/DocSdkUsage.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocSdkUsage/index.ts
+++ b/packages/api-explorer/src/components/DocSdkUsage/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocSdkUsage/utils.ts
+++ b/packages/api-explorer/src/components/DocSdkUsage/utils.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocSource/DocSource.spec.tsx
+++ b/packages/api-explorer/src/components/DocSource/DocSource.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocSource/DocSource.tsx
+++ b/packages/api-explorer/src/components/DocSource/DocSource.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocSource/index.ts
+++ b/packages/api-explorer/src/components/DocSource/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocStatus/DocStatus.spec.tsx
+++ b/packages/api-explorer/src/components/DocStatus/DocStatus.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocStatus/DocStatus.tsx
+++ b/packages/api-explorer/src/components/DocStatus/DocStatus.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocStatus/index.ts
+++ b/packages/api-explorer/src/components/DocStatus/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocTitle/DocTitle.spec.tsx
+++ b/packages/api-explorer/src/components/DocTitle/DocTitle.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocTitle/DocTitle.tsx
+++ b/packages/api-explorer/src/components/DocTitle/DocTitle.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocTitle/index.ts
+++ b/packages/api-explorer/src/components/DocTitle/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocTypeSummary/DocTypeSummary.spec.tsx
+++ b/packages/api-explorer/src/components/DocTypeSummary/DocTypeSummary.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocTypeSummary/DocTypeSummary.tsx
+++ b/packages/api-explorer/src/components/DocTypeSummary/DocTypeSummary.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/DocTypeSummary/index.tsx
+++ b/packages/api-explorer/src/components/DocTypeSummary/index.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/ErrorBoundary/ErrorBoundary.spec.tsx
+++ b/packages/api-explorer/src/components/ErrorBoundary/ErrorBoundary.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/packages/api-explorer/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/ErrorBoundary/components/SomethingWentWrong/SomethingWentWrong.spec.tsx
+++ b/packages/api-explorer/src/components/ErrorBoundary/components/SomethingWentWrong/SomethingWentWrong.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/ErrorBoundary/components/SomethingWentWrong/SomethingWentWrong.tsx
+++ b/packages/api-explorer/src/components/ErrorBoundary/components/SomethingWentWrong/SomethingWentWrong.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/ErrorBoundary/components/SomethingWentWrong/components/SomethingWentWrongGraphic/SomethingWentWrongGraphic.tsx
+++ b/packages/api-explorer/src/components/ErrorBoundary/components/SomethingWentWrong/components/SomethingWentWrongGraphic/SomethingWentWrongGraphic.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/ErrorBoundary/components/SomethingWentWrong/components/SomethingWentWrongGraphic/index.ts
+++ b/packages/api-explorer/src/components/ErrorBoundary/components/SomethingWentWrong/components/SomethingWentWrongGraphic/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/ErrorBoundary/components/SomethingWentWrong/components/index.ts
+++ b/packages/api-explorer/src/components/ErrorBoundary/components/SomethingWentWrong/components/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/ErrorBoundary/components/SomethingWentWrong/index.ts
+++ b/packages/api-explorer/src/components/ErrorBoundary/components/SomethingWentWrong/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/ErrorBoundary/index.ts
+++ b/packages/api-explorer/src/components/ErrorBoundary/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/ExploreType/ExploreProperty.spec.tsx
+++ b/packages/api-explorer/src/components/ExploreType/ExploreProperty.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/ExploreType/ExploreProperty.tsx
+++ b/packages/api-explorer/src/components/ExploreType/ExploreProperty.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/ExploreType/ExploreType.spec.tsx
+++ b/packages/api-explorer/src/components/ExploreType/ExploreType.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/ExploreType/ExploreType.tsx
+++ b/packages/api-explorer/src/components/ExploreType/ExploreType.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/ExploreType/exploreUtils.spec.tsx
+++ b/packages/api-explorer/src/components/ExploreType/exploreUtils.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/ExploreType/exploreUtils.tsx
+++ b/packages/api-explorer/src/components/ExploreType/exploreUtils.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/ExploreType/index.ts
+++ b/packages/api-explorer/src/components/ExploreType/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/Header/Header.spec.tsx
+++ b/packages/api-explorer/src/components/Header/Header.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/Header/Header.tsx
+++ b/packages/api-explorer/src/components/Header/Header.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/Header/index.ts
+++ b/packages/api-explorer/src/components/Header/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/Link/Link.tsx
+++ b/packages/api-explorer/src/components/Link/Link.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/Link/index.ts
+++ b/packages/api-explorer/src/components/Link/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/SelectorContainer/ApiSpecSelector.spec.tsx
+++ b/packages/api-explorer/src/components/SelectorContainer/ApiSpecSelector.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/SelectorContainer/ApiSpecSelector.tsx
+++ b/packages/api-explorer/src/components/SelectorContainer/ApiSpecSelector.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/SelectorContainer/SdkLanguageSelector.spec.tsx
+++ b/packages/api-explorer/src/components/SelectorContainer/SdkLanguageSelector.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/SelectorContainer/SdkLanguageSelector.tsx
+++ b/packages/api-explorer/src/components/SelectorContainer/SdkLanguageSelector.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/SelectorContainer/SelectorContainer.spec.tsx
+++ b/packages/api-explorer/src/components/SelectorContainer/SelectorContainer.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/SelectorContainer/SelectorContainer.tsx
+++ b/packages/api-explorer/src/components/SelectorContainer/SelectorContainer.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/SelectorContainer/index.ts
+++ b/packages/api-explorer/src/components/SelectorContainer/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/SideNav/SearchMessage.tsx
+++ b/packages/api-explorer/src/components/SideNav/SearchMessage.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/SideNav/SideNav.spec.tsx
+++ b/packages/api-explorer/src/components/SideNav/SideNav.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/SideNav/SideNav.tsx
+++ b/packages/api-explorer/src/components/SideNav/SideNav.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/SideNav/SideNavMethodTags.spec.tsx
+++ b/packages/api-explorer/src/components/SideNav/SideNavMethodTags.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/SideNav/SideNavMethodTags.tsx
+++ b/packages/api-explorer/src/components/SideNav/SideNavMethodTags.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/SideNav/SideNavMethods.spec.tsx
+++ b/packages/api-explorer/src/components/SideNav/SideNavMethods.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/SideNav/SideNavMethods.tsx
+++ b/packages/api-explorer/src/components/SideNav/SideNavMethods.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/SideNav/SideNavTypeTags.spec.tsx
+++ b/packages/api-explorer/src/components/SideNav/SideNavTypeTags.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/SideNav/SideNavTypeTags.tsx
+++ b/packages/api-explorer/src/components/SideNav/SideNavTypeTags.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/SideNav/SideNavTypes.spec.tsx
+++ b/packages/api-explorer/src/components/SideNav/SideNavTypes.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/SideNav/SideNavTypes.tsx
+++ b/packages/api-explorer/src/components/SideNav/SideNavTypes.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/SideNav/index.ts
+++ b/packages/api-explorer/src/components/SideNav/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/SideNav/searchUtils.ts
+++ b/packages/api-explorer/src/components/SideNav/searchUtils.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/common/Loader.tsx
+++ b/packages/api-explorer/src/components/common/Loader.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/common/common.tsx
+++ b/packages/api-explorer/src/components/common/common.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/common/index.ts
+++ b/packages/api-explorer/src/components/common/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/components/index.ts
+++ b/packages/api-explorer/src/components/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/index.ts
+++ b/packages/api-explorer/src/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/routes/AppRouter.tsx
+++ b/packages/api-explorer/src/routes/AppRouter.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/routes/index.ts
+++ b/packages/api-explorer/src/routes/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/scenes/DiffScene/DiffScene.tsx
+++ b/packages/api-explorer/src/scenes/DiffScene/DiffScene.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/scenes/DiffScene/DocDiff/DiffBanner.tsx
+++ b/packages/api-explorer/src/scenes/DiffScene/DocDiff/DiffBanner.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/scenes/DiffScene/DocDiff/DiffItem.spec.tsx
+++ b/packages/api-explorer/src/scenes/DiffScene/DocDiff/DiffItem.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/scenes/DiffScene/DocDiff/DiffItem.tsx
+++ b/packages/api-explorer/src/scenes/DiffScene/DocDiff/DiffItem.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/scenes/DiffScene/DocDiff/DiffLegend.tsx
+++ b/packages/api-explorer/src/scenes/DiffScene/DocDiff/DiffLegend.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/scenes/DiffScene/DocDiff/DocDiff.tsx
+++ b/packages/api-explorer/src/scenes/DiffScene/DocDiff/DocDiff.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/scenes/DiffScene/DocDiff/docDiffUtils.tsx
+++ b/packages/api-explorer/src/scenes/DiffScene/DocDiff/docDiffUtils.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/scenes/DiffScene/DocDiff/index.ts
+++ b/packages/api-explorer/src/scenes/DiffScene/DocDiff/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/scenes/DiffScene/diffUtils.spec.ts
+++ b/packages/api-explorer/src/scenes/DiffScene/diffUtils.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/scenes/DiffScene/diffUtils.ts
+++ b/packages/api-explorer/src/scenes/DiffScene/diffUtils.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/scenes/DiffScene/index.ts
+++ b/packages/api-explorer/src/scenes/DiffScene/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/scenes/HomeScene/HomeScene.tsx
+++ b/packages/api-explorer/src/scenes/HomeScene/HomeScene.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/scenes/HomeScene/index.ts
+++ b/packages/api-explorer/src/scenes/HomeScene/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/scenes/MethodScene/MethodScene.tsx
+++ b/packages/api-explorer/src/scenes/MethodScene/MethodScene.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/scenes/MethodScene/components/DocOperation.spec.tsx
+++ b/packages/api-explorer/src/scenes/MethodScene/components/DocOperation.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/scenes/MethodScene/components/DocOperation.tsx
+++ b/packages/api-explorer/src/scenes/MethodScene/components/DocOperation.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/scenes/MethodScene/components/DocRequestBody.spec.tsx
+++ b/packages/api-explorer/src/scenes/MethodScene/components/DocRequestBody.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/scenes/MethodScene/components/DocRequestBody.tsx
+++ b/packages/api-explorer/src/scenes/MethodScene/components/DocRequestBody.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/scenes/MethodScene/components/index.ts
+++ b/packages/api-explorer/src/scenes/MethodScene/components/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/scenes/MethodScene/index.ts
+++ b/packages/api-explorer/src/scenes/MethodScene/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/scenes/MethodTagScene/MethodTagScene.spec.tsx
+++ b/packages/api-explorer/src/scenes/MethodTagScene/MethodTagScene.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/scenes/MethodTagScene/MethodTagScene.tsx
+++ b/packages/api-explorer/src/scenes/MethodTagScene/MethodTagScene.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/scenes/MethodTagScene/index.ts
+++ b/packages/api-explorer/src/scenes/MethodTagScene/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/scenes/MethodTagScene/utils.spec.ts
+++ b/packages/api-explorer/src/scenes/MethodTagScene/utils.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/scenes/MethodTagScene/utils.ts
+++ b/packages/api-explorer/src/scenes/MethodTagScene/utils.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/scenes/TypeScene/TypeScene.tsx
+++ b/packages/api-explorer/src/scenes/TypeScene/TypeScene.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/scenes/TypeScene/index.ts
+++ b/packages/api-explorer/src/scenes/TypeScene/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/scenes/TypeTagScene/TypeTagScene.spec.tsx
+++ b/packages/api-explorer/src/scenes/TypeTagScene/TypeTagScene.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/scenes/TypeTagScene/TypeTagScene.tsx
+++ b/packages/api-explorer/src/scenes/TypeTagScene/TypeTagScene.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/scenes/TypeTagScene/index.ts
+++ b/packages/api-explorer/src/scenes/TypeTagScene/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/scenes/TypeTagScene/utils.spec.ts
+++ b/packages/api-explorer/src/scenes/TypeTagScene/utils.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/scenes/TypeTagScene/utils.ts
+++ b/packages/api-explorer/src/scenes/TypeTagScene/utils.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/scenes/index.ts
+++ b/packages/api-explorer/src/scenes/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/state/index.ts
+++ b/packages/api-explorer/src/state/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/state/lodes/index.ts
+++ b/packages/api-explorer/src/state/lodes/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/state/lodes/sagas.spec.ts
+++ b/packages/api-explorer/src/state/lodes/sagas.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/state/lodes/sagas.ts
+++ b/packages/api-explorer/src/state/lodes/sagas.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/state/lodes/selectors.spec.ts
+++ b/packages/api-explorer/src/state/lodes/selectors.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/state/lodes/selectors.ts
+++ b/packages/api-explorer/src/state/lodes/selectors.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/state/lodes/slice.ts
+++ b/packages/api-explorer/src/state/lodes/slice.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/state/settings/index.ts
+++ b/packages/api-explorer/src/state/settings/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/state/settings/sagas.spec.ts
+++ b/packages/api-explorer/src/state/settings/sagas.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/state/settings/sagas.ts
+++ b/packages/api-explorer/src/state/settings/sagas.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/state/settings/selectors.spec.ts
+++ b/packages/api-explorer/src/state/settings/selectors.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/state/settings/selectors.ts
+++ b/packages/api-explorer/src/state/settings/selectors.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/state/settings/slice.ts
+++ b/packages/api-explorer/src/state/settings/slice.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/state/specs/index.ts
+++ b/packages/api-explorer/src/state/specs/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/state/specs/sagas.spec.ts
+++ b/packages/api-explorer/src/state/specs/sagas.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/state/specs/sagas.ts
+++ b/packages/api-explorer/src/state/specs/sagas.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/state/specs/selectors.ts
+++ b/packages/api-explorer/src/state/specs/selectors.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/state/specs/slice.ts
+++ b/packages/api-explorer/src/state/specs/slice.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/state/store.ts
+++ b/packages/api-explorer/src/state/store.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/test-data/declarations.ts
+++ b/packages/api-explorer/src/test-data/declarations.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/test-data/examples.ts
+++ b/packages/api-explorer/src/test-data/examples.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/test-data/index.ts
+++ b/packages/api-explorer/src/test-data/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/test-data/specs.ts
+++ b/packages/api-explorer/src/test-data/specs.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/test-utils/index.ts
+++ b/packages/api-explorer/src/test-utils/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/test-utils/lodes.tsx
+++ b/packages/api-explorer/src/test-utils/lodes.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/test-utils/redux.tsx
+++ b/packages/api-explorer/src/test-utils/redux.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/test-utils/router.tsx
+++ b/packages/api-explorer/src/test-utils/router.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/utils/adaptorUtils.ts
+++ b/packages/api-explorer/src/utils/adaptorUtils.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/utils/apixAdaptor.ts
+++ b/packages/api-explorer/src/utils/apixAdaptor.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/utils/highlight.spec.tsx
+++ b/packages/api-explorer/src/utils/highlight.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/utils/highlight.tsx
+++ b/packages/api-explorer/src/utils/highlight.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/utils/index.ts
+++ b/packages/api-explorer/src/utils/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/utils/lodeUtils.ts
+++ b/packages/api-explorer/src/utils/lodeUtils.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/utils/path.spec.ts
+++ b/packages/api-explorer/src/utils/path.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/utils/path.ts
+++ b/packages/api-explorer/src/utils/path.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/api-explorer/src/utils/useWindowSize.tsx
+++ b/packages/api-explorer/src/utils/useWindowSize.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/code-editor/src/CodeCopy/CodeCopy.spec.tsx
+++ b/packages/code-editor/src/CodeCopy/CodeCopy.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/code-editor/src/CodeCopy/CodeCopy.tsx
+++ b/packages/code-editor/src/CodeCopy/CodeCopy.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/code-editor/src/CodeCopy/index.ts
+++ b/packages/code-editor/src/CodeCopy/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/code-editor/src/CodeDisplay/CodeDisplay.spec.tsx
+++ b/packages/code-editor/src/CodeDisplay/CodeDisplay.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/code-editor/src/CodeDisplay/CodeDisplay.tsx
+++ b/packages/code-editor/src/CodeDisplay/CodeDisplay.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/code-editor/src/CodeDisplay/CodeWrapper.tsx
+++ b/packages/code-editor/src/CodeDisplay/CodeWrapper.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/code-editor/src/CodeDisplay/LineItem.tsx
+++ b/packages/code-editor/src/CodeDisplay/LineItem.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/code-editor/src/CodeDisplay/index.ts
+++ b/packages/code-editor/src/CodeDisplay/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/code-editor/src/CodeDisplay/types.ts
+++ b/packages/code-editor/src/CodeDisplay/types.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/code-editor/src/CodeEditor/CodeEditor.spec.tsx
+++ b/packages/code-editor/src/CodeEditor/CodeEditor.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/code-editor/src/CodeEditor/CodeEditor.tsx
+++ b/packages/code-editor/src/CodeEditor/CodeEditor.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/code-editor/src/CodeEditor/index.ts
+++ b/packages/code-editor/src/CodeEditor/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/code-editor/src/Markdown/Markdown.spec.tsx
+++ b/packages/code-editor/src/Markdown/Markdown.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/code-editor/src/Markdown/Markdown.tsx
+++ b/packages/code-editor/src/Markdown/Markdown.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/code-editor/src/Markdown/TableCell.tsx
+++ b/packages/code-editor/src/Markdown/TableCell.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/code-editor/src/Markdown/common.tsx
+++ b/packages/code-editor/src/Markdown/common.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/code-editor/src/Markdown/index.ts
+++ b/packages/code-editor/src/Markdown/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/code-editor/src/Markdown/utils.spec.ts
+++ b/packages/code-editor/src/Markdown/utils.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/code-editor/src/Markdown/utils.ts
+++ b/packages/code-editor/src/Markdown/utils.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/code-editor/src/index.ts
+++ b/packages/code-editor/src/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/code-editor/src/test-data/codeBlob.ts
+++ b/packages/code-editor/src/test-data/codeBlob.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/code-editor/src/test-data/index.ts
+++ b/packages/code-editor/src/test-data/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/code-editor/src/utils/index.ts
+++ b/packages/code-editor/src/utils/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/code-editor/src/utils/utils.spec.ts
+++ b/packages/code-editor/src/utils/utils.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/code-editor/src/utils/utils.ts
+++ b/packages/code-editor/src/utils/utils.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-api-explorer/src/ExtensionApiExplorer.tsx
+++ b/packages/extension-api-explorer/src/ExtensionApiExplorer.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-api-explorer/src/index.tsx
+++ b/packages/extension-api-explorer/src/index.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-playground/src/App.tsx
+++ b/packages/extension-playground/src/App.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-playground/src/Playground.tsx
+++ b/packages/extension-playground/src/Playground.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-playground/src/index.tsx
+++ b/packages/extension-playground/src/index.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk-react/__mocks__/@looker/extension-sdk.ts
+++ b/packages/extension-sdk-react/__mocks__/@looker/extension-sdk.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk-react/src/components/ErrorMessage/ErrorMessage.spec.tsx
+++ b/packages/extension-sdk-react/src/components/ErrorMessage/ErrorMessage.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk-react/src/components/ErrorMessage/ErrorMessage.tsx
+++ b/packages/extension-sdk-react/src/components/ErrorMessage/ErrorMessage.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk-react/src/components/ErrorMessage/index.ts
+++ b/packages/extension-sdk-react/src/components/ErrorMessage/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk-react/src/components/ErrorMessage/types.ts
+++ b/packages/extension-sdk-react/src/components/ErrorMessage/types.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk-react/src/components/ExtensionConnector/ExtensionConnector.spec.tsx
+++ b/packages/extension-sdk-react/src/components/ExtensionConnector/ExtensionConnector.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk-react/src/components/ExtensionConnector/ExtensionConnector.tsx
+++ b/packages/extension-sdk-react/src/components/ExtensionConnector/ExtensionConnector.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk-react/src/components/ExtensionConnector/index.ts
+++ b/packages/extension-sdk-react/src/components/ExtensionConnector/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk-react/src/components/ExtensionConnector/types.ts
+++ b/packages/extension-sdk-react/src/components/ExtensionConnector/types.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk-react/src/components/ExtensionProvider/ExtensionProvider.spec.tsx
+++ b/packages/extension-sdk-react/src/components/ExtensionProvider/ExtensionProvider.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk-react/src/components/ExtensionProvider/ExtensionProvider.tsx
+++ b/packages/extension-sdk-react/src/components/ExtensionProvider/ExtensionProvider.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk-react/src/components/ExtensionProvider/index.ts
+++ b/packages/extension-sdk-react/src/components/ExtensionProvider/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk-react/src/components/ExtensionProvider/types.ts
+++ b/packages/extension-sdk-react/src/components/ExtensionProvider/types.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk-react/src/components/ExtensionProvider2/ExtensionProvider2.spec.tsx
+++ b/packages/extension-sdk-react/src/components/ExtensionProvider2/ExtensionProvider2.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk-react/src/components/ExtensionProvider2/ExtensionProvider2.tsx
+++ b/packages/extension-sdk-react/src/components/ExtensionProvider2/ExtensionProvider2.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk-react/src/components/ExtensionProvider2/index.ts
+++ b/packages/extension-sdk-react/src/components/ExtensionProvider2/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk-react/src/components/ExtensionProviderBase/ExtensionProviderBase.tsx
+++ b/packages/extension-sdk-react/src/components/ExtensionProviderBase/ExtensionProviderBase.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk-react/src/components/ExtensionProviderBase/index.ts
+++ b/packages/extension-sdk-react/src/components/ExtensionProviderBase/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk-react/src/components/RouteChangeListener/RouteChangeListener.tsx
+++ b/packages/extension-sdk-react/src/components/RouteChangeListener/RouteChangeListener.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk-react/src/components/RouteChangeListener/index.ts
+++ b/packages/extension-sdk-react/src/components/RouteChangeListener/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk-react/src/components/RouteChangeListener/types.ts
+++ b/packages/extension-sdk-react/src/components/RouteChangeListener/types.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk-react/src/components/utils/get_initial_route_entries.spec.ts
+++ b/packages/extension-sdk-react/src/components/utils/get_initial_route_entries.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk-react/src/components/utils/get_initial_route_entries.ts
+++ b/packages/extension-sdk-react/src/components/utils/get_initial_route_entries.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk-react/src/components/utils/setup_close_popovers.ts
+++ b/packages/extension-sdk-react/src/components/utils/setup_close_popovers.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk-react/src/index.tsx
+++ b/packages/extension-sdk-react/src/index.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk-react/src/sdk/core_sdk.spec.ts
+++ b/packages/extension-sdk-react/src/sdk/core_sdk.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk-react/src/sdk/core_sdk.ts
+++ b/packages/extension-sdk-react/src/sdk/core_sdk.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk-react/src/sdk/core_sdk2.ts
+++ b/packages/extension-sdk-react/src/sdk/core_sdk2.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk-react/src/sdk/core_sdk_31.ts
+++ b/packages/extension-sdk-react/src/sdk/core_sdk_31.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk-react/src/sdk/core_sdk_40.ts
+++ b/packages/extension-sdk-react/src/sdk/core_sdk_40.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk/src/connect/connect_extension_host.spec.ts
+++ b/packages/extension-sdk/src/connect/connect_extension_host.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk/src/connect/connect_extension_host.ts
+++ b/packages/extension-sdk/src/connect/connect_extension_host.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk/src/connect/extension_host_api.spec.ts
+++ b/packages/extension-sdk/src/connect/extension_host_api.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk/src/connect/extension_host_api.ts
+++ b/packages/extension-sdk/src/connect/extension_host_api.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk/src/connect/fetch_proxy.spec.ts
+++ b/packages/extension-sdk/src/connect/fetch_proxy.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk/src/connect/fetch_proxy.ts
+++ b/packages/extension-sdk/src/connect/fetch_proxy.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk/src/connect/global_listener.ts
+++ b/packages/extension-sdk/src/connect/global_listener.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk/src/connect/index.ts
+++ b/packages/extension-sdk/src/connect/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk/src/connect/types.ts
+++ b/packages/extension-sdk/src/connect/types.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk/src/index.ts
+++ b/packages/extension-sdk/src/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk/src/sdk/extension_sdk.spec.ts
+++ b/packages/extension-sdk/src/sdk/extension_sdk.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk/src/sdk/extension_sdk.ts
+++ b/packages/extension-sdk/src/sdk/extension_sdk.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk/src/sdk/extension_sdk_31.ts
+++ b/packages/extension-sdk/src/sdk/extension_sdk_31.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk/src/sdk/extension_sdk_40.ts
+++ b/packages/extension-sdk/src/sdk/extension_sdk_40.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk/src/sdk/index.ts
+++ b/packages/extension-sdk/src/sdk/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-sdk/src/sdk/sdk_connection.ts
+++ b/packages/extension-sdk/src/sdk/sdk_connection.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-utils/src/OAuthScene.tsx
+++ b/packages/extension-utils/src/OAuthScene.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-utils/src/adaptorUtils.ts
+++ b/packages/extension-utils/src/adaptorUtils.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-utils/src/authUtils.ts
+++ b/packages/extension-utils/src/authUtils.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-utils/src/browserAdaptor.spec.ts
+++ b/packages/extension-utils/src/browserAdaptor.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-utils/src/browserAdaptor.ts
+++ b/packages/extension-utils/src/browserAdaptor.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-utils/src/extensionAdaptor.spec.ts
+++ b/packages/extension-utils/src/extensionAdaptor.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-utils/src/extensionAdaptor.ts
+++ b/packages/extension-utils/src/extensionAdaptor.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/extension-utils/src/index.ts
+++ b/packages/extension-utils/src/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/Hackathon.tsx
+++ b/packages/hackathon/src/Hackathon.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/authToken/extensionProxyTransport.ts
+++ b/packages/hackathon/src/authToken/extensionProxyTransport.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/authToken/gAuthSession.ts
+++ b/packages/hackathon/src/authToken/gAuthSession.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/components/ExtMarkdown/ExtMarkdown.tsx
+++ b/packages/hackathon/src/components/ExtMarkdown/ExtMarkdown.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/components/ExtMarkdown/index.ts
+++ b/packages/hackathon/src/components/ExtMarkdown/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/components/Header/Header.tsx
+++ b/packages/hackathon/src/components/Header/Header.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/components/Header/index.ts
+++ b/packages/hackathon/src/components/Header/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/components/Loading/Loading.tsx
+++ b/packages/hackathon/src/components/Loading/Loading.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/components/Loading/index.ts
+++ b/packages/hackathon/src/components/Loading/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/components/ProjectViewDialog/ProjectViewDialog.tsx
+++ b/packages/hackathon/src/components/ProjectViewDialog/ProjectViewDialog.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/components/ProjectViewDialog/index.ts
+++ b/packages/hackathon/src/components/ProjectViewDialog/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/components/Scroller/Scroller.tsx
+++ b/packages/hackathon/src/components/Scroller/Scroller.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/components/Scroller/index.ts
+++ b/packages/hackathon/src/components/Scroller/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/components/SideNav/SideNav.tsx
+++ b/packages/hackathon/src/components/SideNav/SideNav.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/components/SideNav/index.ts
+++ b/packages/hackathon/src/components/SideNav/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/components/index.ts
+++ b/packages/hackathon/src/components/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/constants.tsx
+++ b/packages/hackathon/src/constants.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/data/add_user/actions.ts
+++ b/packages/hackathon/src/data/add_user/actions.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/data/add_user/reducer.ts
+++ b/packages/hackathon/src/data/add_user/reducer.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/data/add_user/sagas.ts
+++ b/packages/hackathon/src/data/add_user/sagas.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/data/add_user/selectors.ts
+++ b/packages/hackathon/src/data/add_user/selectors.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/data/admin/actions.ts
+++ b/packages/hackathon/src/data/admin/actions.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/data/admin/reducer.ts
+++ b/packages/hackathon/src/data/admin/reducer.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/data/admin/sagas.ts
+++ b/packages/hackathon/src/data/admin/sagas.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/data/admin/selectors.ts
+++ b/packages/hackathon/src/data/admin/selectors.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/data/common/actions.ts
+++ b/packages/hackathon/src/data/common/actions.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/data/common/reducer.ts
+++ b/packages/hackathon/src/data/common/reducer.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/data/common/selectors.ts
+++ b/packages/hackathon/src/data/common/selectors.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/data/hack_session/actions.ts
+++ b/packages/hackathon/src/data/hack_session/actions.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/data/hack_session/reducer.ts
+++ b/packages/hackathon/src/data/hack_session/reducer.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/data/hack_session/sagas.ts
+++ b/packages/hackathon/src/data/hack_session/sagas.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/data/hack_session/selectors.ts
+++ b/packages/hackathon/src/data/hack_session/selectors.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/data/hackers/actions.ts
+++ b/packages/hackathon/src/data/hackers/actions.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/data/hackers/reducer.ts
+++ b/packages/hackathon/src/data/hackers/reducer.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/data/hackers/sagas.ts
+++ b/packages/hackathon/src/data/hackers/sagas.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/data/hackers/selectors.ts
+++ b/packages/hackathon/src/data/hackers/selectors.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/data/judgings/actions.ts
+++ b/packages/hackathon/src/data/judgings/actions.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/data/judgings/reducer.ts
+++ b/packages/hackathon/src/data/judgings/reducer.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/data/judgings/sagas.ts
+++ b/packages/hackathon/src/data/judgings/sagas.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/data/judgings/selectors.ts
+++ b/packages/hackathon/src/data/judgings/selectors.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/data/projects/actions.ts
+++ b/packages/hackathon/src/data/projects/actions.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/data/projects/reducer.ts
+++ b/packages/hackathon/src/data/projects/reducer.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/data/projects/sagas.ts
+++ b/packages/hackathon/src/data/projects/sagas.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/data/projects/selectors.ts
+++ b/packages/hackathon/src/data/projects/selectors.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/data/root_reducer.ts
+++ b/packages/hackathon/src/data/root_reducer.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/data/sheets_client.ts
+++ b/packages/hackathon/src/data/sheets_client.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/data/store.ts
+++ b/packages/hackathon/src/data/store.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/data/types.ts
+++ b/packages/hackathon/src/data/types.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/index.tsx
+++ b/packages/hackathon/src/index.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/models/Hackathons.spec.ts
+++ b/packages/hackathon/src/models/Hackathons.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/models/Hackathons.ts
+++ b/packages/hackathon/src/models/Hackathons.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/models/Hacker.spec.ts
+++ b/packages/hackathon/src/models/Hacker.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/models/Hacker.ts
+++ b/packages/hackathon/src/models/Hacker.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/models/Judgings.spec.ts
+++ b/packages/hackathon/src/models/Judgings.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/models/Judgings.ts
+++ b/packages/hackathon/src/models/Judgings.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/models/Projects.spec.ts
+++ b/packages/hackathon/src/models/Projects.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/models/Projects.ts
+++ b/packages/hackathon/src/models/Projects.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/models/Registrations.ts
+++ b/packages/hackathon/src/models/Registrations.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/models/SheetData.spec.ts
+++ b/packages/hackathon/src/models/SheetData.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/models/SheetData.ts
+++ b/packages/hackathon/src/models/SheetData.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/models/SheetRow.ts
+++ b/packages/hackathon/src/models/SheetRow.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/models/TeamMembers.ts
+++ b/packages/hackathon/src/models/TeamMembers.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/models/Technologies.ts
+++ b/packages/hackathon/src/models/Technologies.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/models/Users.ts
+++ b/packages/hackathon/src/models/Users.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/models/index.ts
+++ b/packages/hackathon/src/models/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/models/sheetUtils.tsx
+++ b/packages/hackathon/src/models/sheetUtils.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/routes/AppRouter.tsx
+++ b/packages/hackathon/src/routes/AppRouter.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/routes/index.ts
+++ b/packages/hackathon/src/routes/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/AdminScene/AdminScene.tsx
+++ b/packages/hackathon/src/scenes/AdminScene/AdminScene.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/AdminScene/components/AddUsers.tsx
+++ b/packages/hackathon/src/scenes/AdminScene/components/AddUsers.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/AdminScene/components/UserAttributes.tsx
+++ b/packages/hackathon/src/scenes/AdminScene/components/UserAttributes.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/AdminScene/index.ts
+++ b/packages/hackathon/src/scenes/AdminScene/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/HomeScene/HomeScene.tsx
+++ b/packages/hackathon/src/scenes/HomeScene/HomeScene.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/HomeScene/agenda.ts
+++ b/packages/hackathon/src/scenes/HomeScene/agenda.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/HomeScene/components/Agenda.spec.tsx
+++ b/packages/hackathon/src/scenes/HomeScene/components/Agenda.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/HomeScene/components/Agenda.tsx
+++ b/packages/hackathon/src/scenes/HomeScene/components/Agenda.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/HomeScene/components/AgendaEra.tsx
+++ b/packages/hackathon/src/scenes/HomeScene/components/AgendaEra.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/HomeScene/components/AgendaRow.tsx
+++ b/packages/hackathon/src/scenes/HomeScene/components/AgendaRow.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/HomeScene/components/agendaUtils.spec.ts
+++ b/packages/hackathon/src/scenes/HomeScene/components/agendaUtils.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/HomeScene/components/agendaUtils.ts
+++ b/packages/hackathon/src/scenes/HomeScene/components/agendaUtils.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/HomeScene/components/index.ts
+++ b/packages/hackathon/src/scenes/HomeScene/components/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/HomeScene/index.ts
+++ b/packages/hackathon/src/scenes/HomeScene/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/JudgingEditorScene/JudgingEditorScene.tsx
+++ b/packages/hackathon/src/scenes/JudgingEditorScene/JudgingEditorScene.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/JudgingEditorScene/components/JudgingForm.tsx
+++ b/packages/hackathon/src/scenes/JudgingEditorScene/components/JudgingForm.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/JudgingEditorScene/components/JudgingView.tsx
+++ b/packages/hackathon/src/scenes/JudgingEditorScene/components/JudgingView.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/JudgingEditorScene/components/JudgingViewDialog.tsx
+++ b/packages/hackathon/src/scenes/JudgingEditorScene/components/JudgingViewDialog.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/JudgingEditorScene/components/index.ts
+++ b/packages/hackathon/src/scenes/JudgingEditorScene/components/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/JudgingEditorScene/index.ts
+++ b/packages/hackathon/src/scenes/JudgingEditorScene/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/JudgingScene/JudgingScene.tsx
+++ b/packages/hackathon/src/scenes/JudgingScene/JudgingScene.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/JudgingScene/components/JudgingList.tsx
+++ b/packages/hackathon/src/scenes/JudgingScene/components/JudgingList.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/JudgingScene/components/index.ts
+++ b/packages/hackathon/src/scenes/JudgingScene/components/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/JudgingScene/index.ts
+++ b/packages/hackathon/src/scenes/JudgingScene/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/NotFoundScene/NotFoundScene.tsx
+++ b/packages/hackathon/src/scenes/NotFoundScene/NotFoundScene.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/NotFoundScene/index.ts
+++ b/packages/hackathon/src/scenes/NotFoundScene/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/ProjectEditorScene/ProjectEditorScene.tsx
+++ b/packages/hackathon/src/scenes/ProjectEditorScene/ProjectEditorScene.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/ProjectEditorScene/components/ProjectForm.tsx
+++ b/packages/hackathon/src/scenes/ProjectEditorScene/components/ProjectForm.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/ProjectEditorScene/components/index.ts
+++ b/packages/hackathon/src/scenes/ProjectEditorScene/components/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/ProjectEditorScene/index.ts
+++ b/packages/hackathon/src/scenes/ProjectEditorScene/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/ProjectsScene/ProjectsScene.tsx
+++ b/packages/hackathon/src/scenes/ProjectsScene/ProjectsScene.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/ProjectsScene/components/ProjectList.tsx
+++ b/packages/hackathon/src/scenes/ProjectsScene/components/ProjectList.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/ProjectsScene/components/ProjectView.tsx
+++ b/packages/hackathon/src/scenes/ProjectsScene/components/ProjectView.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/ProjectsScene/components/index.ts
+++ b/packages/hackathon/src/scenes/ProjectsScene/components/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/ProjectsScene/index.ts
+++ b/packages/hackathon/src/scenes/ProjectsScene/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/ResourceScene/ResourceScene.tsx
+++ b/packages/hackathon/src/scenes/ResourceScene/ResourceScene.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/ResourceScene/index.ts
+++ b/packages/hackathon/src/scenes/ResourceScene/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/ResourceScene/resource_data.ts
+++ b/packages/hackathon/src/scenes/ResourceScene/resource_data.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/UsersScene/UsersScene.tsx
+++ b/packages/hackathon/src/scenes/UsersScene/UsersScene.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/UsersScene/components/HackerList.tsx
+++ b/packages/hackathon/src/scenes/UsersScene/components/HackerList.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/UsersScene/components/index.ts
+++ b/packages/hackathon/src/scenes/UsersScene/components/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/UsersScene/index.ts
+++ b/packages/hackathon/src/scenes/UsersScene/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/index.ts
+++ b/packages/hackathon/src/scenes/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/scenes/utils.ts
+++ b/packages/hackathon/src/scenes/utils.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/test-data/index.ts
+++ b/packages/hackathon/src/test-data/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/test-data/mocks.ts
+++ b/packages/hackathon/src/test-data/mocks.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/utils/csv_parse.ts
+++ b/packages/hackathon/src/utils/csv_parse.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/utils/index.ts
+++ b/packages/hackathon/src/utils/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/utils/permissions.ts
+++ b/packages/hackathon/src/utils/permissions.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/hackathon/src/utils/tabs.ts
+++ b/packages/hackathon/src/utils/tabs.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/redux/src/createSliceHooks/index-integration.spec.tsx
+++ b/packages/redux/src/createSliceHooks/index-integration.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/redux/src/createSliceHooks/index.spec.ts
+++ b/packages/redux/src/createSliceHooks/index.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/redux/src/createSliceHooks/index.ts
+++ b/packages/redux/src/createSliceHooks/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/redux/src/createStore/index.spec.tsx
+++ b/packages/redux/src/createStore/index.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/redux/src/createStore/index.ts
+++ b/packages/redux/src/createStore/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/redux/src/deepCombineReducers/index.spec.tsx
+++ b/packages/redux/src/deepCombineReducers/index.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/redux/src/deepCombineReducers/index.ts
+++ b/packages/redux/src/deepCombineReducers/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/redux/src/index.spec.ts
+++ b/packages/redux/src/index.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/redux/src/index.ts
+++ b/packages/redux/src/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/redux/src/types/index.ts
+++ b/packages/redux/src/types/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/redux/src/useActions/index.spec.ts
+++ b/packages/redux/src/useActions/index.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/redux/src/useActions/index.ts
+++ b/packages/redux/src/useActions/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/redux/src/useSaga/index.spec.ts
+++ b/packages/redux/src/useSaga/index.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/redux/src/useSaga/index.ts
+++ b/packages/redux/src/useSaga/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/redux/src/useSagas/index.spec.ts
+++ b/packages/redux/src/useSagas/index.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/redux/src/useSagas/index.ts
+++ b/packages/redux/src/useSagas/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/redux/src/useSlice/index.spec.ts
+++ b/packages/redux/src/useSlice/index.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/redux/src/useSlice/index.ts
+++ b/packages/redux/src/useSlice/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/redux/src/useStore/index.spec.tsx
+++ b/packages/redux/src/useStore/index.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/redux/src/useStore/index.ts
+++ b/packages/redux/src/useStore/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/redux/src/useStoreState/index.spec.ts
+++ b/packages/redux/src/useStoreState/index.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/redux/src/useStoreState/index.ts
+++ b/packages/redux/src/useStoreState/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/playground/RunItDemo.tsx
+++ b/packages/run-it/playground/RunItDemo.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/playground/index.tsx
+++ b/packages/run-it/playground/index.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/RunIt.spec.tsx
+++ b/packages/run-it/src/RunIt.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/RunIt.tsx
+++ b/packages/run-it/src/RunIt.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/RunItProvider.tsx
+++ b/packages/run-it/src/RunItProvider.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/Collapser/CollapserCard.spec.tsx
+++ b/packages/run-it/src/components/Collapser/CollapserCard.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/Collapser/CollapserCard.tsx
+++ b/packages/run-it/src/components/Collapser/CollapserCard.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/Collapser/index.ts
+++ b/packages/run-it/src/components/Collapser/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/ConfigForm/ConfigForm.spec.tsx
+++ b/packages/run-it/src/components/ConfigForm/ConfigForm.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/ConfigForm/ConfigForm.tsx
+++ b/packages/run-it/src/components/ConfigForm/ConfigForm.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -258,7 +258,7 @@ export const ConfigForm: FC<ConfigFormProps> = ({
     // This will set storage variables and return to OAuthScene when successful
     await adaptor.login()
   }
-
+  /* eslint-disable */
   return (
     <SpaceVertical gap="u2">
       <RunItHeading>{title}</RunItHeading>
@@ -372,4 +372,5 @@ export const ConfigForm: FC<ConfigFormProps> = ({
       </CollapserCard>
     </SpaceVertical>
   )
+  /* eslint-enable */
 }

--- a/packages/run-it/src/components/ConfigForm/index.ts
+++ b/packages/run-it/src/components/ConfigForm/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/ConfigForm/utils.spec.ts
+++ b/packages/run-it/src/components/ConfigForm/utils.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/ConfigForm/utils.ts
+++ b/packages/run-it/src/components/ConfigForm/utils.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/DataGrid/DataGrid.tsx
+++ b/packages/run-it/src/components/DataGrid/DataGrid.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/DataGrid/gridUtils.spec.tsx
+++ b/packages/run-it/src/components/DataGrid/gridUtils.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/DataGrid/gridUtils.tsx
+++ b/packages/run-it/src/components/DataGrid/gridUtils.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/DataGrid/index.ts
+++ b/packages/run-it/src/components/DataGrid/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/DocSdkCalls/DocMultiCall.tsx
+++ b/packages/run-it/src/components/DocSdkCalls/DocMultiCall.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/DocSdkCalls/DocSdkCalls.spec.tsx
+++ b/packages/run-it/src/components/DocSdkCalls/DocSdkCalls.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/DocSdkCalls/DocSdkCalls.tsx
+++ b/packages/run-it/src/components/DocSdkCalls/DocSdkCalls.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/DocSdkCalls/callUtils.ts
+++ b/packages/run-it/src/components/DocSdkCalls/callUtils.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/DocSdkCalls/index.ts
+++ b/packages/run-it/src/components/DocSdkCalls/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/Loading/Loading.spec.tsx
+++ b/packages/run-it/src/components/Loading/Loading.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/Loading/Loading.tsx
+++ b/packages/run-it/src/components/Loading/Loading.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/Loading/index.ts
+++ b/packages/run-it/src/components/Loading/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/LoginForm/LoginForm.spec.tsx
+++ b/packages/run-it/src/components/LoginForm/LoginForm.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/LoginForm/LoginForm.tsx
+++ b/packages/run-it/src/components/LoginForm/LoginForm.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/LoginForm/index.ts
+++ b/packages/run-it/src/components/LoginForm/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/MethodBadge/MethodBadge.spec.tsx
+++ b/packages/run-it/src/components/MethodBadge/MethodBadge.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/MethodBadge/MethodBadge.tsx
+++ b/packages/run-it/src/components/MethodBadge/MethodBadge.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/MethodBadge/index.ts
+++ b/packages/run-it/src/components/MethodBadge/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/PerfTracker/PerfChart.tsx
+++ b/packages/run-it/src/components/PerfTracker/PerfChart.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/PerfTracker/PerfTable.spec.tsx
+++ b/packages/run-it/src/components/PerfTracker/PerfTable.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/PerfTracker/PerfTable.tsx
+++ b/packages/run-it/src/components/PerfTracker/PerfTable.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/PerfTracker/PerfTracker.spec.tsx
+++ b/packages/run-it/src/components/PerfTracker/PerfTracker.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/PerfTracker/PerfTracker.tsx
+++ b/packages/run-it/src/components/PerfTracker/PerfTracker.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/PerfTracker/index.ts
+++ b/packages/run-it/src/components/PerfTracker/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/PerfTracker/perfTableUtils.tsx
+++ b/packages/run-it/src/components/PerfTracker/perfTableUtils.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/PerfTracker/perfUtils.ts
+++ b/packages/run-it/src/components/PerfTracker/perfUtils.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/RequestForm/FormItem.tsx
+++ b/packages/run-it/src/components/RequestForm/FormItem.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/RequestForm/RequestForm.spec.tsx
+++ b/packages/run-it/src/components/RequestForm/RequestForm.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/RequestForm/RequestForm.tsx
+++ b/packages/run-it/src/components/RequestForm/RequestForm.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -126,7 +126,7 @@ export const RequestForm: FC<RequestFormProps> = ({
     setRequestContent({})
     safeSetMessage('')
   }
-
+  /* eslint-disable */
   return (
     <Form onSubmit={handleSubmit}>
       {validationMessage && (
@@ -180,4 +180,5 @@ export const RequestForm: FC<RequestFormProps> = ({
       </Fieldset>
     </Form>
   )
+  /* eslint-enable */
 }

--- a/packages/run-it/src/components/RequestForm/formUtils.spec.tsx
+++ b/packages/run-it/src/components/RequestForm/formUtils.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/RequestForm/formUtils.tsx
+++ b/packages/run-it/src/components/RequestForm/formUtils.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/RequestForm/index.ts
+++ b/packages/run-it/src/components/RequestForm/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/ResponseExplorer/ResponseExplorer.spec.tsx
+++ b/packages/run-it/src/components/ResponseExplorer/ResponseExplorer.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/ResponseExplorer/ResponseExplorer.tsx
+++ b/packages/run-it/src/components/ResponseExplorer/ResponseExplorer.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -55,6 +55,7 @@ const getHeaders = (response: ResponseContent): HeaderTable => {
 
 const getBodySize = (response: ResponseContent): string => {
   const size =
+    // eslint-disable-next-line no-nested-ternary
     !response || !response.body
       ? 0
       : response?.body instanceof Blob

--- a/packages/run-it/src/components/ResponseExplorer/index.ts
+++ b/packages/run-it/src/components/ResponseExplorer/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/ShowResponse/ShowResponse.spec.tsx
+++ b/packages/run-it/src/components/ShowResponse/ShowResponse.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/ShowResponse/ShowResponse.tsx
+++ b/packages/run-it/src/components/ShowResponse/ShowResponse.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/ShowResponse/index.ts
+++ b/packages/run-it/src/components/ShowResponse/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/ShowResponse/responseUtils.spec.tsx
+++ b/packages/run-it/src/components/ShowResponse/responseUtils.spec.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/ShowResponse/responseUtils.tsx
+++ b/packages/run-it/src/components/ShowResponse/responseUtils.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/common/common.tsx
+++ b/packages/run-it/src/components/common/common.tsx
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/common/index.ts
+++ b/packages/run-it/src/components/common/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/components/index.ts
+++ b/packages/run-it/src/components/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/index.ts
+++ b/packages/run-it/src/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/test-data/index.ts
+++ b/packages/run-it/src/test-data/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/test-data/responses.ts
+++ b/packages/run-it/src/test-data/responses.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/test-data/specs.ts
+++ b/packages/run-it/src/test-data/specs.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/utils/RunItSDK.spec.ts
+++ b/packages/run-it/src/utils/RunItSDK.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/utils/RunItSDK.ts
+++ b/packages/run-it/src/utils/RunItSDK.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/utils/index.ts
+++ b/packages/run-it/src/utils/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/utils/requestUtils.spec.ts
+++ b/packages/run-it/src/utils/requestUtils.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/run-it/src/utils/requestUtils.ts
+++ b/packages/run-it/src/utils/requestUtils.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -26,7 +26,7 @@
 
 import type { IAPIMethods, IRawResponse } from '@looker/sdk-rtl'
 import cloneDeep from 'lodash/cloneDeep'
-import { isEmpty } from 'lodash'
+import isEmpty from 'lodash/isEmpty'
 import type { IApiModel, IMethod, IType } from '@looker/sdk-codegen'
 import {
   ArrayType,

--- a/packages/sdk-codegen-scripts/scripts/mineDeclarations.ts
+++ b/packages/sdk-codegen-scripts/scripts/mineDeclarations.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen-scripts/scripts/mineExamples.ts
+++ b/packages/sdk-codegen-scripts/scripts/mineExamples.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen-scripts/scripts/refresh_specs.ts
+++ b/packages/sdk-codegen-scripts/scripts/refresh_specs.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen-scripts/scripts/register.ts
+++ b/packages/sdk-codegen-scripts/scripts/register.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen-scripts/scripts/specLinter.ts
+++ b/packages/sdk-codegen-scripts/scripts/specLinter.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen-scripts/scripts/utils.ts
+++ b/packages/sdk-codegen-scripts/scripts/utils.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen-scripts/src/convert.spec.ts
+++ b/packages/sdk-codegen-scripts/src/convert.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen-scripts/src/convert.ts
+++ b/packages/sdk-codegen-scripts/src/convert.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen-scripts/src/declarationMiner.spec.ts
+++ b/packages/sdk-codegen-scripts/src/declarationMiner.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen-scripts/src/declarationMiner.ts
+++ b/packages/sdk-codegen-scripts/src/declarationMiner.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen-scripts/src/exampleMiner.spec.ts
+++ b/packages/sdk-codegen-scripts/src/exampleMiner.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen-scripts/src/exampleMiner.ts
+++ b/packages/sdk-codegen-scripts/src/exampleMiner.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen-scripts/src/fetchSpec.spec.ts
+++ b/packages/sdk-codegen-scripts/src/fetchSpec.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen-scripts/src/fetchSpec.ts
+++ b/packages/sdk-codegen-scripts/src/fetchSpec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen-scripts/src/index.ts
+++ b/packages/sdk-codegen-scripts/src/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen-scripts/src/languages.ts
+++ b/packages/sdk-codegen-scripts/src/languages.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen-scripts/src/legacy.ts
+++ b/packages/sdk-codegen-scripts/src/legacy.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen-scripts/src/legacyGenerator.ts
+++ b/packages/sdk-codegen-scripts/src/legacyGenerator.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen-scripts/src/nodeUtils.ts
+++ b/packages/sdk-codegen-scripts/src/nodeUtils.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen-scripts/src/prettify.ts
+++ b/packages/sdk-codegen-scripts/src/prettify.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen-scripts/src/reformatter.ts
+++ b/packages/sdk-codegen-scripts/src/reformatter.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen-scripts/src/sdkConfig.ts
+++ b/packages/sdk-codegen-scripts/src/sdkConfig.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen-scripts/src/sdkGen.ts
+++ b/packages/sdk-codegen-scripts/src/sdkGen.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen-scripts/src/sdkGenerator.spec.ts
+++ b/packages/sdk-codegen-scripts/src/sdkGenerator.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen-scripts/src/sdkGenerator.ts
+++ b/packages/sdk-codegen-scripts/src/sdkGenerator.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen-scripts/src/specConvert.ts
+++ b/packages/sdk-codegen-scripts/src/specConvert.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen-scripts/src/testUtils/index.ts
+++ b/packages/sdk-codegen-scripts/src/testUtils/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen-scripts/src/testUtils/mocks.ts
+++ b/packages/sdk-codegen-scripts/src/testUtils/mocks.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen-scripts/src/testUtils/testUtils.ts
+++ b/packages/sdk-codegen-scripts/src/testUtils/testUtils.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen-scripts/src/utils.spec.ts
+++ b/packages/sdk-codegen-scripts/src/utils.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen-scripts/src/utils.ts
+++ b/packages/sdk-codegen-scripts/src/utils.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen-scripts/src/yamlToJson.ts
+++ b/packages/sdk-codegen-scripts/src/yamlToJson.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen-utils/src/index.ts
+++ b/packages/sdk-codegen-utils/src/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen-utils/src/utils.ts
+++ b/packages/sdk-codegen-utils/src/utils.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen/src/codeGen.ts
+++ b/packages/sdk-codegen/src/codeGen.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen/src/codeGenerators.spec.ts
+++ b/packages/sdk-codegen/src/codeGenerators.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen/src/codeGenerators.ts
+++ b/packages/sdk-codegen/src/codeGenerators.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen/src/csharp.gen.spec.ts
+++ b/packages/sdk-codegen/src/csharp.gen.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen/src/csharp.gen.ts
+++ b/packages/sdk-codegen/src/csharp.gen.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -207,6 +207,7 @@ namespace Looker.SDK.API${this.apiRef}
     const mapped = this.typeMap(type)
     const arg = this.reserve(param.name)
     const pOpt = param.required ? '' : '?'
+    // eslint-disable-next-line no-nested-ternary
     const defaulting = param.required
       ? ''
       : mapped.optional

--- a/packages/sdk-codegen/src/declarationInfo.ts
+++ b/packages/sdk-codegen/src/declarationInfo.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen/src/exampleInfo.spec.ts
+++ b/packages/sdk-codegen/src/exampleInfo.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen/src/exampleInfo.ts
+++ b/packages/sdk-codegen/src/exampleInfo.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen/src/go.gen.spec.ts
+++ b/packages/sdk-codegen/src/go.gen.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen/src/go.gen.ts
+++ b/packages/sdk-codegen/src/go.gen.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen/src/index.ts
+++ b/packages/sdk-codegen/src/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen/src/kotlin.gen.spec.ts
+++ b/packages/sdk-codegen/src/kotlin.gen.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen/src/kotlin.gen.ts
+++ b/packages/sdk-codegen/src/kotlin.gen.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -188,6 +188,7 @@ import java.util.*
     }
     return (
       `${indent}${param.name}: ${mapped.name}${pOpt}` +
+      // eslint-disable-next-line no-nested-ternary
       (param.required ? '' : mapped.default ? ` = ${mapped.default}` : '')
     )
   }

--- a/packages/sdk-codegen/src/pseudo.gen.spec.ts
+++ b/packages/sdk-codegen/src/pseudo.gen.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen/src/pseudo.gen.ts
+++ b/packages/sdk-codegen/src/pseudo.gen.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen/src/python.gen.spec.ts
+++ b/packages/sdk-codegen/src/python.gen.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen/src/python.gen.ts
+++ b/packages/sdk-codegen/src/python.gen.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen/src/sdkModels.spec.ts
+++ b/packages/sdk-codegen/src/sdkModels.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen/src/sdkModels.ts
+++ b/packages/sdk-codegen/src/sdkModels.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen/src/specConverter.spec.ts
+++ b/packages/sdk-codegen/src/specConverter.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen/src/specConverter.ts
+++ b/packages/sdk-codegen/src/specConverter.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen/src/specDiff.spec.ts
+++ b/packages/sdk-codegen/src/specDiff.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen/src/specDiff.ts
+++ b/packages/sdk-codegen/src/specDiff.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen/src/swift.gen.spec.ts
+++ b/packages/sdk-codegen/src/swift.gen.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen/src/swift.gen.ts
+++ b/packages/sdk-codegen/src/swift.gen.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -297,6 +297,7 @@ import Foundation
   }
 
   getSpecialHandling(property: IProperty) {
+    // eslint-disable-next-line no-nested-ternary
     return this.useAnyString(property)
       ? 'AnyString'
       : this.useAnyInt(property)
@@ -331,6 +332,7 @@ import Foundation
       const ra = typeOfType(property.type) === TypeOfType.Array
       const privy = this.reserve('_' + property.name)
       const bump = this.bumper(indent)
+      // eslint-disable-next-line no-nested-ternary
       const setter = property.required
         ? ra
           ? `${privy} = newValue.map { ${specialHandling}.init($0) }`
@@ -338,6 +340,7 @@ import Foundation
         : ra
         ? `if let v = newValue { ${privy} = v.map { ${specialHandling}.init($0) } } else { ${privy} = nil }`
         : `${privy} = newValue.map(${specialHandling}.init)`
+      // eslint-disable-next-line no-nested-ternary
       const getter = property.required
         ? ra
           ? `${privy}.map { $0.value }`
@@ -385,6 +388,7 @@ ${indent}}\n`
     return (
       this.commentHeader(indent, this.paramComment(param, mapped)) +
       `${indent}${line}${this.reserve(param.name)}: ${mapped.name}${pOpt}` +
+      // eslint-disable-next-line no-nested-ternary
       (param.required ? '' : mapped.default ? ` = ${mapped.default}` : '')
     )
   }

--- a/packages/sdk-codegen/src/testUtils/index.ts
+++ b/packages/sdk-codegen/src/testUtils/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen/src/testUtils/testUtils.ts
+++ b/packages/sdk-codegen/src/testUtils/testUtils.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen/src/typescript.gen.spec.ts
+++ b/packages/sdk-codegen/src/typescript.gen.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-codegen/src/typescript.gen.ts
+++ b/packages/sdk-codegen/src/typescript.gen.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -290,6 +290,7 @@ export class ${this.packageName}Stream extends APIMethods {
     }
     return (
       `${indent}${this.reserve(param.name)}${pOpt}: ${mapped.name}` +
+      // eslint-disable-next-line no-nested-ternary
       (param.required ? '' : mapped.default ? ` = ${mapped.default}` : '')
     )
   }

--- a/packages/sdk-node/src/index.ts
+++ b/packages/sdk-node/src/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-node/src/nodeSdk.ts
+++ b/packages/sdk-node/src/nodeSdk.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-node/src/nodeServices.spec.ts
+++ b/packages/sdk-node/src/nodeServices.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-node/src/nodeServices.ts
+++ b/packages/sdk-node/src/nodeServices.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-node/src/nodeSession.spec.ts
+++ b/packages/sdk-node/src/nodeSession.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-node/src/nodeSession.ts
+++ b/packages/sdk-node/src/nodeSession.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-node/src/nodeSettings.spec.ts
+++ b/packages/sdk-node/src/nodeSettings.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-node/src/nodeSettings.ts
+++ b/packages/sdk-node/src/nodeSettings.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-node/src/nodeTransport.spec.ts
+++ b/packages/sdk-node/src/nodeTransport.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-node/src/nodeTransport.ts
+++ b/packages/sdk-node/src/nodeTransport.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-node/src/testUtils/index.ts
+++ b/packages/sdk-node/src/testUtils/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-node/src/testUtils/testUtils.ts
+++ b/packages/sdk-node/src/testUtils/testUtils.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-node/test/methods.spec.ts
+++ b/packages/sdk-node/test/methods.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-rtl/src/CSRFSession.ts
+++ b/packages/sdk-rtl/src/CSRFSession.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-rtl/src/apiMethods.spec.ts
+++ b/packages/sdk-rtl/src/apiMethods.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-rtl/src/apiMethods.ts
+++ b/packages/sdk-rtl/src/apiMethods.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-rtl/src/apiSettings.spec.ts
+++ b/packages/sdk-rtl/src/apiSettings.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-rtl/src/apiSettings.ts
+++ b/packages/sdk-rtl/src/apiSettings.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-rtl/src/authSession.ts
+++ b/packages/sdk-rtl/src/authSession.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-rtl/src/authToken.spec.ts
+++ b/packages/sdk-rtl/src/authToken.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-rtl/src/authToken.ts
+++ b/packages/sdk-rtl/src/authToken.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-rtl/src/baseTransport.ts
+++ b/packages/sdk-rtl/src/baseTransport.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-rtl/src/browser.ts
+++ b/packages/sdk-rtl/src/browser.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-rtl/src/browserServices.spec.ts
+++ b/packages/sdk-rtl/src/browserServices.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-rtl/src/browserServices.ts
+++ b/packages/sdk-rtl/src/browserServices.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-rtl/src/browserSession.spec.ts
+++ b/packages/sdk-rtl/src/browserSession.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-rtl/src/browserSession.ts
+++ b/packages/sdk-rtl/src/browserSession.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-rtl/src/browserTransport.spec.ts
+++ b/packages/sdk-rtl/src/browserTransport.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-rtl/src/browserTransport.ts
+++ b/packages/sdk-rtl/src/browserTransport.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-rtl/src/constants.spec.ts
+++ b/packages/sdk-rtl/src/constants.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-rtl/src/constants.ts
+++ b/packages/sdk-rtl/src/constants.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-rtl/src/cryptoHash.ts
+++ b/packages/sdk-rtl/src/cryptoHash.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-rtl/src/delimArray.spec.ts
+++ b/packages/sdk-rtl/src/delimArray.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-rtl/src/delimArray.ts
+++ b/packages/sdk-rtl/src/delimArray.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-rtl/src/extensionSession.spec.ts
+++ b/packages/sdk-rtl/src/extensionSession.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-rtl/src/extensionSession.ts
+++ b/packages/sdk-rtl/src/extensionSession.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-rtl/src/extensionTransport.spec.ts
+++ b/packages/sdk-rtl/src/extensionTransport.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-rtl/src/extensionTransport.ts
+++ b/packages/sdk-rtl/src/extensionTransport.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-rtl/src/index.ts
+++ b/packages/sdk-rtl/src/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-rtl/src/oauthSession.spec.ts
+++ b/packages/sdk-rtl/src/oauthSession.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-rtl/src/oauthSession.ts
+++ b/packages/sdk-rtl/src/oauthSession.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-rtl/src/paging.spec.ts
+++ b/packages/sdk-rtl/src/paging.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-rtl/src/paging.ts
+++ b/packages/sdk-rtl/src/paging.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-rtl/src/platformServices.ts
+++ b/packages/sdk-rtl/src/platformServices.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-rtl/src/proxySession.spec.ts
+++ b/packages/sdk-rtl/src/proxySession.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-rtl/src/proxySession.ts
+++ b/packages/sdk-rtl/src/proxySession.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-rtl/src/testUtils/index.ts
+++ b/packages/sdk-rtl/src/testUtils/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-rtl/src/testUtils/testUtils.ts
+++ b/packages/sdk-rtl/src/testUtils/testUtils.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-rtl/src/transport.spec.ts
+++ b/packages/sdk-rtl/src/transport.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk-rtl/src/transport.ts
+++ b/packages/sdk-rtl/src/transport.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk/src/3.1/funcs.ts
+++ b/packages/sdk/src/3.1/funcs.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk/src/3.1/methods.ts
+++ b/packages/sdk/src/3.1/methods.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk/src/3.1/methodsInterface.ts
+++ b/packages/sdk/src/3.1/methodsInterface.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk/src/3.1/models.ts
+++ b/packages/sdk/src/3.1/models.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk/src/3.1/streams.ts
+++ b/packages/sdk/src/3.1/streams.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk/src/4.0/funcs.ts
+++ b/packages/sdk/src/4.0/funcs.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk/src/4.0/methods.ts
+++ b/packages/sdk/src/4.0/methods.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk/src/4.0/methodsInterface.ts
+++ b/packages/sdk/src/4.0/methodsInterface.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk/src/4.0/models.ts
+++ b/packages/sdk/src/4.0/models.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk/src/4.0/streams.ts
+++ b/packages/sdk/src/4.0/streams.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk/src/browserSdk.ts
+++ b/packages/sdk/src/browserSdk.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk/src/constants.ts
+++ b/packages/sdk/src/constants.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk/src/extensionSdk.ts
+++ b/packages/sdk/src/extensionSdk.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/wholly-sheet/src/RowModel.spec.ts
+++ b/packages/wholly-sheet/src/RowModel.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/wholly-sheet/src/RowModel.ts
+++ b/packages/wholly-sheet/src/RowModel.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/wholly-sheet/src/SheetSDK.spec.ts
+++ b/packages/wholly-sheet/src/SheetSDK.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/wholly-sheet/src/SheetSDK.ts
+++ b/packages/wholly-sheet/src/SheetSDK.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/wholly-sheet/src/WhollySheet.spec.ts
+++ b/packages/wholly-sheet/src/WhollySheet.spec.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/wholly-sheet/src/WhollySheet.ts
+++ b/packages/wholly-sheet/src/WhollySheet.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/wholly-sheet/src/index.ts
+++ b/packages/wholly-sheet/src/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/wholly-sheet/src/testUtils/testUtils.ts
+++ b/packages/wholly-sheet/src/testUtils/testUtils.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/yarn.lock
+++ b/yarn.lock
@@ -2323,10 +2323,10 @@
     polished "^4.1.2"
     styled-system "^5.1.5"
 
-"@looker/eslint-config-oss@^1.7.1":
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/@looker/eslint-config-oss/-/eslint-config-oss-1.7.1.tgz#fbcac3570faa7e53bb838237812c140be1ff20e4"
-  integrity sha512-vyV6UTWutzvttReVRPOQz2g02YrxRO7TimM+fTi8JPFJE6sZ0GGyQlWjjpC+na4PeQQCWU4fwDi71/v3vKNrQQ==
+"@looker/eslint-config-oss@1.7.14":
+  version "1.7.14"
+  resolved "https://registry.yarnpkg.com/@looker/eslint-config-oss/-/eslint-config-oss-1.7.14.tgz#e6ea69149c5d724a6b3f50797a2594dad8da5ba9"
+  integrity sha512-cTh9EDlL3l9/lyD/h3baAs7AHoTZfKX+Oq8mUznBTNEm+EAkYtvxlo9H+shrpgoRzhaHFwUU8W1LJgvI3w/9Cg==
   dependencies:
     "@typescript-eslint/eslint-plugin" "^4.29.2"
     "@typescript-eslint/parser" "^4.31.0"
@@ -2339,6 +2339,7 @@
     eslint-plugin-i18next "^5.1.1"
     eslint-plugin-import "^2.24.1"
     eslint-plugin-jest-dom "3.9.0"
+    eslint-plugin-lodash "7.1.0"
     eslint-plugin-mdx "^1.14.1"
     eslint-plugin-node "^11.1.0"
     eslint-plugin-prettier "3.4.0"
@@ -2348,7 +2349,6 @@
     eslint-plugin-sort-keys-fix "^1.1.2"
     eslint-plugin-standard "5.0.0"
     eslint-plugin-testing-library "4.11.0"
-    prettier "^2.3.1"
     typescript "4.4.2"
 
 "@looker/extension-sdk-react@^21.4.2":
@@ -6421,6 +6421,11 @@ eslint-plugin-jest-dom@3.9.0:
     "@babel/runtime" "^7.9.6"
     "@testing-library/dom" "^7.28.1"
     requireindex "^1.2.0"
+
+eslint-plugin-lodash@7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-lodash/-/eslint-plugin-lodash-7.1.0.tgz#5ad9bf1240a01c6c3f94e956213e2d6422af3192"
+  integrity sha512-BRkEI/+ZjmeDCM1DfzR+NVwYkC/+ChJhaOSm3Xm7rer/fs89TKU6AMtkQiDdqQel1wZ4IJM+B6hlep9xwVKaMQ==
 
 eslint-plugin-markdown@^2.2.0:
   version "2.2.1"
@@ -11909,7 +11914,7 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^2.3.1, prettier@^2.4.1:
+prettier@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.4.1.tgz#671e11c89c14a4cfc876ce564106c4a6726c9f5c"
   integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==


### PR DESCRIPTION
Upgraded @looker/eslint-config-oss to version 1.7.14. Attempted to upgrade
to latest which is 1.7.15 but it wanted me to add an add package @looker/eslint-config
but that package is marked as no longer supported. Decided to leave that investigation
for another day.

Automatic fix fixed most of the errors which I assume is the header. I have not looked at
every file.

There were a number of no-nested-ternary errors for which I added eslint ignores. To much
room for error to fix. A couple were embedded in really large JSX snippets so had to ignore
all of the JSX.

The was one error to do with lodash. Nice easy fix on that one.

