### PR TITLE
feat: extension tile information

### DIFF
--- a/packages/extension-sdk/src/connect/tile/tile_sdk.spec.ts
+++ b/packages/extension-sdk/src/connect/tile/tile_sdk.spec.ts
@@ -45,7 +45,9 @@ describe('TileSDK', () => {
     } as unknown as ExtensionHostApiImpl
     const tileSdk = new TileSDKImpl(api)
     tileSdk.tileHostDataChanged({
-      isDashboardEditing: true,
+      dashboardId: '42',
+      elementId: '84',
+      isDashboardEditing: false,
       dashboardRunState: DashboardRunState.NOT_RUNNING,
       dashboardFilters: { hello: 'world' },
     })
@@ -64,8 +66,16 @@ describe('TileSDK', () => {
 
   it('constructs', () => {
     const tileSdk = new TileSDKImpl(api)
-    const { isDashboardEditing, dashboardRunState, dashboardFilters } =
-      tileSdk.tileHostData
+    const {
+      isDashboardEditing,
+      dashboardRunState,
+      dashboardFilters,
+      dashboardId,
+      elementId,
+    } = tileSdk.tileHostData
+    expect(dashboardId).toEqual(undefined)
+    expect(elementId).toEqual(undefined)
+    expect(isDashboardEditing).toEqual(false)
     expect(isDashboardEditing).toEqual(false)
     expect(dashboardRunState).toEqual('UNKNOWN')
     expect(dashboardFilters).toEqual({})
@@ -74,12 +84,21 @@ describe('TileSDK', () => {
   it('updates host data', () => {
     const tileSdk = new TileSDKImpl(api)
     tileSdk.tileHostDataChanged({
+      dashboardId: '42',
+      elementId: '84',
       isDashboardEditing: true,
       dashboardRunState: DashboardRunState.RUNNING,
       dashboardFilters: { hello: 'world' },
     })
-    const { isDashboardEditing, dashboardRunState, dashboardFilters } =
-      tileSdk.tileHostData
+    const {
+      isDashboardEditing,
+      dashboardRunState,
+      dashboardFilters,
+      dashboardId,
+      elementId,
+    } = tileSdk.tileHostData
+    expect(dashboardId).toEqual('42')
+    expect(elementId).toEqual('84')
     expect(isDashboardEditing).toEqual(true)
     expect(dashboardRunState).toEqual('RUNNING')
     expect(dashboardFilters).toEqual({ hello: 'world' })
@@ -92,12 +111,21 @@ describe('TileSDK', () => {
     } as unknown as ExtensionHostApiImpl
     const tileSdk = new TileSDKImpl(api)
     tileSdk.tileHostDataChanged({
+      dashboardId: '42',
+      elementId: '84',
       isDashboardEditing: true,
       dashboardRunState: DashboardRunState.RUNNING,
       dashboardFilters: { hello: 'world' },
     })
-    const { isDashboardEditing, dashboardRunState, dashboardFilters } =
-      tileSdk.tileHostData
+    const {
+      isDashboardEditing,
+      dashboardRunState,
+      dashboardFilters,
+      dashboardId,
+      elementId,
+    } = tileSdk.tileHostData
+    expect(dashboardId).toEqual(undefined)
+    expect(elementId).toEqual(undefined)
     expect(isDashboardEditing).toEqual(false)
     expect(dashboardRunState).toEqual('UNKNOWN')
     expect(dashboardFilters).toEqual({})

--- a/packages/extension-sdk/src/connect/tile/types.ts
+++ b/packages/extension-sdk/src/connect/tile/types.ts
@@ -50,10 +50,15 @@ export interface TileHostData {
    */
   isExploring?: boolean
   /**
-   * The dashboard if the tile is being rendered in. If the tile
+   * The dashboard id the tile is being rendered in. If the tile
    * is being configured as an explore this will not be populated.
    */
   dashboardId?: string
+  /**
+   * The element id of the tile being rendered. If the tile
+   * is being configured as an explore this will not be populated.
+   */
+  elementId?: string
   /**
    * The filters being applied to the dashboard. If the tile
    * is being configured as an explore this will not be populated.
@@ -82,6 +87,18 @@ export interface TileHostData {
    */
   isDashboardCrossFilteringEnabled?: boolean
   /**
+   * The id of the tile extension element that triggered the last
+   * dashboard run. The id will be undefined if the dashboard run
+   * was triggered by the dashboard run button or auto run or if
+   * the run was triggered using the embed SDK. If the tile
+   * is being configured as an explore this will not be populated.
+   * Note that the lastRunSourceElementId CAN be the same as the
+   * element id of the current extension instance, in other words,
+   * if the extension triggers a dashboard run, it will be notified
+   * when the dashboard run starts and finishes.
+   */
+  lastRunSourceElementId?: string
+  /**
    * Indicates the last dashboard run start time. If the tile
    * is being configured as an explore this will not be populated.
    * Note that the start and end times reported should not
@@ -91,6 +108,7 @@ export interface TileHostData {
   /**
    * Indicates the last dashboard run end time. If the tile
    * is being configured as an explore this will not be populated.
+   * If the tile is running, this will not be populated.
    * Note that the start and end times reported should not
    * used for capturing performance metrics.
    */
@@ -99,6 +117,7 @@ export interface TileHostData {
    * Indicates whether the last dashboard run was succesful or not.
    * If the tile is being configured as an explore this will not be
    * populated.
+   * If the tile is running, this will not be populated.
    */
   lastRunSuccess?: boolean
 }

--- a/packages/extension-tile-playground/src/components/Inspector/components/TileHostData/TileHostData.tsx
+++ b/packages/extension-tile-playground/src/components/Inspector/components/TileHostData/TileHostData.tsx
@@ -38,6 +38,7 @@ export const TileHostData: React.FC = () => {
   const { tileHostData, lookerHostData } = useContext(ExtensionContext40)
   const {
     dashboardId,
+    elementId,
     isExploring,
     isDashboardEditing,
     dashboardRunState,
@@ -46,9 +47,12 @@ export const TileHostData: React.FC = () => {
     lastRunStartTime,
     lastRunEndTime,
     lastRunSuccess,
+    lastRunSourceElementId,
   } = tileHostData
 
-  const dashboardIdMessage = `Dashboard id is ${dashboardId}`
+  const dashboardIdMessage = `Dashboard id is "${
+    dashboardId || ''
+  }". Element id is "${elementId || ''}".`
 
   const dashboardPrintingMessage =
     lookerHostData?.isRendering && dashboardId
@@ -78,7 +82,9 @@ export const TileHostData: React.FC = () => {
   const lastDashboardRunMessage = lastRunStartTime
     ? `Last start time: ${lastRunStartTime || ''}, last end time: ${
         lastRunEndTime || ''
-      }, last success: ${lastRunSuccess || ''}`
+      }, last success: ${lastRunSuccess || ''}, initiated by: ${
+        lastRunSourceElementId || ''
+      }`
     : 'The dashboard has not run yet'
 
   const dashboardCrossFiltersEnabledMessage = isDashboardCrossFilteringEnabled


### PR DESCRIPTION
Provides additional information about the dashboard tile.
1. element id.
2. lastRunSourceElementId - populated when dashboard run is
   initiated by an extension tile.

Also, minor fix to documentation.
Also, minor adjustment to tests.
