### PR TITLE
docs: update OAuth and CORS docs

### DIFF
--- a/examplesIndex.json
+++ b/examplesIndex.json
@@ -1,5 +1,5 @@
 {
-  "commitHash": "a4eb5a0b1c9d09f7e45db2a83d30be7ebd707afb",
+  "commitHash": "2330eef43ed80eff1f3b47eac6b645ab581f2694",
   "remoteOrigin": "https://github.com/looker-open-source/sdk-codegen",
   "summaries": {
     "packages/sdk-codegen/src/codeGenerators.ts": {

--- a/packages/extension-utils/README.md
+++ b/packages/extension-utils/README.md
@@ -1,5 +1,7 @@
 # @looker/extension-utils
 
+Easier browser-based TypeScript authentication via OAuth, and support for building React applications that can run both inside and outside of [Looker's Extension Framework](https://docs.looker.com/data-modeling/extension-framework/extension-framework-intro) hosting environment.
+
 ## "Dual mode" Looker browser applications
 
 This package provides interfaces and classes that support building a Looker application that can be both hosted as


### PR DESCRIPTION
Updated OAuth documentation to use `@looker/extension-utils` source references