### PR TITLE
feat: implement receive tile host message

### DIFF
--- a/packages/extension-sdk-react/src/components/ExtensionConnector/ExtensionConnector.spec.tsx
+++ b/packages/extension-sdk-react/src/components/ExtensionConnector/ExtensionConnector.spec.tsx
@@ -198,16 +198,16 @@ describe('ExtensionConnector component', () => {
     expect(await screen.findByText('Mock Extension')).toBeInTheDocument()
     expect(connectedCallback).toHaveBeenCalled()
     tileHostDataChangedCb!({
-      isEditing: false,
-      dashboardRunState: DashboardRunState.COMPLETE,
-      filters: {},
-      isCrossFiltersEnabled: false,
+      isDashboardEditing: false,
+      dashboardRunState: DashboardRunState.NOT_RUNNING,
+      dashboardFilters: {},
+      isDashboardCrossFilteringEnabled: false,
     })
     expect(tileSDK.tileHostDataChanged).toHaveBeenCalledWith({
-      filters: {},
-      isCrossFiltersEnabled: false,
-      dashboardRunState: 'COMPLETE',
-      isEditing: false,
+      dashboardFilters: {},
+      isDashboardCrossFilteringEnabled: false,
+      dashboardRunState: 'NOT_RUNNING',
+      isDashboardEditing: false,
     })
   })
 
@@ -228,9 +228,10 @@ describe('ExtensionConnector component', () => {
       visConfig: {},
       queryResponse: { data: [], fields: {}, pivots: [] },
     })
-    expect(updateContextData).toHaveBeenNthCalledWith(1, getContextData())
+    expect(updateContextData).toHaveBeenNthCalledWith(1, {
+      tileHostData: undefined,
+    })
     expect(updateContextData).toHaveBeenNthCalledWith(2, {
-      ...getContextData(),
       visualizationData: {
         visConfig: {},
         queryResponse: { data: [], fields: {}, pivots: [] },

--- a/packages/extension-sdk-react/src/components/ExtensionConnector/ExtensionConnector.tsx
+++ b/packages/extension-sdk-react/src/components/ExtensionConnector/ExtensionConnector.tsx
@@ -25,7 +25,7 @@
  */
 
 import isEqual from 'lodash/isEqual'
-import React, { useState } from 'react'
+import React, { useEffect, useState, useCallback, useRef } from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import type { RawVisualizationData, TileHostData } from '@looker/extension-sdk'
 import { connectExtensionHost } from '@looker/extension-sdk'
@@ -52,55 +52,65 @@ export const ExtensionConnector: React.FC<ExtensionConnectorProps> = ({
   chattyTimeout,
   children,
 }) => {
+  const contextDataRef = useRef(contextData)
   const [initialRouteData, setInitialRouteData] = useState<RouteData>()
   const [hostRouteData, setHostRouteData] = useState<RouteData>({ route: '' })
   const [initializing, setInitializing] = useState(true)
   const [initializeError, setInitializeError] = useState<string>()
 
-  const setInitialRouteAndRouteState = (route: string, routeState?: any) => {
-    if (hostTracksRoute) {
-      setInitialRouteData({ route, routeState })
-    }
-  }
+  useEffect(() => {
+    contextDataRef.current = contextData
+  }, [contextData])
 
-  const hostChangedRoute = (_route: string, routeState?: any) => {
-    const route = _route.startsWith('/') ? _route : '/' + _route
-    if (
-      route !== hostRouteData.route ||
-      !isEqual(routeState, hostRouteData.routeState)
-    ) {
-      setHostRouteData({ route, routeState })
+  const setInitialRouteAndRouteState = useCallback(
+    (route: string, routeState?: any) => {
+      if (hostTracksRoute) {
+        setInitialRouteData({ route, routeState })
+      }
+    },
+    [hostTracksRoute, setInitialRouteData]
+  )
+
+  const hostChangedRoute = useCallback(
+    (_route: string, routeState?: any) => {
+      const route = _route.startsWith('/') ? _route : '/' + _route
+      if (
+        route !== hostRouteData.route ||
+        !isEqual(routeState, hostRouteData.routeState)
+      ) {
+        setHostRouteData({ route, routeState })
+        updateContextData({
+          route,
+          routeState,
+        })
+      }
+    },
+    [setHostRouteData, updateContextData]
+  )
+
+  const visualizationDataReceivedCallback = useCallback(
+    (visualizationData: RawVisualizationData) => {
       updateContextData({
-        ...contextData,
-        route,
-        routeState,
+        visualizationData,
       })
-    }
-  }
+    },
+    [updateContextData]
+  )
 
-  const visualizationDataReceivedCallback = (
-    visualizationData: RawVisualizationData
-  ) => {
-    updateContextData({
-      ...contextData,
-      visualizationData,
-    })
-  }
+  const tileHostDataChangedCallback = useCallback(
+    (partialHostData: Partial<TileHostData>) => {
+      if (contextDataRef.current.tileSDK) {
+        const { tileSDK } = contextDataRef.current
+        tileSDK.tileHostDataChanged(partialHostData)
+        updateContextData({
+          tileHostData: tileSDK.tileHostData,
+        })
+      }
+    },
+    [updateContextData]
+  )
 
-  const tileHostDataChangedCallback = (
-    partialHostData: Partial<TileHostData>
-  ) => {
-    if (contextData.tileSDK) {
-      const { tileSDK } = contextData
-      tileSDK.tileHostDataChanged(partialHostData)
-      updateContextData({
-        ...contextData,
-        tileHostData: tileSDK.tileHostData,
-      })
-    }
-  }
-
-  React.useEffect(() => {
+  useEffect(() => {
     const initialize = async () => {
       try {
         const extensionHost = await connectExtensionHost({
@@ -126,7 +136,7 @@ export const ExtensionConnector: React.FC<ExtensionConnectorProps> = ({
     }
   }, [])
 
-  React.useEffect(() => {
+  useEffect(() => {
     return initializing
       ? undefined
       : setupClosePopoversListener(contextData.extensionSDK)

--- a/packages/extension-sdk-react/src/components/ExtensionConnector/types.ts
+++ b/packages/extension-sdk-react/src/components/ExtensionConnector/types.ts
@@ -131,6 +131,6 @@ export interface ExtensionProviderProps {
 export interface ExtensionConnectorProps extends ExtensionProviderProps {
   contextData: BaseExtensionContextData
   connectedCallback: (extensionSDK: ExtensionHostApi) => void
-  updateContextData: (contextData: BaseExtensionContextData) => void
+  updateContextData: (contextData: Partial<BaseExtensionContextData>) => void
   unloadedCallback: () => void
 }

--- a/packages/extension-sdk-react/src/components/ExtensionProvider/ExtensionProvider.tsx
+++ b/packages/extension-sdk-react/src/components/ExtensionProvider/ExtensionProvider.tsx
@@ -88,7 +88,9 @@ export const ExtensionProvider: React.FC<ExtensionProviderProps> = ({
     unregisterCore40SDK()
   }
 
-  const updateContextData = (updatedContextData: BaseExtensionContextData) => {
+  const updateContextData = (
+    updatedContextData: Partial<BaseExtensionContextData>
+  ) => {
     setExtensionData((previousState: ExtensionContextData) => {
       return {
         ...previousState,

--- a/packages/extension-sdk-react/src/components/ExtensionProvider2/ExtensionProvider2.tsx
+++ b/packages/extension-sdk-react/src/components/ExtensionProvider2/ExtensionProvider2.tsx
@@ -93,7 +93,9 @@ export function ExtensionProvider2<T>(props: ExtensionProvider2Props<T>) {
     unregisterCoreSDK2()
   }
 
-  const updateContextData = (updatedContextData: BaseExtensionContextData) => {
+  const updateContextData = (
+    updatedContextData: Partial<BaseExtensionContextData>
+  ) => {
     setExtensionData((previousState: ExtensionContextData2<T>) => {
       return {
         ...previousState,

--- a/packages/extension-sdk-react/src/components/ExtensionProvider40/ExtensionProvider40.tsx
+++ b/packages/extension-sdk-react/src/components/ExtensionProvider40/ExtensionProvider40.tsx
@@ -83,7 +83,9 @@ export function ExtensionProvider40(props: ExtensionProvider40Props) {
     unregisterCore40SDK()
   }
 
-  const updateContextData = (updatedContextData: BaseExtensionContextData) => {
+  const updateContextData = (
+    updatedContextData: Partial<BaseExtensionContextData>
+  ) => {
     setExtensionData((previousState: ExtensionContextData40) => {
       return {
         ...previousState,

--- a/packages/extension-sdk-react/src/components/ExtensionProviderBase/ExtensionProviderBase.tsx
+++ b/packages/extension-sdk-react/src/components/ExtensionProviderBase/ExtensionProviderBase.tsx
@@ -73,8 +73,13 @@ export const ExtensionProviderBase: React.FC<ExtensionProviderProps> = ({
     // noop
   }
 
-  const updateContextData = (contextData: BaseExtensionContextData) => {
-    setExtensionData(contextData)
+  const updateContextData = (
+    contextData: Partial<BaseExtensionContextData>
+  ) => {
+    setExtensionData((previousContextData) => ({
+      ...previousContextData,
+      ...contextData,
+    }))
   }
 
   return (

--- a/packages/extension-sdk/src/connect/extension_host_api.spec.ts
+++ b/packages/extension-sdk/src/connect/extension_host_api.spec.ts
@@ -233,12 +233,15 @@ describe('extension_host_api tests', () => {
     })
     api.handleNotification({
       type: ExtensionNotificationType.TILE_HOST_DATA,
-      payload: { isEditing: true, isCrossFiltersEnabled: true },
+      payload: {
+        isDashboardEditing: true,
+        isDashboardCrossFilteringEnabled: true,
+      },
     })
     expect(api.tileSDK).toBeDefined()
     expect(tileHostDataChangedCallback).toHaveBeenCalledWith({
-      isEditing: true,
-      isCrossFiltersEnabled: true,
+      isDashboardEditing: true,
+      isDashboardCrossFilteringEnabled: true,
     })
   })
 

--- a/packages/extension-sdk/src/connect/tile/tile_sdk.spec.ts
+++ b/packages/extension-sdk/src/connect/tile/tile_sdk.spec.ts
@@ -45,9 +45,9 @@ describe('TileSDK', () => {
     } as unknown as ExtensionHostApiImpl
     const tileSdk = new TileSDKImpl(api)
     tileSdk.tileHostDataChanged({
-      isEditing: true,
-      dashboardRunState: DashboardRunState.COMPLETE,
-      filters: { hello: 'world' },
+      isDashboardEditing: true,
+      dashboardRunState: DashboardRunState.NOT_RUNNING,
+      dashboardFilters: { hello: 'world' },
     })
     return tileSdk
   }
@@ -64,23 +64,25 @@ describe('TileSDK', () => {
 
   it('constructs', () => {
     const tileSdk = new TileSDKImpl(api)
-    const { isEditing, dashboardRunState, filters } = tileSdk.tileHostData
-    expect(isEditing).toEqual(false)
+    const { isDashboardEditing, dashboardRunState, dashboardFilters } =
+      tileSdk.tileHostData
+    expect(isDashboardEditing).toEqual(false)
     expect(dashboardRunState).toEqual('UNKNOWN')
-    expect(filters).toEqual({})
+    expect(dashboardFilters).toEqual({})
   })
 
   it('updates host data', () => {
     const tileSdk = new TileSDKImpl(api)
     tileSdk.tileHostDataChanged({
-      isEditing: true,
+      isDashboardEditing: true,
       dashboardRunState: DashboardRunState.RUNNING,
-      filters: { hello: 'world' },
+      dashboardFilters: { hello: 'world' },
     })
-    const { isEditing, dashboardRunState, filters } = tileSdk.tileHostData
-    expect(isEditing).toEqual(true)
+    const { isDashboardEditing, dashboardRunState, dashboardFilters } =
+      tileSdk.tileHostData
+    expect(isDashboardEditing).toEqual(true)
     expect(dashboardRunState).toEqual('RUNNING')
-    expect(filters).toEqual({ hello: 'world' })
+    expect(dashboardFilters).toEqual({ hello: 'world' })
   })
 
   it('does not update host data when dashboard tile mount not supported', () => {
@@ -90,14 +92,15 @@ describe('TileSDK', () => {
     } as unknown as ExtensionHostApiImpl
     const tileSdk = new TileSDKImpl(api)
     tileSdk.tileHostDataChanged({
-      isEditing: true,
+      isDashboardEditing: true,
       dashboardRunState: DashboardRunState.RUNNING,
-      filters: { hello: 'world' },
+      dashboardFilters: { hello: 'world' },
     })
-    const { isEditing, dashboardRunState, filters } = tileSdk.tileHostData
-    expect(isEditing).toEqual(false)
+    const { isDashboardEditing, dashboardRunState, dashboardFilters } =
+      tileSdk.tileHostData
+    expect(isDashboardEditing).toEqual(false)
     expect(dashboardRunState).toEqual('UNKNOWN')
-    expect(filters).toEqual({})
+    expect(dashboardFilters).toEqual({})
   })
 
   it('sends add errors message ', () => {

--- a/packages/extension-sdk/src/connect/tile/tile_sdk.ts
+++ b/packages/extension-sdk/src/connect/tile/tile_sdk.ts
@@ -40,9 +40,9 @@ import type {
 import { DashboardRunState } from './types'
 
 const defaultHostData: TileHostData = {
-  isEditing: false,
+  isDashboardEditing: false,
   dashboardRunState: DashboardRunState.UNKNOWN,
-  filters: {},
+  dashboardFilters: {},
 }
 export class TileSDKImpl implements TileSDK {
   hostApi: ExtensionHostApiImpl

--- a/packages/extension-sdk/src/connect/tile/types.ts
+++ b/packages/extension-sdk/src/connect/tile/types.ts
@@ -36,15 +36,16 @@ export type TileHostDataChangedCallback = (
 
 export enum DashboardRunState {
   UNKNOWN = 'UNKNOWN',
-  LOADED = 'LOADED',
   RUNNING = 'RUNNING',
-  COMPLETE = 'COMPLETE',
+  NOT_RUNNING = 'NOT_RUNNING',
 }
 export interface TileHostData {
-  isEditing: boolean
-  dashboardRunState: DashboardRunState
-  filters: Filters
-  isCrossFiltersEnabled?: boolean
+  isExploring?: boolean
+  dashboardId?: string
+  dashboardFilters?: Filters
+  dashboardRunState?: DashboardRunState
+  isDashboardEditing?: boolean
+  isDashboardCrossFilteringEnabled?: boolean
 }
 
 export interface Pivot {

--- a/packages/extension-tile-playground/src/components/Inspector/components/EventTester/EventTester.tsx
+++ b/packages/extension-tile-playground/src/components/Inspector/components/EventTester/EventTester.tsx
@@ -37,7 +37,7 @@ import { ExtensionContext40 } from '@looker/extension-sdk-react'
 export const EventTester: React.FC = () => {
   const {
     tileSDK,
-    tileHostData: { filters },
+    tileHostData: { dashboardFilters },
   } = useContext(ExtensionContext40)
 
   const addErrorsClick = useCallback(() => {
@@ -111,14 +111,14 @@ export const EventTester: React.FC = () => {
 
   const updateFiltersClick = useCallback(() => {
     const updatedFilter = {}
-    Object.entries(filters).forEach(([key, value]) => {
+    Object.entries(dashboardFilters || {}).forEach(([key, value]) => {
       updatedFilter[key] = value
       if (typeof value === 'string') {
         updatedFilter[key] = value.split('').reverse().join()
       }
     })
     tileSDK.updateFilters(updatedFilter)
-  }, [tileSDK, filters])
+  }, [tileSDK, dashboardFilters])
 
   const openScheduleDialogClick = useCallback(() => {
     tileSDK.openScheduleDialog()

--- a/packages/extension-tile-playground/src/components/Inspector/components/TileHostData/TileHostData.tsx
+++ b/packages/extension-tile-playground/src/components/Inspector/components/TileHostData/TileHostData.tsx
@@ -36,37 +36,45 @@ import { DashboardRunState } from '@looker/extension-sdk'
 
 export const TileHostData: React.FC = () => {
   const { tileHostData, lookerHostData } = useContext(ExtensionContext40)
-  const { isEditing, dashboardRunState, filters, isCrossFiltersEnabled } =
-    tileHostData
+  const {
+    dashboardId,
+    isExploring,
+    isDashboardEditing,
+    dashboardRunState,
+    dashboardFilters,
+    isDashboardCrossFilteringEnabled,
+  } = tileHostData
 
-  const printingMessage = lookerHostData?.isRendering
-    ? 'Dashboard is printing'
-    : 'Dashboard is NOT printing'
+  const dashboardIdMessage = `Dashboard id is ${dashboardId}`
 
-  const editingMessage = isEditing
+  const dashboardPrintingMessage =
+    lookerHostData?.isRendering && dashboardId
+      ? 'Dashboard is printing'
+      : 'Dashboard is NOT printing'
+
+  const exploringMessage =
+    isExploring && 'Extension visualization is being configured in exlore'
+
+  const dashboardEditingMessage = isDashboardEditing
     ? 'Dashboard is editing'
     : 'Dashboard is NOT editing'
 
   let dashboardRunStateMessage
   switch (dashboardRunState) {
-    case DashboardRunState.LOADED:
-      dashboardRunStateMessage = 'Dashboard has not started running'
-      break
     case DashboardRunState.RUNNING:
-      dashboardRunStateMessage = 'Dashboard is running'
+      dashboardRunStateMessage = 'Dashboard queries are running'
       break
-    case DashboardRunState.COMPLETE:
-      dashboardRunStateMessage = 'Dashboard is NOT running'
+    case DashboardRunState.NOT_RUNNING:
+      dashboardRunStateMessage = 'Dashboard queries are not running'
       break
-
     default:
-      dashboardRunStateMessage = 'Dashboard run state is unknown'
+      dashboardRunStateMessage = 'Query run state is unknown'
       break
   }
-  const crossFiltersEnabledMessage = isCrossFiltersEnabled
-    ? 'Cross filters are enabled'
-    : 'Cross filters are NOT enabled'
-  const filtersArray = Object.entries(filters)
+  const dashboardCrossFiltersEnabledMessage = isDashboardCrossFilteringEnabled
+    ? 'Dashboard cross filters are enabled'
+    : 'DashboardCross filters are NOT enabled'
+  const filtersArray = Object.entries(dashboardFilters || {})
     .map(([key, value]) => `${key}=${value}`)
     .join(', ')
 
@@ -75,15 +83,21 @@ export const TileHostData: React.FC = () => {
       <CardContent>
         <Accordion2 label="Tile host data" defaultOpen>
           <SpaceVertical gap="small" mt="medium">
-            <Paragraph>{printingMessage}</Paragraph>
-            <Paragraph>{editingMessage}</Paragraph>
-            <Paragraph>{dashboardRunStateMessage}</Paragraph>
-            <Paragraph>{crossFiltersEnabledMessage}</Paragraph>
-            <Paragraph>
-              {filtersArray.length
-                ? `Dashboard filters are ${filtersArray}`
-                : 'Dashboard has no filters'}
-            </Paragraph>
+            {isExploring && <Paragraph>{exploringMessage}</Paragraph>}
+            {!isExploring && (
+              <>
+                <Paragraph>{dashboardIdMessage}</Paragraph>
+                <Paragraph>{dashboardPrintingMessage}</Paragraph>
+                <Paragraph>{dashboardEditingMessage}</Paragraph>
+                <Paragraph>{dashboardRunStateMessage}</Paragraph>
+                <Paragraph>{dashboardCrossFiltersEnabledMessage}</Paragraph>
+                <Paragraph>
+                  {filtersArray.length
+                    ? `Dashboard filters are ${filtersArray}`
+                    : 'Dashboard has no filters'}
+                </Paragraph>
+              </>
+            )}
           </SpaceVertical>
         </Accordion2>
       </CardContent>


### PR DESCRIPTION
The major change here is that it became apparent that the ExtensionConnector
did not have an up to date copy of the provider data. This was okay because all of
the provider components merged the data received from the ExtensionConnector
with the existing data. As the ExtensionConnector was only passing partial
data this was okay. For extensions as tile however, the ExtensionConnector
needed to update other provider and was failing because it did not have the
latest data. This was due to the callbacks being called from the chatty api
and being unaware changes made to properties in the react render cycle. To
solve this provider data is now stored in a reference so the latest data
is always available. In addition, provider data updates are now explicitly
called out as partial updates.

The main aim (although in the end a smaller change) is to make the extension
aware of changes made by the host to the tile. This involved some simplification
of states (DashboardRunState now has UNKNOWN, RUNNING, NOT_RUNNING), renaming
to be more dashboard specific (isDashboardEditing, isDashboardCrossFilteringEnabled,
dashboardFilters) and addition of new fields (dashboardId and isExploring).

isExploring indicates that the extension is running inside of an explore. In this
case the dashboard fields are not populated. It is possible that isExploring
may be moved to its own message in a future change.

Note that this branch is branched off of feature/extension-dashboard-tile and
will subsequently be merged into that branch
