### PR TITLE
feat: additional tile host data

### DIFF
--- a/packages/extension-sdk/src/connect/tile/types.ts
+++ b/packages/extension-sdk/src/connect/tile/types.ts
@@ -34,18 +34,73 @@ export type TileHostDataChangedCallback = (
   tileHostData: Partial<TileHostData>
 ) => void
 
+/**
+ * Defines the current run state of the dashboard
+ */
 export enum DashboardRunState {
   UNKNOWN = 'UNKNOWN',
   RUNNING = 'RUNNING',
   NOT_RUNNING = 'NOT_RUNNING',
 }
+
 export interface TileHostData {
+  /**
+   * When true indicates that the tile is being configured as
+   * a visualization inside of an explore.
+   */
   isExploring?: boolean
+  /**
+   * The dashboard if the tile is being rendered in. If the tile
+   * is being configured as an explore this will not be populated.
+   */
   dashboardId?: string
+  /**
+   * The filters being applied to the dashboard. If the tile
+   * is being configured as an explore this will not be populated.
+   */
   dashboardFilters?: Filters
+  /**
+   * Indicates whether the dashboard is running. If the tile
+   * is being configured as an explore the state will be UNKNOWN.
+   * Note that for dashboard performance reasons, the runstate
+   * may NEVER be shown as running. This generally will happen
+   * if there no other tiles associated with a query (including
+   * the one the extension is associated with).
+   * If the extension needs to know for certain that a dashboard
+   * has been run, detecting differences in the lastRunStartTime
+   * is the reliable way.
+   */
   dashboardRunState?: DashboardRunState
+  /**
+   * When true, the dashboard is being edited. If the tile
+   * is being configured as an explore this will not be populated.
+   */
   isDashboardEditing?: boolean
+  /**
+   * When true, cross filtering. If the tile
+   * is being configured as an explore this will not be populated.
+   */
   isDashboardCrossFilteringEnabled?: boolean
+  /**
+   * Indicates the last dashboard run start time. If the tile
+   * is being configured as an explore this will not be populated.
+   * Note that the start and end times reported should not
+   * used for capturing performance metrics.
+   */
+  lastRunStartTime?: number
+  /**
+   * Indicates the last dashboard run end time. If the tile
+   * is being configured as an explore this will not be populated.
+   * Note that the start and end times reported should not
+   * used for capturing performance metrics.
+   */
+  lastRunEndTime?: number
+  /**
+   * Indicates whether the last dashboard run was succesful or not.
+   * If the tile is being configured as an explore this will not be
+   * populated.
+   */
+  lastRunSuccess?: boolean
 }
 
 export interface Pivot {

--- a/packages/extension-tile-playground/src/components/Inspector/components/TileHostData/TileHostData.tsx
+++ b/packages/extension-tile-playground/src/components/Inspector/components/TileHostData/TileHostData.tsx
@@ -43,6 +43,9 @@ export const TileHostData: React.FC = () => {
     dashboardRunState,
     dashboardFilters,
     isDashboardCrossFilteringEnabled,
+    lastRunStartTime,
+    lastRunEndTime,
+    lastRunSuccess,
   } = tileHostData
 
   const dashboardIdMessage = `Dashboard id is ${dashboardId}`
@@ -71,9 +74,15 @@ export const TileHostData: React.FC = () => {
       dashboardRunStateMessage = 'Query run state is unknown'
       break
   }
+
+  const lastDashboardRunMessage = lastRunStartTime
+    ? `Last start time: ${lastRunStartTime}, last end time: ${lastRunEndTime}, last success: ${lastRunSuccess}`
+    : 'The dashboard has not run yet'
+
   const dashboardCrossFiltersEnabledMessage = isDashboardCrossFilteringEnabled
     ? 'Dashboard cross filters are enabled'
     : 'DashboardCross filters are NOT enabled'
+
   const filtersArray = Object.entries(dashboardFilters || {})
     .map(([key, value]) => `${key}=${value}`)
     .join(', ')
@@ -90,6 +99,7 @@ export const TileHostData: React.FC = () => {
                 <Paragraph>{dashboardPrintingMessage}</Paragraph>
                 <Paragraph>{dashboardEditingMessage}</Paragraph>
                 <Paragraph>{dashboardRunStateMessage}</Paragraph>
+                <Paragraph>{lastDashboardRunMessage}</Paragraph>
                 <Paragraph>{dashboardCrossFiltersEnabledMessage}</Paragraph>
                 <Paragraph>
                   {filtersArray.length

--- a/packages/extension-tile-playground/src/components/Inspector/components/TileHostData/TileHostData.tsx
+++ b/packages/extension-tile-playground/src/components/Inspector/components/TileHostData/TileHostData.tsx
@@ -76,7 +76,9 @@ export const TileHostData: React.FC = () => {
   }
 
   const lastDashboardRunMessage = lastRunStartTime
-    ? `Last start time: ${lastRunStartTime}, last end time: ${lastRunEndTime}, last success: ${lastRunSuccess}`
+    ? `Last start time: ${lastRunStartTime || ''}, last end time: ${
+        lastRunEndTime || ''
+      }, last success: ${lastRunSuccess || ''}`
     : 'The dashboard has not run yet'
 
   const dashboardCrossFiltersEnabledMessage = isDashboardCrossFilteringEnabled


### PR DESCRIPTION
Dashboard run start/end times now provided along with success information.
Allows extension to determin if the dashboard run button was pressed (or
auto run).

Example of usage provided.
