### PR TITLE
fix: Update prod entrypoint to match dev entrypoint (App.tsx)

### DIFF
--- a/packages/api-explorer/webpack.prod.config.js
+++ b/packages/api-explorer/webpack.prod.config.js
@@ -30,7 +30,7 @@ const browser = require('../../webpack.browser.config')()
 
 module.exports = merge(base, browser, {
   entry: {
-    app: path.join(__dirname, 'src/index.ts'),
+    app: path.join(__dirname, 'src/App.tsx'),
   },
   mode: 'production',
 })


### PR DESCRIPTION
Running `yarn run build` previously resulted in an empty (0b) output bundle.js

I believe this discrepancy was initially introduced inadvertently in https://github.com/looker-open-source/sdk-codegen/commit/fb8634fded843e3d9cbfeee2065fd70a8248b89e