### PR TITLE
fix (README): Fixed to issues page on README for Python

### DIFF
--- a/python/README.rst
+++ b/python/README.rst
@@ -12,7 +12,7 @@ initializing that supports run-time specific transports (currently only
 (`AuthSession` and `OAuthSession`). The methods and models are generated from
 the Looker API spec by a new code generator developed at Looker.
 
-Please [report any issues](https://github.com/looker-open-source/sdk-codegen/issues)
+Please `report any issues <https://github.com/looker-open-source/sdk-codegen/issues>`_
 encountered, and indicate the SDK language in the report.
 
 Basic Usage


### PR DESCRIPTION
Fixed the link syntax from Markdown to RST.

Fixes https://github.com/looker-open-source/sdk-codegen/issues/1077