### PR TITLE
fix: example miner github permalinks do not use `.git` in the repository name

### DIFF
--- a/examplesIndex.json
+++ b/examplesIndex.json
@@ -1,5 +1,5 @@
 {
-  "commitHash": "71f9d2a3efecdf5abc76541d2d20d31bd22c5500",
+  "commitHash": "82838d0fac84b360068411b6f2200e5cdba61bea",
   "remoteOrigin": "https://github.com/looker-open-source/sdk-codegen",
   "summaries": {
     "packages/sdk-codegen/src/codeGenerators.ts": {

--- a/examplesIndex.json
+++ b/examplesIndex.json
@@ -1,6 +1,6 @@
 {
-  "commitHash": "6654f37f120153217a1c04f1e03ed0f1ea5304d4",
-  "remoteOrigin": "https://github.com/looker-open-source/sdk-codegen.git",
+  "commitHash": "71f9d2a3efecdf5abc76541d2d20d31bd22c5500",
+  "remoteOrigin": "https://github.com/looker-open-source/sdk-codegen",
   "summaries": {
     "packages/sdk-codegen/src/codeGenerators.ts": {
       "summary": "`codeGenerators.ts`",
@@ -438,12 +438,12 @@
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 18,
-            "line": 730
+            "line": 729
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 35,
-            "line": 736
+            "line": 735
           }
         ],
         ".kt": [
@@ -593,67 +593,67 @@
           {
             "sourceFile": "packages/hackathon/src/models/Hacker.ts",
             "column": 41,
-            "line": 141
+            "line": 139
           },
           {
             "sourceFile": "packages/sdk-codegen-scripts/src/exampleMiner.spec.ts",
             "column": 40,
-            "line": 185
+            "line": 192
           },
           {
             "sourceFile": "packages/sdk-codegen-scripts/src/exampleMiner.spec.ts",
             "column": 81,
-            "line": 198
+            "line": 205
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 34,
-            "line": 325
+            "line": 326
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 34,
-            "line": 335
+            "line": 336
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 37,
-            "line": 358
+            "line": 359
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 34,
-            "line": 373
+            "line": 374
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 30,
-            "line": 378
+            "line": 379
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 34,
-            "line": 383
+            "line": 384
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 30,
-            "line": 389
+            "line": 390
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 30,
-            "line": 394
+            "line": 395
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 32,
-            "line": 939
+            "line": 938
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 30,
-            "line": 1120
+            "line": 1119
           }
         ],
         ".kt": [
@@ -689,19 +689,19 @@
           {
             "sourceFile": "csharp/sdk/3.1/methods.cs",
             "column": 17,
-            "line": 5236
+            "line": 5227
           },
           {
             "sourceFile": "csharp/sdk/4.0/methods.cs",
             "column": 17,
-            "line": 6679
+            "line": 6674
           }
         ],
         ".go": [
           {
             "sourceFile": "go/sdk/v4/methods.go",
             "column": 14,
-            "line": 5103
+            "line": 5091
           }
         ],
         ".kt": [
@@ -718,54 +718,54 @@
           {
             "sourceFile": "kotlin/src/main/com/looker/sdk/4.0/methods.kt",
             "column": 18,
-            "line": 6778
+            "line": 6723
           },
           {
             "sourceFile": "kotlin/src/main/com/looker/sdk/4.0/streams.kt",
             "column": 18,
-            "line": 6777
+            "line": 6722
           }
         ],
         ".ts": [
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 14,
-            "line": 7036
+            "line": 7031
           },
           {
             "sourceFile": "packages/sdk/src/3.1/methods.ts",
             "column": 16,
-            "line": 6590
+            "line": 6585
           },
           {
             "sourceFile": "packages/sdk/src/3.1/methodsInterface.ts",
             "column": 16,
-            "line": 4696
+            "line": 4695
           },
           {
             "sourceFile": "packages/sdk/src/3.1/streams.ts",
             "column": 16,
-            "line": 7567
+            "line": 7562
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 14,
-            "line": 8957
+            "line": 8897
           },
           {
             "sourceFile": "packages/sdk/src/4.0/methods.ts",
             "column": 16,
-            "line": 8396
+            "line": 8344
           },
           {
             "sourceFile": "packages/sdk/src/4.0/methodsInterface.ts",
             "column": 16,
-            "line": 5965
+            "line": 5893
           },
           {
             "sourceFile": "packages/sdk/src/4.0/streams.ts",
             "column": 16,
-            "line": 9643
+            "line": 9575
           },
           {
             "sourceFile": "packages/sdk-codegen/src/python.gen.spec.ts",
@@ -777,24 +777,24 @@
           {
             "sourceFile": "python/looker_sdk/sdk/api31/methods.py",
             "column": 17,
-            "line": 6652
+            "line": 6642
           },
           {
             "sourceFile": "python/looker_sdk/sdk/api40/methods.py",
             "column": 17,
-            "line": 8514
+            "line": 8480
           }
         ],
         ".swift": [
           {
             "sourceFile": "swift/looker/sdk/methods.swift",
             "column": 18,
-            "line": 7885
+            "line": 7825
           },
           {
             "sourceFile": "swift/looker/sdk/streams.swift",
             "column": 18,
-            "line": 7883
+            "line": 7823
           }
         ]
       }
@@ -806,19 +806,19 @@
           {
             "sourceFile": "csharp/sdk/3.1/methods.cs",
             "column": 7,
-            "line": 7456
+            "line": 7447
           },
           {
             "sourceFile": "csharp/sdk/4.0/methods.cs",
             "column": 7,
-            "line": 8725
+            "line": 8747
           }
         ],
         ".go": [
           {
             "sourceFile": "go/sdk/v4/methods.go",
             "column": 4,
-            "line": 6617
+            "line": 6632
           }
         ],
         ".kt": [
@@ -835,78 +835,78 @@
           {
             "sourceFile": "kotlin/src/main/com/looker/sdk/4.0/methods.kt",
             "column": 8,
-            "line": 8855
+            "line": 8800
           },
           {
             "sourceFile": "kotlin/src/main/com/looker/sdk/4.0/streams.kt",
             "column": 8,
-            "line": 8854
+            "line": 8799
           }
         ],
         ".ts": [
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 4,
-            "line": 9701
+            "line": 9696
           },
           {
             "sourceFile": "packages/sdk/src/3.1/methods.ts",
             "column": 6,
-            "line": 9118
+            "line": 9113
           },
           {
             "sourceFile": "packages/sdk/src/3.1/methodsInterface.ts",
             "column": 6,
-            "line": 6553
+            "line": 6552
           },
           {
             "sourceFile": "packages/sdk/src/3.1/streams.ts",
             "column": 6,
-            "line": 10464
+            "line": 10459
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 4,
-            "line": 11365
+            "line": 11332
           },
           {
             "sourceFile": "packages/sdk/src/4.0/methods.ts",
             "column": 6,
-            "line": 10682
+            "line": 10657
           },
           {
             "sourceFile": "packages/sdk/src/4.0/methodsInterface.ts",
             "column": 6,
-            "line": 7654
+            "line": 7582
           },
           {
             "sourceFile": "packages/sdk/src/4.0/streams.ts",
             "column": 6,
-            "line": 12253
+            "line": 12212
           }
         ],
         ".py": [
           {
             "sourceFile": "python/looker_sdk/sdk/api31/methods.py",
             "column": 7,
-            "line": 9365
+            "line": 9355
           },
           {
             "sourceFile": "python/looker_sdk/sdk/api40/methods.py",
             "column": 7,
-            "line": 11001
+            "line": 10994
           }
         ],
         ".swift": [
           {
             "sourceFile": "swift/looker/sdk/methods.swift",
             "column": 8,
-            "line": 10278
+            "line": 10218
           },
           {
             "sourceFile": "swift/looker/sdk/streams.swift",
             "column": 8,
-            "line": 10276
+            "line": 10216
           }
         ]
       }
@@ -919,6 +919,11 @@
             "sourceFile": "examples/go/get_all_dashboards.go",
             "column": 20,
             "line": 21
+          },
+          {
+            "sourceFile": "go/integration/integration_test.go",
+            "column": 22,
+            "line": 572
           }
         ]
       }
@@ -955,6 +960,11 @@
             "sourceFile": "examples/go/get_all_looks.go",
             "column": 15,
             "line": 21
+          },
+          {
+            "sourceFile": "go/integration/integration_test.go",
+            "column": 16,
+            "line": 557
           }
         ]
       }
@@ -1060,7 +1070,7 @@
           {
             "sourceFile": "packages/hackathon/src/models/Hacker.ts",
             "column": 11,
-            "line": 252
+            "line": 250
           }
         ]
       }
@@ -1104,32 +1114,32 @@
           {
             "sourceFile": "packages/hackathon/src/models/Hacker.ts",
             "column": 11,
-            "line": 258
+            "line": 256
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 8,
-            "line": 144
+            "line": 145
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 10,
-            "line": 149
+            "line": 150
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 8,
-            "line": 189
+            "line": 190
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 10,
-            "line": 193
+            "line": 194
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 8,
-            "line": 531
+            "line": 532
           }
         ],
         ".kt": [
@@ -1218,12 +1228,12 @@
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 10,
-            "line": 163
+            "line": 164
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 12,
-            "line": 476
+            "line": 477
           }
         ],
         ".swift": [
@@ -1259,12 +1269,12 @@
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 21,
-            "line": 177
+            "line": 178
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 12,
-            "line": 509
+            "line": 510
           }
         ]
       }
@@ -1320,27 +1330,27 @@
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 14,
-            "line": 760
+            "line": 759
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 14,
-            "line": 770
+            "line": 769
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 14,
-            "line": 773
+            "line": 772
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 14,
-            "line": 888
+            "line": 887
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 14,
-            "line": 891
+            "line": 890
           }
         ],
         ".swift": [
@@ -1504,17 +1514,17 @@
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 23,
-            "line": 157
+            "line": 158
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 12,
-            "line": 489
+            "line": 490
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 12,
-            "line": 500
+            "line": 501
           }
         ],
         ".swift": [
@@ -1565,47 +1575,47 @@
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 36,
-            "line": 213
+            "line": 214
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 42,
-            "line": 272
+            "line": 273
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 35,
-            "line": 659
+            "line": 658
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 12,
-            "line": 661
+            "line": 660
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 33,
-            "line": 679
+            "line": 678
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 18,
-            "line": 702
+            "line": 701
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 12,
-            "line": 709
+            "line": 708
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 32,
-            "line": 929
+            "line": 928
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 38,
-            "line": 954
+            "line": 953
           }
         ],
         ".kt": [
@@ -1820,22 +1830,22 @@
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 35,
-            "line": 264
+            "line": 265
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 34,
-            "line": 408
+            "line": 409
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 8,
-            "line": 420
+            "line": 421
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 10,
-            "line": 441
+            "line": 442
           }
         ],
         ".swift": [
@@ -2080,12 +2090,12 @@
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 10,
-            "line": 354
+            "line": 355
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 33,
-            "line": 565
+            "line": 564
           }
         ],
         ".kt": [
@@ -2206,7 +2216,7 @@
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 35,
-            "line": 437
+            "line": 438
           }
         ],
         ".swift": [
@@ -2483,17 +2493,17 @@
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 37,
-            "line": 754
+            "line": 753
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 10,
-            "line": 874
+            "line": 873
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 12,
-            "line": 948
+            "line": 947
           }
         ],
         ".swift": [
@@ -2743,12 +2753,12 @@
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 36,
-            "line": 828
+            "line": 827
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 35,
-            "line": 839
+            "line": 838
           }
         ]
       }
@@ -2777,12 +2787,12 @@
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 12,
-            "line": 1013
+            "line": 1012
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 12,
-            "line": 1021
+            "line": 1020
           }
         ]
       }
@@ -3047,7 +3057,7 @@
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 28,
-            "line": 178
+            "line": 179
           }
         ],
         ".py": [
@@ -3428,12 +3438,22 @@
           {
             "sourceFile": "go/integration/integration_test.go",
             "column": 15,
-            "line": 108
+            "line": 170
           },
           {
             "sourceFile": "go/integration/integration_test.go",
             "column": 14,
-            "line": 120
+            "line": 182
+          },
+          {
+            "sourceFile": "go/integration/integration_test.go",
+            "column": 11,
+            "line": 321
+          },
+          {
+            "sourceFile": "go/integration/integration_test.go",
+            "column": 11,
+            "line": 410
           }
         ]
       }
@@ -3457,7 +3477,7 @@
           {
             "sourceFile": "go/integration/integration_test.go",
             "column": 15,
-            "line": 25
+            "line": 87
           }
         ]
       }
@@ -3469,7 +3489,7 @@
           {
             "sourceFile": "go/integration/integration_test.go",
             "column": 14,
-            "line": 50
+            "line": 112
           }
         ]
       }
@@ -3481,7 +3501,7 @@
           {
             "sourceFile": "go/integration/integration_test.go",
             "column": 14,
-            "line": 72
+            "line": 134
           }
         ]
       }
@@ -3493,7 +3513,7 @@
           {
             "sourceFile": "go/integration/integration_test.go",
             "column": 15,
-            "line": 95
+            "line": 157
           }
         ]
       }
@@ -3505,17 +3525,17 @@
           {
             "sourceFile": "go/integration/integration_test.go",
             "column": 18,
-            "line": 132
+            "line": 194
           },
           {
             "sourceFile": "go/integration/integration_test.go",
             "column": 17,
-            "line": 152
+            "line": 214
           },
           {
             "sourceFile": "go/integration/integration_test.go",
             "column": 17,
-            "line": 172
+            "line": 234
           }
         ]
       }
@@ -3527,12 +3547,215 @@
           {
             "sourceFile": "go/integration/integration_test.go",
             "column": 11,
-            "line": 144
+            "line": 206
           },
           {
             "sourceFile": "go/integration/integration_test.go",
             "column": 11,
-            "line": 164
+            "line": 226
+          }
+        ]
+      }
+    },
+    "CreateQuery": {
+      "operationId": "CreateQuery",
+      "calls": {
+        ".go": [
+          {
+            "sourceFile": "go/integration/integration_test.go",
+            "column": 17,
+            "line": 247
+          },
+          {
+            "sourceFile": "go/integration/integration_test.go",
+            "column": 17,
+            "line": 324
+          },
+          {
+            "sourceFile": "go/integration/integration_test.go",
+            "column": 17,
+            "line": 501
+          }
+        ]
+      }
+    },
+    "RunQuery": {
+      "operationId": "RunQuery",
+      "calls": {
+        ".go": [
+          {
+            "sourceFile": "go/integration/integration_test.go",
+            "column": 15,
+            "line": 253
+          },
+          {
+            "sourceFile": "go/integration/integration_test.go",
+            "column": 22,
+            "line": 266
+          },
+          {
+            "sourceFile": "go/integration/integration_test.go",
+            "column": 12,
+            "line": 285
+          }
+        ]
+      }
+    },
+    "RunInlineQuery": {
+      "operationId": "RunInlineQuery",
+      "calls": {
+        ".go": [
+          {
+            "sourceFile": "go/integration/integration_test.go",
+            "column": 22,
+            "line": 298
+          }
+        ]
+      }
+    },
+    "CreateLook": {
+      "operationId": "CreateLook",
+      "calls": {
+        ".go": [
+          {
+            "sourceFile": "go/integration/integration_test.go",
+            "column": 16,
+            "line": 331
+          }
+        ]
+      }
+    },
+    "Look": {
+      "operationId": "Look",
+      "calls": {
+        ".go": [
+          {
+            "sourceFile": "go/integration/integration_test.go",
+            "column": 18,
+            "line": 362
+          },
+          {
+            "sourceFile": "go/integration/integration_test.go",
+            "column": 18,
+            "line": 402
+          }
+        ]
+      }
+    },
+    "UpdateLook": {
+      "operationId": "UpdateLook",
+      "calls": {
+        ".go": [
+          {
+            "sourceFile": "go/integration/integration_test.go",
+            "column": 23,
+            "line": 375
+          }
+        ]
+      }
+    },
+    "DeleteLook": {
+      "operationId": "DeleteLook",
+      "calls": {
+        ".go": [
+          {
+            "sourceFile": "go/integration/integration_test.go",
+            "column": 13,
+            "line": 392
+          }
+        ]
+      }
+    },
+    "CreateDashboard": {
+      "operationId": "CreateDashboard",
+      "calls": {
+        ".go": [
+          {
+            "sourceFile": "go/integration/integration_test.go",
+            "column": 21,
+            "line": 415
+          }
+        ]
+      }
+    },
+    "Dashboard": {
+      "operationId": "Dashboard",
+      "calls": {
+        ".go": [
+          {
+            "sourceFile": "go/integration/integration_test.go",
+            "column": 23,
+            "line": 435
+          },
+          {
+            "sourceFile": "go/integration/integration_test.go",
+            "column": 23,
+            "line": 547
+          }
+        ]
+      }
+    },
+    "UpdateDashboard": {
+      "operationId": "UpdateDashboard",
+      "calls": {
+        ".go": [
+          {
+            "sourceFile": "go/integration/integration_test.go",
+            "column": 28,
+            "line": 447
+          }
+        ]
+      }
+    },
+    "CreateDashboardFilter": {
+      "operationId": "CreateDashboardFilter",
+      "calls": {
+        ".go": [
+          {
+            "sourceFile": "go/integration/integration_test.go",
+            "column": 19,
+            "line": 465
+          }
+        ]
+      }
+    },
+    "CreateDashboardElement": {
+      "operationId": "CreateDashboardElement",
+      "calls": {
+        ".go": [
+          {
+            "sourceFile": "go/integration/integration_test.go",
+            "column": 17,
+            "line": 508
+          }
+        ]
+      }
+    },
+    "DeleteDashboard": {
+      "operationId": "DeleteDashboard",
+      "calls": {
+        ".go": [
+          {
+            "sourceFile": "go/integration/integration_test.go",
+            "column": 13,
+            "line": 537
+          }
+        ]
+      }
+    },
+    "ContentThumbnail": {
+      "operationId": "ContentThumbnail",
+      "calls": {
+        ".go": [
+          {
+            "sourceFile": "go/integration/integration_test.go",
+            "column": 16,
+            "line": 590
+          },
+          {
+            "sourceFile": "go/integration/integration_test.go",
+            "column": 15,
+            "line": 607
           }
         ]
       }
@@ -3556,7 +3779,7 @@
           {
             "sourceFile": "packages/sdk-codegen-scripts/src/exampleMiner.spec.ts",
             "column": 37,
-            "line": 191
+            "line": 198
           },
           {
             "sourceFile": "packages/sdk-rtl/src/apiMethods.ts",
@@ -3571,7 +3794,7 @@
           {
             "sourceFile": "packages/sdk-rtl/src/transport.ts",
             "column": 25,
-            "line": 508
+            "line": 516
           }
         ],
         ".py": [
@@ -3602,7 +3825,7 @@
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 12,
-            "line": 957
+            "line": 956
           }
         ],
         ".py": [
@@ -3740,7 +3963,7 @@
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 34,
-            "line": 303
+            "line": 304
           }
         ],
         ".py": [
@@ -3800,7 +4023,7 @@
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 40,
-            "line": 620
+            "line": 619
           }
         ],
         ".swift": [
@@ -4288,7 +4511,7 @@
           {
             "sourceFile": "packages/hackathon/src/models/Hacker.ts",
             "column": 43,
-            "line": 314
+            "line": 312
           }
         ],
         ".swift": [
@@ -4502,7 +4725,7 @@
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 10,
-            "line": 237
+            "line": 238
           }
         ]
       }
@@ -4521,7 +4744,7 @@
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 21,
-            "line": 249
+            "line": 250
           }
         ]
       }
@@ -4540,12 +4763,12 @@
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 10,
-            "line": 282
+            "line": 283
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 10,
-            "line": 287
+            "line": 288
           }
         ],
         ".py": [
@@ -4583,12 +4806,12 @@
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 23,
-            "line": 202
+            "line": 203
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 38,
-            "line": 512
+            "line": 513
           }
         ],
         ".py": [
@@ -4636,12 +4859,12 @@
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 37,
-            "line": 301
+            "line": 302
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 39,
-            "line": 313
+            "line": 314
           }
         ],
         ".py": [
@@ -4684,12 +4907,12 @@
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 12,
-            "line": 309
+            "line": 310
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 23,
-            "line": 315
+            "line": 316
           }
         ],
         ".py": [
@@ -4732,1052 +4955,1057 @@
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 458
+            "line": 459
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 662
+            "line": 663
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 712
+            "line": 713
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 780
+            "line": 781
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 856
+            "line": 857
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 906
+            "line": 907
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 1022
+            "line": 1023
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 1063
+            "line": 1064
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 1086
+            "line": 1087
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 1154
+            "line": 1155
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 1213
+            "line": 1214
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 1241
+            "line": 1242
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 1266
+            "line": 1267
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 1327
+            "line": 1328
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 1412
+            "line": 1413
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 1458
+            "line": 1459
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 1502
+            "line": 1503
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 1571
+            "line": 1572
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 1638
+            "line": 1639
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 1684
+            "line": 1685
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 1728
+            "line": 1729
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 1751
+            "line": 1752
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 1798
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 1839
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 1857
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 1876
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 1928
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 1977
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 2144
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 2192
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 2228
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 2299
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 2324
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 2374
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 2478
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 2509
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 2553
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 2603
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 2636
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 2723
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 2851
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 2942
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 2968
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 3014
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 3048
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 3126
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 3175
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 3253
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 3304
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 3360
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 3386
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 3464
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 3564
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 3583
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 3637
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 3661
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 3686
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 3715
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 3741
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 3768
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 3807
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 3886
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 3931
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 3960
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 3986
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 4012
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 4040
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 4066
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 4093
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 4172
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 4208
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 4278
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 4326
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 4491
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 4559
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 4600
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 4679
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 4737
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 4816
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 4870
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 4947
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 4974
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 5026
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 5124
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 5150
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 5261
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 5336
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 5379
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 5493
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 5533
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 5582
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 5661
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 5691
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 5717
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 5813
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 5986
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 6038
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 6113
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 6139
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 6208
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 6270
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 6298
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 6328
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 6363
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 6396
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 6426
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 6452
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 6574
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 6649
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 6681
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 6727
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 6768
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 6810
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 6889
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 7075
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 7103
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 7165
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 7213
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 7444
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 7487
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 7535
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 7570
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 7641
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 7680
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 7719
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 7754
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 7825
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 7871
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 7940
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 7972
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 8035
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 8083
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 8142
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 8169
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 8295
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 8471
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 8508
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 8546
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 8648
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 8742
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 8783
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 8863
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 8912
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 8943
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 8971
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 8999
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 9029
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 9057
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 9090
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 9182
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 9221
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 9280
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 9310
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 9369
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 9451
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 9469
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 9552
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 9596
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 9636
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 9734
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 9759
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 9861
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 9936
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 9984
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 10032
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 10080
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 10130
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 10180
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 10234
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 10284
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 10309
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 10359
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 10409
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 10463
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 10531
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 10622
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 10681
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 10762
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 10835
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 10882
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 326
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 361
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 817
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 1018
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 1046
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 1270
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 1320
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 1388
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 1464
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 1514
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 1630
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 1673
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
             "line": 1797
           },
           {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 1838
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 1856
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 1875
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 1927
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 1976
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 2143
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 2191
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 2227
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 2298
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 2323
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 2373
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 2477
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 2508
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 2552
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 2602
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 2635
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 2722
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 2852
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 2943
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 2969
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 3015
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 3049
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 3127
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 3178
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 3256
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 3307
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 3363
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 3389
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 3467
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 3567
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 3586
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 3640
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 3664
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 3689
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 3718
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 3744
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 3771
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 3810
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 3889
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 3934
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 3963
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 3989
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 4015
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 4043
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 4069
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 4096
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 4175
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 4211
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 4281
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 4329
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 4494
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 4562
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 4603
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 4682
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 4740
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 4819
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 4873
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 4950
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 4977
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 5029
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 5127
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 5153
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 5264
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 5339
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 5384
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 5498
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 5538
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 5587
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 5666
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 5696
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 5722
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 5818
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 5991
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 6043
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 6118
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 6144
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 6213
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 6275
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 6303
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 6333
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 6368
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 6401
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 6431
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 6457
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 6579
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 6654
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 6686
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 6732
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 6773
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 6815
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 6894
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 7080
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 7108
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 7170
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 7218
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 7449
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 7492
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 7540
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 7575
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 7646
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 7685
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 7724
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 7759
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 7830
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 7876
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 7945
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 7977
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 8040
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 8088
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 8147
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 8174
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 8300
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 8476
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 8513
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 8551
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 8653
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 8747
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 8788
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 8868
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 8917
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 8948
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 8976
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 9004
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 9034
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 9062
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 9095
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 9187
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 9226
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 9285
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 9315
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 9374
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 9456
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 9474
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 9557
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 9601
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 9641
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 9739
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 9764
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 9866
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 9941
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 9989
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 10037
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 10085
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 10135
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 10185
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 10239
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 10289
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 10314
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 10364
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 10414
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 10468
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 10536
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 10627
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 10686
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 10767
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 10840
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 10887
+            "line": 1820
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 329
+            "line": 1843
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 363
+            "line": 1906
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 813
+            "line": 1970
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 1014
+            "line": 2010
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 1042
+            "line": 2080
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 1264
+            "line": 2135
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 1314
+            "line": 2210
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 1382
+            "line": 2261
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 1458
+            "line": 2347
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 1508
+            "line": 2406
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 1624
+            "line": 2434
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 1667
+            "line": 2459
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 1791
+            "line": 2520
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 1814
+            "line": 2603
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 1837
+            "line": 2649
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 1898
+            "line": 2720
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 1962
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 2001
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 2069
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 2123
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 2196
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 2246
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 2330
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 2389
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 2417
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 2442
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 2503
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 2588
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 2693
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 2739
+            "line": 2789
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
@@ -5787,7 +6015,7 @@
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 2879
+            "line": 2856
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
@@ -5797,477 +6025,472 @@
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 2946
+            "line": 2924
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 2990
+            "line": 2971
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 3014
+            "line": 2987
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 3061
+            "line": 3018
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 3077
+            "line": 3101
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 3108
+            "line": 3117
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 3191
+            "line": 3135
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 3207
+            "line": 3159
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 3225
+            "line": 3185
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 3249
+            "line": 3239
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 3275
+            "line": 3288
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 3329
+            "line": 3455
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 3378
+            "line": 3480
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 3545
+            "line": 3556
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 3570
+            "line": 3603
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 3646
+            "line": 3677
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 3693
+            "line": 3700
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 3767
+            "line": 3747
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 3790
+            "line": 3821
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 3837
+            "line": 3844
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 3911
+            "line": 3887
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 3934
+            "line": 3925
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 3977
+            "line": 3997
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 4014
+            "line": 4023
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 4085
+            "line": 4074
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 4110
+            "line": 4180
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 4160
+            "line": 4211
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 4265
+            "line": 4255
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 4296
+            "line": 4305
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 4340
+            "line": 4338
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 4390
+            "line": 4425
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 4423
+            "line": 4555
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 4510
+            "line": 4646
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 4640
+            "line": 4672
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 4731
+            "line": 4815
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 4757
+            "line": 4849
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 4900
+            "line": 4927
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 4934
+            "line": 4976
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 5012
+            "line": 5054
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 5063
+            "line": 5105
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 5141
+            "line": 5161
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 5192
+            "line": 5187
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 5248
+            "line": 5265
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 5274
+            "line": 5365
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 5352
+            "line": 5384
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 5452
+            "line": 5438
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 5470
+            "line": 5462
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 5523
+            "line": 5487
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 5547
+            "line": 5516
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 5572
+            "line": 5542
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 5601
+            "line": 5569
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 5627
+            "line": 5608
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 5654
+            "line": 5687
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 5693
+            "line": 5732
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 5772
+            "line": 5761
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 5817
+            "line": 5787
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 5846
+            "line": 5813
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 5872
+            "line": 5841
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 5898
+            "line": 5867
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 5926
+            "line": 5894
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 5952
+            "line": 5975
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 5979
+            "line": 6032
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 6058
+            "line": 6090
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 6115
+            "line": 6127
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 6173
+            "line": 6200
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 6209
+            "line": 6250
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 6279
+            "line": 6424
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 6327
+            "line": 6451
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 6490
+            "line": 6504
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 6517
+            "line": 6605
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 6569
+            "line": 6631
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 6667
+            "line": 6742
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 6693
+            "line": 6817
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 6804
+            "line": 6864
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 6879
+            "line": 6981
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 6926
+            "line": 7084
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 7043
+            "line": 7133
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 7146
+            "line": 7212
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 7195
+            "line": 7260
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 7274
+            "line": 7284
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 7322
+            "line": 7311
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 7346
+            "line": 7339
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 7373
+            "line": 7363
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 7401
+            "line": 7396
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 7425
+            "line": 7427
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 7458
+            "line": 7460
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 7489
+            "line": 7554
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 7522
+            "line": 7580
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 7616
+            "line": 7676
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 7642
+            "line": 7849
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 7738
+            "line": 7901
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 7911
+            "line": 7976
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 7963
+            "line": 8002
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 8038
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 8064
+            "line": 8071
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
@@ -6277,327 +6500,322 @@
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 8195
+            "line": 8161
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 8223
+            "line": 8191
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 8253
+            "line": 8226
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 8288
+            "line": 8259
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 8321
+            "line": 8289
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 8351
+            "line": 8315
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 8377
+            "line": 8437
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 8499
+            "line": 8512
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 8574
+            "line": 8544
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 8606
+            "line": 8590
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 8652
+            "line": 8632
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 8693
+            "line": 8674
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 8735
+            "line": 8754
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 8814
+            "line": 8941
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 9001
+            "line": 8969
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 9029
+            "line": 9031
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 9091
+            "line": 9079
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 9139
+            "line": 9275
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 9333
+            "line": 9318
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 9376
+            "line": 9403
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 9461
+            "line": 9439
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 9496
+            "line": 9512
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 9567
+            "line": 9551
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 9606
+            "line": 9590
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 9645
+            "line": 9626
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 9680
+            "line": 9699
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 9751
+            "line": 9745
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 9797
+            "line": 9814
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 9866
+            "line": 9870
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 9922
+            "line": 9903
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 9954
+            "line": 9969
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 10017
+            "line": 10019
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 10065
+            "line": 10080
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 10124
+            "line": 10108
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 10151
+            "line": 10236
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 10277
+            "line": 10413
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 10453
+            "line": 10451
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 10490
+            "line": 10489
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 10528
+            "line": 10592
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 10630
+            "line": 10662
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 10700
+            "line": 10754
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 10792
+            "line": 10793
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 10831
+            "line": 10852
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 10890
+            "line": 10882
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 10920
+            "line": 10941
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 10978
+            "line": 11046
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 11082
+            "line": 11078
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 11114
+            "line": 11096
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 11132
+            "line": 11181
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 11217
+            "line": 11227
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 11263
+            "line": 11270
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 11305
+            "line": 11370
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 11403
+            "line": 11396
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 11428
+            "line": 11502
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 11530
+            "line": 11580
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 11605
+            "line": 11630
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 11653
+            "line": 11680
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 11701
+            "line": 11730
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 11749
+            "line": 11783
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 11799
+            "line": 11836
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 11849
+            "line": 11891
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 11901
+            "line": 11944
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 11951
+            "line": 11970
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 11976
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 12026
+            "line": 12023
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
@@ -6607,37 +6825,37 @@
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 12130
+            "line": 12132
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 12198
+            "line": 12202
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 12370
+            "line": 12380
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 12429
+            "line": 12440
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 12510
+            "line": 12524
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 12583
+            "line": 12598
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 12630
+            "line": 12645
           },
           {
             "sourceFile": "packages/sdk-codegen/src/specConverter.ts",
@@ -6953,8 +7171,8 @@
         ".ts": [
           {
             "sourceFile": "packages/hackathon/src/models/Hacker.ts",
-            "column": 8,
-            "line": 117
+            "column": 33,
+            "line": 116
           }
         ]
       }
@@ -6966,7 +7184,7 @@
           {
             "sourceFile": "packages/hackathon/src/models/Hacker.ts",
             "column": 13,
-            "line": 144
+            "line": 142
           }
         ]
       }
@@ -6978,17 +7196,17 @@
           {
             "sourceFile": "packages/hackathon/src/models/Hacker.ts",
             "column": 15,
-            "line": 319
+            "line": 317
           },
           {
             "sourceFile": "packages/hackathon/src/models/Hacker.ts",
             "column": 15,
-            "line": 329
+            "line": 327
           },
           {
             "sourceFile": "packages/hackathon/src/models/Hacker.ts",
             "column": 15,
-            "line": 339
+            "line": 337
           }
         ]
       }
@@ -7000,777 +7218,772 @@
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 306
+            "line": 307
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 346
+            "line": 347
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 422
+            "line": 423
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 759
+            "line": 760
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 953
+            "line": 954
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 976
+            "line": 977
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 1001
+            "line": 1002
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 1185
+            "line": 1186
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 1617
+            "line": 1618
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 1817
+            "line": 1818
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 1950
+            "line": 1951
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 2273
+            "line": 2274
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 2398
+            "line": 2399
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 2671
+            "line": 2672
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 2784
+            "line": 2783
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 3152
+            "line": 3149
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 3281
+            "line": 3278
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 3492
+            "line": 3489
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 3519
+            "line": 3516
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 3542
+            "line": 3539
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 3910
+            "line": 3907
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 4129
+            "line": 4126
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 4306
+            "line": 4303
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 4359
+            "line": 4356
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 4516
+            "line": 4513
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 4713
+            "line": 4710
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 4846
+            "line": 4843
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 5004
+            "line": 5001
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 5104
+            "line": 5101
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 5207
+            "line": 5204
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 5231
+            "line": 5228
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 5287
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 5556
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 5784
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 5874
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 5909
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 5935
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 5961
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 6010
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 6171
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 6242
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 6478
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 6606
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 6842
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 6978
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 7144
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 7233
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 7265
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 7302
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 7344
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 7380
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 7408
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 7659
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 7848
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 7894
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 8379
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 8438
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 8621
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 8886
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 9122
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 9339
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 9500
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 9786
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 9888
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 10207
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 10440
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 10656
+          },
+          {
+            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
+            "column": 9,
+            "line": 10808
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 488
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 514
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 568
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 609
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 654
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 734
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 781
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 1079
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 1200
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 1367
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 1561
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 1584
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 1609
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 1700
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 1926
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 2109
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 2235
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 2378
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 2766
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 3078
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 3262
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 3507
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 3535
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 3579
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 3723
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 3972
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 4099
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 4374
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 4487
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 4735
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 4769
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 4950
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
+            "column": 9,
+            "line": 5079
+          },
+          {
+            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
             "line": 5290
           },
           {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 5561
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 5789
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 5879
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 5914
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 5940
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 5966
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 6015
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 6176
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 6247
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 6483
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 6611
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 6847
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 6983
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 7149
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 7238
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 7270
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 7307
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 7349
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 7385
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 7413
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 7664
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 7853
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 7899
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 8384
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 8443
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 8626
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 8891
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 9127
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 9344
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 9505
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 9791
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 9893
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 10212
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 10445
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 10661
-          },
-          {
-            "sourceFile": "packages/sdk/src/3.1/funcs.ts",
-            "column": 9,
-            "line": 10813
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 487
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 512
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 566
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 606
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 651
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 730
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 777
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 1075
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 1195
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 1361
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 1555
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 1578
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 1603
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 1694
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 1918
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 2098
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 2221
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 2361
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 2618
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 2856
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 3168
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 3352
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 3597
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 3625
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 3669
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 3813
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 4060
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 4185
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 4459
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 4572
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 4820
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 4854
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 5037
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 5166
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 5377
-          },
-          {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 5404
+            "line": 5317
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 5427
+            "line": 5340
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 5793
+            "line": 5708
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 6012
+            "line": 5929
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 6304
+            "line": 6226
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 6357
+            "line": 6283
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 6544
+            "line": 6478
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 6644
+            "line": 6582
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 6747
+            "line": 6685
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 6771
+            "line": 6709
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 6830
+            "line": 6768
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 7088
+            "line": 7026
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 7169
+            "line": 7107
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 7554
+            "line": 7492
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 7590
+            "line": 7528
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 7709
+            "line": 7647
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 7799
+            "line": 7737
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 7834
+            "line": 7772
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 7860
+            "line": 7798
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 7886
+            "line": 7824
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 7935
+            "line": 7873
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 8096
+            "line": 8034
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 8167
+            "line": 8105
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 8403
+            "line": 8341
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 8531
+            "line": 8469
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 8767
+            "line": 8706
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 8904
+            "line": 8844
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 9070
+            "line": 9010
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 9159
+            "line": 9099
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 9191
+            "line": 9131
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 9231
+            "line": 9172
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 9267
+            "line": 9209
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 9296
+            "line": 9238
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 9413
+            "line": 9355
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 9585
+            "line": 9530
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 9774
+            "line": 9722
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 9820
+            "line": 9768
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 10361
+            "line": 10320
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 10420
+            "line": 10379
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 10603
+            "line": 10565
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 10732
+            "line": 10694
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 10949
+            "line": 10911
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 11165
+            "line": 11129
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 11455
+            "line": 11424
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 11557
+            "line": 11530
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 11874
+            "line": 11862
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 12107
+            "line": 12108
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 12293
+            "line": 12302
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 12325
+            "line": 12335
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 12348
+            "line": 12358
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 12404
+            "line": 12414
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 12556
+            "line": 12571
           },
           {
             "sourceFile": "packages/sdk-codegen/src/typescript.gen.spec.ts",
@@ -7787,502 +8000,497 @@
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 367
+            "line": 368
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 736
+            "line": 737
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 930
+            "line": 931
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 1120
+            "line": 1121
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 1385
+            "line": 1386
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 2026
+            "line": 2027
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 2053
+            "line": 2054
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 2250
+            "line": 2251
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 2446
+            "line": 2447
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 2917
+            "line": 2916
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 3101
+            "line": 3100
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 3230
+            "line": 3227
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 3441
+            "line": 3438
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 3861
+            "line": 3858
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 4261
+            "line": 4258
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 4384
+            "line": 4381
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 4409
+            "line": 4406
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 4465
+            "line": 4462
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 4657
+            "line": 4654
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 4794
+            "line": 4791
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 4927
+            "line": 4924
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 5081
+            "line": 5078
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 5459
+            "line": 5454
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 5637
+            "line": 5632
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 5847
+            "line": 5842
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 6553
+            "line": 6548
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 7194
+            "line": 7189
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 7623
+            "line": 7618
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 7807
+            "line": 7802
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 8020
+            "line": 8015
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 8267
+            "line": 8262
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 8843
+            "line": 8838
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 9434
+            "line": 9429
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 9688
+            "line": 9683
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 9841
+            "line": 9836
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 9916
+            "line": 9911
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 9964
+            "line": 9959
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 10012
+            "line": 10007
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 10060
+            "line": 10055
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 10108
+            "line": 10103
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 10160
+            "line": 10155
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 10264
+            "line": 10259
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 10337
+            "line": 10332
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 10389
+            "line": 10384
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 10600
+            "line": 10595
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 10736
+            "line": 10731
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 435
+            "line": 436
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 627
+            "line": 630
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 674
+            "line": 678
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 1134
+            "line": 1138
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 1161
+            "line": 1165
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 1232
+            "line": 1238
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 1338
+            "line": 1344
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 1532
+            "line": 1538
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 1720
+            "line": 1726
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 1871
+            "line": 1879
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 2051
+            "line": 2062
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 2173
+            "line": 2187
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 2296
+            "line": 2313
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 2561
+            "line": 2578
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 2668
+            "line": 3338
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 3428
+            "line": 3365
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 3455
+            "line": 3653
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 3743
+            "line": 3797
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 3887
+            "line": 3949
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 4037
+            "line": 4149
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 4234
+            "line": 4620
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 4705
+            "line": 4901
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 4986
+            "line": 5028
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 5115
+            "line": 5239
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 5326
+            "line": 5659
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 5744
+            "line": 6179
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 6259
+            "line": 6310
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 6382
+            "line": 6337
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 6407
+            "line": 6397
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 6463
+            "line": 6558
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 6621
+            "line": 6941
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 7003
+            "line": 7183
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 7245
+            "line": 7705
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 7767
+            "line": 8411
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 8473
+            "line": 9055
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 9115
+            "line": 9489
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 9544
+            "line": 9676
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 9728
+            "line": 9948
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 9997
+            "line": 10203
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 10244
+            "line": 11001
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 11037
+            "line": 11319
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 11352
+            "line": 11476
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 11505
+            "line": 11554
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 11580
+            "line": 11604
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 11628
+            "line": 11654
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 11676
+            "line": 11704
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 11724
+            "line": 11754
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 11772
+            "line": 11810
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 11824
+            "line": 11918
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 11926
+            "line": 11994
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 11999
+            "line": 12050
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 12051
+            "line": 12270
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 12262
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 12479
+            "line": 12492
           }
         ]
       }
@@ -8294,222 +8502,222 @@
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 486
+            "line": 487
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 688
+            "line": 689
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 803
+            "line": 804
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 882
+            "line": 883
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 1040
+            "line": 1041
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 1354
+            "line": 1355
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 1437
+            "line": 1438
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 1481
+            "line": 1482
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 1527
+            "line": 1528
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 1594
+            "line": 1595
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 1663
+            "line": 1664
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 1707
+            "line": 1708
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 1776
+            "line": 1777
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 2002
+            "line": 2003
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 2348
+            "line": 2349
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 2820
+            "line": 2819
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 2887
+            "line": 2886
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 3077
+            "line": 3076
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 3206
+            "line": 3203
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 3337
+            "line": 3334
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 3417
+            "line": 3414
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 3612
+            "line": 3609
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 3836
+            "line": 3833
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 4238
+            "line": 4235
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 4440
+            "line": 4437
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 4632
+            "line": 4629
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 4769
+            "line": 4766
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 4902
+            "line": 4899
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 5058
+            "line": 5055
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 5181
+            "line": 5178
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 5430
+            "line": 5425
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 5613
+            "line": 5608
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 6092
+            "line": 6087
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 7600
+            "line": 7595
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 7784
+            "line": 7779
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 7997
+            "line": 7992
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 8240
+            "line": 8235
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 8690
+            "line": 8685
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 8816
+            "line": 8811
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 9402
+            "line": 9397
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 9663
+            "line": 9658
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 9818
+            "line": 9813
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 10570
+            "line": 10565
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 10713
+            "line": 10708
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
@@ -8519,247 +8727,242 @@
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 841
+            "line": 845
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 1105
+            "line": 1109
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 1290
+            "line": 1296
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 1405
+            "line": 1411
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 1484
+            "line": 1490
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 1642
+            "line": 1648
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 2028
+            "line": 2038
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 2150
+            "line": 2163
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 2273
+            "line": 2289
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 2530
+            "line": 2547
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 2645
+            "line": 2626
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 2716
+            "line": 2676
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 2766
+            "line": 2743
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 2833
+            "line": 2835
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 2925
+            "line": 2879
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 2969
+            "line": 2950
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 3040
+            "line": 3053
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 3143
+            "line": 3314
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 3404
+            "line": 3629
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 3719
+            "line": 3773
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 3863
+            "line": 4049
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 4135
+            "line": 4523
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 4608
+            "line": 4590
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 4675
+            "line": 4703
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 4788
+            "line": 4877
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 4962
+            "line": 5004
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 5091
+            "line": 5135
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 5222
+            "line": 5215
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 5302
+            "line": 5410
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 5495
+            "line": 5634
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 5719
+            "line": 6155
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 6236
+            "line": 6370
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 6438
+            "line": 6534
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 6598
+            "line": 6659
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 6721
+            "line": 6911
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 6973
+            "line": 7057
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 7119
+            "line": 7159
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 7221
+            "line": 7950
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 8012
+            "line": 9465
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 9521
+            "line": 9652
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 9705
+            "line": 9924
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 9974
+            "line": 10175
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 10217
+            "line": 10629
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 10667
+            "line": 10969
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 11005
+            "line": 11293
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 11327
+            "line": 11452
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 11482
+            "line": 12238
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 12232
-          },
-          {
-            "sourceFile": "packages/sdk/src/4.0/funcs.ts",
-            "column": 9,
-            "line": 12456
+            "line": 12468
           }
         ]
       }
@@ -8771,187 +8974,187 @@
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 526
+            "line": 527
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 568
+            "line": 569
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 599
+            "line": 600
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 630
+            "line": 631
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 824
+            "line": 825
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 1292
+            "line": 1293
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 1550
+            "line": 1551
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 1900
+            "line": 1901
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 2088
+            "line": 2089
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 2120
+            "line": 2121
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 2423
+            "line": 2424
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 5756
+            "line": 5751
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 6521
+            "line": 6516
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 8065
+            "line": 8060
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 8116
+            "line": 8111
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 9254
+            "line": 9249
           },
           {
             "sourceFile": "packages/sdk/src/3.1/funcs.ts",
             "column": 9,
-            "line": 10498
+            "line": 10493
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 385
+            "line": 384
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 881
+            "line": 885
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 923
+            "line": 927
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 954
+            "line": 958
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 985
+            "line": 989
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 1426
+            "line": 1432
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 1745
+            "line": 1751
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 1768
+            "line": 1774
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 2468
+            "line": 2485
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 2789
+            "line": 2699
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 3302
+            "line": 3212
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 3490
+            "line": 3400
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 3522
+            "line": 3432
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 4211
+            "line": 4125
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 7676
+            "line": 7614
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 8441
+            "line": 8379
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 10042
+            "line": 9995
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 10093
+            "line": 10048
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 10859
+            "line": 10821
           },
           {
             "sourceFile": "packages/sdk/src/4.0/funcs.ts",
             "column": 9,
-            "line": 12160
+            "line": 12163
           }
         ]
       }
@@ -9043,7 +9246,7 @@
           {
             "sourceFile": "packages/sdk-codegen-scripts/src/exampleMiner.spec.ts",
             "column": 35,
-            "line": 198
+            "line": 205
           }
         ]
       }
@@ -9067,7 +9270,7 @@
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 23,
-            "line": 216
+            "line": 217
           }
         ]
       }
@@ -9079,22 +9282,22 @@
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 10,
-            "line": 542
+            "line": 543
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 10,
-            "line": 557
+            "line": 558
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 10,
-            "line": 587
+            "line": 586
           },
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 10,
-            "line": 598
+            "line": 597
           }
         ],
         ".py": [
@@ -9133,7 +9336,7 @@
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
             "column": 14,
-            "line": 1028
+            "line": 1027
           }
         ],
         ".py": [
@@ -9151,8 +9354,8 @@
         ".ts": [
           {
             "sourceFile": "packages/sdk-node/test/methods.spec.ts",
-            "column": 14,
-            "line": 1057
+            "column": 38,
+            "line": 1077
           }
         ],
         ".py": [

--- a/packages/sdk-codegen-scripts/src/exampleMiner.spec.ts
+++ b/packages/sdk-codegen-scripts/src/exampleMiner.spec.ts
@@ -35,6 +35,7 @@ import {
   getRemoteHttpOrigin,
   MarkdownMiner,
   ExampleMiner,
+  getPermalinkRoot,
 } from './exampleMiner'
 
 describe('example mining', () => {
@@ -77,6 +78,12 @@ describe('example mining', () => {
       expect(
         actual.startsWith('https://github.com/looker-open-source/sdk-codegen')
       ).toEqual(true)
+    })
+    it('getPermalinkRoot', () => {
+      const actual = getPermalinkRoot()
+      expect(actual).toEqual(
+        'https://github.com/looker-open-source/sdk-codegen'
+      )
     })
   })
 

--- a/packages/sdk-codegen-scripts/src/exampleMiner.ts
+++ b/packages/sdk-codegen-scripts/src/exampleMiner.ts
@@ -170,6 +170,13 @@ export const getRemoteHttpOrigin = () => {
   return `https://github.com/${match[1]}`
 }
 
+/** Permalink paths should not have the `.git` ending for a repo */
+export const getPermalinkRoot = () => {
+  let root = getRemoteHttpOrigin()
+  if (root.endsWith('.git')) root = root.substr(0, root.length - 4)
+  return root
+}
+
 export class CodeMiner implements IFileMine {
   static ignoreOps = new Set<string>(['ok', 'init31', 'init40'])
   ignoreCall(call: ISDKCall): boolean {
@@ -314,7 +321,7 @@ export class ExampleMiner {
   summaries: Summaries = {}
   nuggets: Nuggets = {}
   commitHash: string = getCommitHash()
-  remoteOrigin: string = getRemoteHttpOrigin()
+  remoteOrigin: string = getPermalinkRoot()
 
   constructor(public readonly sourcePath: string) {
     this.execute(sourcePath)


### PR DESCRIPTION
Browser permalinks should not end with `.git` in the repository name.

This PR updates the link root and the sdk example index
