### PR TITLE
fix: replacing unimported exception

### DIFF
--- a/examples/python/download_look.py
+++ b/examples/python/download_look.py
@@ -54,7 +54,7 @@ def download_look(look: models.Look, result_format: str, width: int, height: int
     task = sdk.create_look_render_task(id, result_format, width, height,)
 
     if not (task and task.id):
-        raise sdk_exceptions.RenderTaskError(
+        raise Exception(
             f"Could not create a render task for '{look.title}'"
         )
 


### PR DESCRIPTION
Looks like there was some cleanup to remove SDK-specific exception (0126ad978cd0b7df3daab3932d93bae307260bf4). This is cleanup of the final SDK exception reference in the `download_look.py` file.

I didn't open another bug as this addresses #756 but let me know if we want another bug ticket.

## Developer Checklist [ℹ️](https://github.com/looker-open-source/sdk-codegen/blob/main/CONTRIBUTING.md#developer-checklist)

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/looker-open-source/sdk-codegen/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [x] Appropriate docs were updated (if necessary)

Fixes #756 🦕
