### PR TITLE
chore: upgrade @looker/eslint-config-oss

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@babel/preset-typescript": "^7.13.0",
     "@babel/runtime": "^7.14.0",
     "@babel/runtime-corejs3": "^7.14.0",
-    "@looker/eslint-config-oss": "^1.7.1",
+    "@looker/eslint-config-oss": "1.7.14",
     "@testing-library/jest-dom": "^5.11.6",
     "@types/blueimp-md5": "^2.7.0",
     "@types/ini": "^1.3.30",
@@ -174,7 +174,41 @@
           ]
         }
       ],
-      "no-use-before-define": "off"
+      "no-use-before-define": "off",
+      "header/header": [
+        2,
+        "block",
+        [
+          "",
+          "",
+          " MIT License",
+          "",
+          {
+            "pattern": " Copyright \\(c\\) 20\\d{2} Looker Data Sciences, Inc."
+          },
+          "",
+          " Permission is hereby granted, free of charge, to any person obtaining a copy",
+          " of this software and associated documentation files (the \"Software\"), to deal",
+          " in the Software without restriction, including without limitation the rights",
+          " to use, copy, modify, merge, publish, distribute, sublicense, and/or sell",
+          " copies of the Software, and to permit persons to whom the Software is",
+          " furnished to do so, subject to the following conditions:",
+          "",
+          " The above copyright notice and this permission notice shall be included in all",
+          " copies or substantial portions of the Software.",
+          "",
+          " THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR",
+          " IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,",
+          " FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE",
+          " AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER",
+          " LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,",
+          " OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE",
+          " SOFTWARE.",
+          "",
+          " "
+        ],
+        1
+      ]
     },
     "settings": {
       "import/resolver": {

--- a/packages/api-explorer/src/ApiExplorer.tsx
+++ b/packages/api-explorer/src/ApiExplorer.tsx
@@ -225,5 +225,6 @@ const AsideBorder = styled(Aside)<{
   headless: boolean
 }>`
   width: ${({ isOpen, headless }) =>
+    // eslint-disable-next-line no-nested-ternary
     isOpen ? '20rem' : headless ? '2.75rem' : '0rem'};
 `

--- a/packages/run-it/src/components/ConfigForm/ConfigForm.tsx
+++ b/packages/run-it/src/components/ConfigForm/ConfigForm.tsx
@@ -259,6 +259,7 @@ export const ConfigForm: FC<ConfigFormProps> = ({
     await adaptor.login()
   }
 
+  /* eslint-disable */
   return (
     <SpaceVertical gap="u2">
       <RunItHeading>{title}</RunItHeading>
@@ -372,4 +373,5 @@ export const ConfigForm: FC<ConfigFormProps> = ({
       </CollapserCard>
     </SpaceVertical>
   )
+  /* eslint-enable */
 }

--- a/packages/run-it/src/components/RequestForm/RequestForm.tsx
+++ b/packages/run-it/src/components/RequestForm/RequestForm.tsx
@@ -127,6 +127,7 @@ export const RequestForm: FC<RequestFormProps> = ({
     safeSetMessage('')
   }
 
+  /* eslint-disable */
   return (
     <Form onSubmit={handleSubmit}>
       {validationMessage && (
@@ -180,4 +181,5 @@ export const RequestForm: FC<RequestFormProps> = ({
       </Fieldset>
     </Form>
   )
+  /* eslint-enable */
 }

--- a/packages/run-it/src/components/ResponseExplorer/ResponseExplorer.tsx
+++ b/packages/run-it/src/components/ResponseExplorer/ResponseExplorer.tsx
@@ -55,6 +55,7 @@ const getHeaders = (response: ResponseContent): HeaderTable => {
 
 const getBodySize = (response: ResponseContent): string => {
   const size =
+    // eslint-disable-next-line no-nested-ternary
     !response || !response.body
       ? 0
       : response?.body instanceof Blob

--- a/packages/run-it/src/utils/requestUtils.ts
+++ b/packages/run-it/src/utils/requestUtils.ts
@@ -26,7 +26,7 @@
 
 import type { IAPIMethods, IRawResponse } from '@looker/sdk-rtl'
 import cloneDeep from 'lodash/cloneDeep'
-import { isEmpty } from 'lodash'
+import isEmpty from 'lodash/isEmpty'
 import type { IApiModel, IMethod, IType } from '@looker/sdk-codegen'
 import {
   ArrayType,

--- a/packages/sdk-codegen/src/csharp.gen.ts
+++ b/packages/sdk-codegen/src/csharp.gen.ts
@@ -207,6 +207,7 @@ namespace Looker.SDK.API${this.apiRef}
     const mapped = this.typeMap(type)
     const arg = this.reserve(param.name)
     const pOpt = param.required ? '' : '?'
+    // eslint-disable-next-line no-nested-ternary
     const defaulting = param.required
       ? ''
       : mapped.optional

--- a/packages/sdk-codegen/src/kotlin.gen.ts
+++ b/packages/sdk-codegen/src/kotlin.gen.ts
@@ -188,6 +188,7 @@ import java.util.*
     }
     return (
       `${indent}${param.name}: ${mapped.name}${pOpt}` +
+      // eslint-disable-next-line no-nested-ternary
       (param.required ? '' : mapped.default ? ` = ${mapped.default}` : '')
     )
   }

--- a/packages/sdk-codegen/src/swift.gen.ts
+++ b/packages/sdk-codegen/src/swift.gen.ts
@@ -297,6 +297,7 @@ import Foundation
   }
 
   getSpecialHandling(property: IProperty) {
+    // eslint-disable-next-line no-nested-ternary
     return this.useAnyString(property)
       ? 'AnyString'
       : this.useAnyInt(property)
@@ -331,6 +332,7 @@ import Foundation
       const ra = typeOfType(property.type) === TypeOfType.Array
       const privy = this.reserve('_' + property.name)
       const bump = this.bumper(indent)
+      // eslint-disable-next-line no-nested-ternary
       const setter = property.required
         ? ra
           ? `${privy} = newValue.map { ${specialHandling}.init($0) }`
@@ -338,6 +340,7 @@ import Foundation
         : ra
         ? `if let v = newValue { ${privy} = v.map { ${specialHandling}.init($0) } } else { ${privy} = nil }`
         : `${privy} = newValue.map(${specialHandling}.init)`
+      // eslint-disable-next-line no-nested-ternary
       const getter = property.required
         ? ra
           ? `${privy}.map { $0.value }`
@@ -385,6 +388,7 @@ ${indent}}\n`
     return (
       this.commentHeader(indent, this.paramComment(param, mapped)) +
       `${indent}${line}${this.reserve(param.name)}: ${mapped.name}${pOpt}` +
+      // eslint-disable-next-line no-nested-ternary
       (param.required ? '' : mapped.default ? ` = ${mapped.default}` : '')
     )
   }

--- a/packages/sdk-codegen/src/typescript.gen.ts
+++ b/packages/sdk-codegen/src/typescript.gen.ts
@@ -290,6 +290,7 @@ export class ${this.packageName}Stream extends APIMethods {
     }
     return (
       `${indent}${this.reserve(param.name)}${pOpt}: ${mapped.name}` +
+      // eslint-disable-next-line no-nested-ternary
       (param.required ? '' : mapped.default ? ` = ${mapped.default}` : '')
     )
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2323,10 +2323,10 @@
     polished "^4.1.2"
     styled-system "^5.1.5"
 
-"@looker/eslint-config-oss@^1.7.1":
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/@looker/eslint-config-oss/-/eslint-config-oss-1.7.1.tgz#fbcac3570faa7e53bb838237812c140be1ff20e4"
-  integrity sha512-vyV6UTWutzvttReVRPOQz2g02YrxRO7TimM+fTi8JPFJE6sZ0GGyQlWjjpC+na4PeQQCWU4fwDi71/v3vKNrQQ==
+"@looker/eslint-config-oss@1.7.14":
+  version "1.7.14"
+  resolved "https://registry.yarnpkg.com/@looker/eslint-config-oss/-/eslint-config-oss-1.7.14.tgz#e6ea69149c5d724a6b3f50797a2594dad8da5ba9"
+  integrity sha512-cTh9EDlL3l9/lyD/h3baAs7AHoTZfKX+Oq8mUznBTNEm+EAkYtvxlo9H+shrpgoRzhaHFwUU8W1LJgvI3w/9Cg==
   dependencies:
     "@typescript-eslint/eslint-plugin" "^4.29.2"
     "@typescript-eslint/parser" "^4.31.0"
@@ -2339,6 +2339,7 @@
     eslint-plugin-i18next "^5.1.1"
     eslint-plugin-import "^2.24.1"
     eslint-plugin-jest-dom "3.9.0"
+    eslint-plugin-lodash "7.1.0"
     eslint-plugin-mdx "^1.14.1"
     eslint-plugin-node "^11.1.0"
     eslint-plugin-prettier "3.4.0"
@@ -2348,7 +2349,6 @@
     eslint-plugin-sort-keys-fix "^1.1.2"
     eslint-plugin-standard "5.0.0"
     eslint-plugin-testing-library "4.11.0"
-    prettier "^2.3.1"
     typescript "4.4.2"
 
 "@looker/extension-sdk-react@^21.4.2":
@@ -6421,6 +6421,11 @@ eslint-plugin-jest-dom@3.9.0:
     "@babel/runtime" "^7.9.6"
     "@testing-library/dom" "^7.28.1"
     requireindex "^1.2.0"
+
+eslint-plugin-lodash@7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-lodash/-/eslint-plugin-lodash-7.1.0.tgz#5ad9bf1240a01c6c3f94e956213e2d6422af3192"
+  integrity sha512-BRkEI/+ZjmeDCM1DfzR+NVwYkC/+ChJhaOSm3Xm7rer/fs89TKU6AMtkQiDdqQel1wZ4IJM+B6hlep9xwVKaMQ==
 
 eslint-plugin-markdown@^2.2.0:
   version "2.2.1"
@@ -11909,7 +11914,7 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^2.3.1, prettier@^2.4.1:
+prettier@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.4.1.tgz#671e11c89c14a4cfc876ce564106c4a6726c9f5c"
   integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==


### PR DESCRIPTION
1. pinned to version 1.7.14 as 1.7.15 requires unsupported package.
2. overrode header rule to use a pattern for date.
3. fixed one lodash issue that arose.
4. ignored nested ternary issues. should be fixed but outside the
   scope of what I want to do with this change.

The next published version of @looker/eslint-config-oss will include
the overridden header rule so the overridden header rule can be
removed then. Will investigate the unsupported package then.
