### PR TITLE
fix: Sidenav Methods Panel Open & Closing

### DIFF
--- a/packages/api-explorer/src/components/SideNav/SideNavMethods.spec.tsx
+++ b/packages/api-explorer/src/components/SideNav/SideNavMethods.spec.tsx
@@ -52,27 +52,36 @@ describe('SideNavMethods', () => {
     )
   })
 
-  test('method opens successfully', () => {
+  test('tag expands and displays methods after clicked', () => {
     renderWithRouterAndReduxProvider(
       <SideNavMethods methods={methods} tag={tag} specKey={'3.1'} />
     )
-    const initExpandedPanels = screen.queryByRole('region')
-    expect(initExpandedPanels).not.toBeInTheDocument()
+    const firstMethod = Object.values(methods)[0].schema.summary
+    expect(screen.queryByText(firstMethod)).not.toBeInTheDocument()
     userEvent.click(screen.getByText(tag))
-    const expandedPanelsAfterClick = screen.getByRole('region')
-    expect(expandedPanelsAfterClick).toBeInTheDocument()
+    expect(screen.queryByText(firstMethod)).toBeInTheDocument()
+    expect(screen.getAllByRole('link')).toHaveLength(
+      Object.values(methods).length
+    )
   })
 
-  test('method closes successfully', () => {
+  test('expanded tag closes when clicked', () => {
     renderWithRouterAndReduxProvider(
-      <SideNavMethods methods={methods} tag={tag} specKey={'3.1'} />
+      <SideNavMethods
+        methods={methods}
+        tag={tag}
+        specKey={'3.1'}
+        defaultOpen={true}
+      />
+    )
+    const firstMethod = Object.values(methods)[0].schema.summary
+    expect(screen.queryByText(firstMethod)).toBeInTheDocument()
+    expect(screen.queryAllByRole('link')).toHaveLength(
+      Object.values(methods).length
     )
     userEvent.click(screen.getByText(tag))
-    const expandedPanelsAfterClick = screen.getByRole('region')
-    expect(expandedPanelsAfterClick).toBeInTheDocument()
-    userEvent.click(screen.getByText(tag))
-    const expandedPanelsClosed = screen.queryByRole('region')
-    expect(expandedPanelsClosed).not.toBeInTheDocument()
+    expect(screen.queryByText(firstMethod)).not.toBeInTheDocument()
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
   })
 
   test('it highlights text matching search pattern in both tag and methods', () => {

--- a/packages/api-explorer/src/components/SideNav/SideNavMethods.spec.tsx
+++ b/packages/api-explorer/src/components/SideNav/SideNavMethods.spec.tsx
@@ -35,6 +35,17 @@ import {
 } from '../../test-utils'
 import { SideNavMethods } from './SideNavMethods'
 
+const mockHistoryPush = jest.fn()
+jest.mock('react-router-dom', () => {
+  const ReactRouterDOM = jest.requireActual('react-router-dom')
+  return {
+    ...ReactRouterDOM,
+    useHistory: () => ({
+      push: mockHistoryPush,
+    }),
+  }
+})
+
 describe('SideNavMethods', () => {
   const tag = 'Dashboard'
   const methods = api.tags[tag]
@@ -59,6 +70,7 @@ describe('SideNavMethods', () => {
     const firstMethod = Object.values(methods)[0].schema.summary
     expect(screen.queryByText(firstMethod)).not.toBeInTheDocument()
     userEvent.click(screen.getByText(tag))
+    expect(mockHistoryPush).toHaveBeenCalledWith(`/3.1/methods/${tag}`)
     expect(screen.queryByText(firstMethod)).toBeInTheDocument()
     expect(screen.getAllByRole('link')).toHaveLength(
       Object.values(methods).length
@@ -80,6 +92,7 @@ describe('SideNavMethods', () => {
       Object.values(methods).length
     )
     userEvent.click(screen.getByText(tag))
+    expect(mockHistoryPush).toHaveBeenCalledWith(`/3.1/methods`)
     expect(screen.queryByText(firstMethod)).not.toBeInTheDocument()
     expect(screen.queryByRole('link')).not.toBeInTheDocument()
   })

--- a/packages/api-explorer/src/components/SideNav/SideNavMethods.spec.tsx
+++ b/packages/api-explorer/src/components/SideNav/SideNavMethods.spec.tsx
@@ -51,6 +51,37 @@ describe('SideNavMethods', () => {
       `/3.1/methods/${tag}/${Object.values(methods)[0].name}`
     )
   })
+  /*
+   *  Tests to include:
+   *   1) test that can open and close properly
+   *   2) testing if methods show up default unopenned if nothing in url
+   *   3) testing it will be openned if parameter in the url
+   *
+   * *** DO THIS FOR THE SIDENAVTYPES AS WELL ***
+   *
+   * */
+  test('method opens successfully', () => {
+    renderWithRouterAndReduxProvider(
+      <SideNavMethods methods={methods} tag={tag} specKey={'3.1'} />
+    )
+    const initExpandedPanels = screen.queryByRole('region')
+    expect(initExpandedPanels).not.toBeInTheDocument()
+    userEvent.click(screen.getByText(tag))
+    const expandedPanelsAfterClick = screen.getByRole('region')
+    expect(expandedPanelsAfterClick).toBeInTheDocument()
+  })
+
+  test('method closes successfully', () => {
+    renderWithRouterAndReduxProvider(
+      <SideNavMethods methods={methods} tag={tag} specKey={'3.1'} />
+    )
+    userEvent.click(screen.getByText(tag))
+    const expandedPanelsAfterClick = screen.getByRole('region')
+    expect(expandedPanelsAfterClick).toBeInTheDocument()
+    userEvent.click(screen.getByText(tag))
+    const expandedPanelsClosed = screen.queryByRole('region')
+    expect(expandedPanelsClosed).not.toBeInTheDocument()
+  })
 
   test('it highlights text matching search pattern in both tag and methods', () => {
     const store = createTestStore({ settings: { searchPattern: 'dash' } })

--- a/packages/api-explorer/src/components/SideNav/SideNavMethods.spec.tsx
+++ b/packages/api-explorer/src/components/SideNav/SideNavMethods.spec.tsx
@@ -51,15 +51,7 @@ describe('SideNavMethods', () => {
       `/3.1/methods/${tag}/${Object.values(methods)[0].name}`
     )
   })
-  /*
-   *  Tests to include:
-   *   1) test that can open and close properly
-   *   2) testing if methods show up default unopenned if nothing in url
-   *   3) testing it will be openned if parameter in the url
-   *
-   * *** DO THIS FOR THE SIDENAVTYPES AS WELL ***
-   *
-   * */
+
   test('method opens successfully', () => {
     renderWithRouterAndReduxProvider(
       <SideNavMethods methods={methods} tag={tag} specKey={'3.1'} />

--- a/packages/api-explorer/src/components/SideNav/SideNavMethods.spec.tsx
+++ b/packages/api-explorer/src/components/SideNav/SideNavMethods.spec.tsx
@@ -49,29 +49,30 @@ jest.mock('react-router-dom', () => {
 describe('SideNavMethods', () => {
   const tag = 'Dashboard'
   const methods = api.tags[tag]
+  const specKey = '3.1'
 
   test('it renders provided methods', () => {
     renderWithRouterAndReduxProvider(
-      <SideNavMethods methods={methods} tag={tag} specKey={'3.1'} />
+      <SideNavMethods methods={methods} tag={tag} specKey={specKey} />
     )
     userEvent.click(screen.getByText(tag))
     const sideNavItems = screen.getAllByRole('link')
     expect(sideNavItems).toHaveLength(Object.keys(methods).length)
     expect(sideNavItems[0]).toHaveAttribute(
       'href',
-      `/3.1/methods/${tag}/${Object.values(methods)[0].name}`
+      `/${specKey}/methods/${tag}/${Object.values(methods)[0].name}`
     )
   })
 
   test('tag expands and displays methods after clicked', () => {
     renderWithRouterAndReduxProvider(
-      <SideNavMethods methods={methods} tag={tag} specKey={'3.1'} />
+      <SideNavMethods methods={methods} tag={tag} specKey={specKey} />
     )
     const firstMethod = Object.values(methods)[0].schema.summary
     expect(screen.queryByText(firstMethod)).not.toBeInTheDocument()
     userEvent.click(screen.getByText(tag))
-    expect(mockHistoryPush).toHaveBeenCalledWith(`/3.1/methods/${tag}`)
-    expect(screen.queryByText(firstMethod)).toBeInTheDocument()
+    expect(mockHistoryPush).toHaveBeenCalledWith(`/${specKey}/methods/${tag}`)
+    expect(screen.getByRole('link', { name: firstMethod })).toBeInTheDocument()
     expect(screen.getAllByRole('link')).toHaveLength(
       Object.values(methods).length
     )
@@ -82,17 +83,17 @@ describe('SideNavMethods', () => {
       <SideNavMethods
         methods={methods}
         tag={tag}
-        specKey={'3.1'}
+        specKey={specKey}
         defaultOpen={true}
       />
     )
     const firstMethod = Object.values(methods)[0].schema.summary
-    expect(screen.queryByText(firstMethod)).toBeInTheDocument()
-    expect(screen.queryAllByRole('link')).toHaveLength(
+    expect(screen.getByRole('link', { name: firstMethod })).toBeInTheDocument()
+    expect(screen.getAllByRole('link')).toHaveLength(
       Object.values(methods).length
     )
     userEvent.click(screen.getByText(tag))
-    expect(mockHistoryPush).toHaveBeenCalledWith(`/3.1/methods`)
+    expect(mockHistoryPush).toHaveBeenCalledWith(`/${specKey}/methods`)
     expect(screen.queryByText(firstMethod)).not.toBeInTheDocument()
     expect(screen.queryByRole('link')).not.toBeInTheDocument()
   })
@@ -103,7 +104,7 @@ describe('SideNavMethods', () => {
       <SideNavMethods
         methods={pick(methods, 'create_dashboard')}
         tag={tag}
-        specKey={'3.1'}
+        specKey={specKey}
       />,
       undefined,
       store

--- a/packages/api-explorer/src/components/SideNav/SideNavMethods.tsx
+++ b/packages/api-explorer/src/components/SideNav/SideNavMethods.tsx
@@ -56,7 +56,6 @@ export const SideNavMethods = styled(
       const _isOpen = !isOpen
       setIsOpen(_isOpen)
       if (_isOpen) {
-        // do for types as well, else statement remove name
         history.push(`/${specKey}/methods/${tag}`)
       } else {
         history.push(`/${specKey}/methods`)

--- a/packages/api-explorer/src/components/SideNav/SideNavMethods.tsx
+++ b/packages/api-explorer/src/components/SideNav/SideNavMethods.tsx
@@ -45,12 +45,23 @@ interface MethodsProps {
 
 export const SideNavMethods = styled(
   ({ className, methods, tag, specKey, defaultOpen = false }: MethodsProps) => {
+    const searchPattern = useSelector(selectSearchPattern)
     const match = useRouteMatch<{ methodTag: string }>(
       `/:specKey/methods/:methodTag/:methodName?`
     )
-    const searchPattern = useSelector(selectSearchPattern)
     const [isOpen, setIsOpen] = useState(defaultOpen)
     const history = useHistory()
+
+    const handleOpen = () => {
+      const _isOpen = !isOpen
+      setIsOpen(_isOpen)
+      if (_isOpen) {
+        // do for types as well, else statement remove name
+        history.push(`/${specKey}/methods/${tag}`)
+      } else {
+        history.push(`/${specKey}/methods`)
+      }
+    }
 
     useEffect(() => {
       const status = match
@@ -58,12 +69,6 @@ export const SideNavMethods = styled(
         : defaultOpen
       setIsOpen(status)
     }, [defaultOpen])
-
-    const handleOpen = () => {
-      const _isOpen = !isOpen
-      setIsOpen(_isOpen)
-      if (_isOpen) history.push(`/${specKey}/methods/${tag}`)
-    }
 
     /* TODO: Fix highlighting. It is applied but it is somehow being overridden */
     return (

--- a/packages/api-explorer/src/components/SideNav/SideNavMethods.tsx
+++ b/packages/api-explorer/src/components/SideNav/SideNavMethods.tsx
@@ -24,7 +24,7 @@
 
  */
 
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import styled from 'styled-components'
 import { Accordion2, Heading } from '@looker/components'
 import type { MethodList } from '@looker/sdk-codegen'
@@ -45,10 +45,12 @@ interface MethodsProps {
 
 export const SideNavMethods = styled(
   ({ className, methods, tag, specKey, defaultOpen = false }: MethodsProps) => {
-    const searchPattern = useSelector(selectSearchPattern)
     const match = useRouteMatch<{ methodTag: string }>(
       `/:specKey/methods/:methodTag/:methodName?`
     )
+    defaultOpen = match ? match.params.methodTag === tag : defaultOpen
+    const searchPattern = useSelector(selectSearchPattern)
+
     const [isOpen, setIsOpen] = useState(defaultOpen)
     const history = useHistory()
 
@@ -57,13 +59,6 @@ export const SideNavMethods = styled(
       setIsOpen(_isOpen)
       if (_isOpen) history.push(`/${specKey}/methods/${tag}`)
     }
-
-    useEffect(() => {
-      const status = match
-        ? defaultOpen || match.params.methodTag === tag
-        : defaultOpen
-      setIsOpen(status)
-    }, [defaultOpen, match, tag])
 
     /* TODO: Fix highlighting. It is applied but it is somehow being overridden */
     return (

--- a/packages/api-explorer/src/components/SideNav/SideNavMethods.tsx
+++ b/packages/api-explorer/src/components/SideNav/SideNavMethods.tsx
@@ -24,7 +24,7 @@
 
  */
 
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import styled from 'styled-components'
 import { Accordion2, Heading } from '@looker/components'
 import type { MethodList } from '@looker/sdk-codegen'
@@ -48,11 +48,16 @@ export const SideNavMethods = styled(
     const match = useRouteMatch<{ methodTag: string }>(
       `/:specKey/methods/:methodTag/:methodName?`
     )
-    defaultOpen = match ? match.params.methodTag === tag : defaultOpen
     const searchPattern = useSelector(selectSearchPattern)
-
     const [isOpen, setIsOpen] = useState(defaultOpen)
     const history = useHistory()
+
+    useEffect(() => {
+      const status = match
+        ? defaultOpen || match.params.methodTag === tag
+        : defaultOpen
+      setIsOpen(status)
+    }, [defaultOpen])
 
     const handleOpen = () => {
       const _isOpen = !isOpen

--- a/packages/api-explorer/src/components/SideNav/SideNavTypes.spec.tsx
+++ b/packages/api-explorer/src/components/SideNav/SideNavTypes.spec.tsx
@@ -54,8 +54,7 @@ describe('SideNavTypes', () => {
     renderWithRouterAndReduxProvider(
       <SideNavTypes specKey={specKey} types={{ ...api.types }} tag={tag} />
     )
-    const h4 = screen.getByRole('heading', { level: 4 })
-    expect(h4).toHaveTextContent(tag)
+    expect(screen.getByRole('heading', { level: 4 })).toHaveTextContent(tag)
   })
 
   test('tag expands and displays types after clicked', () => {
@@ -64,8 +63,8 @@ describe('SideNavTypes', () => {
     )
     expect(screen.queryByText(typeTags[0])).not.toBeInTheDocument()
     userEvent.click(screen.getByText(tag))
-    expect(mockHistoryPush).toHaveBeenCalledWith(`/3.1/types/${tag}`)
-    expect(screen.queryByText(typeTags[0])).toBeInTheDocument()
+    expect(mockHistoryPush).toHaveBeenCalledWith(`/${specKey}/types/${tag}`)
+    expect(screen.getByRole('link', { name: typeTags[0] })).toBeInTheDocument()
   })
 
   test('expanded tag closes when clicked', () => {
@@ -73,14 +72,16 @@ describe('SideNavTypes', () => {
       <SideNavTypes
         types={{ ...api.types }}
         tag={tag}
-        specKey={'3.1'}
+        specKey={specKey}
         defaultOpen={true}
       />
     )
-    expect(screen.queryByText(typeTags[0])).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: typeTags[0] })).toBeInTheDocument()
     userEvent.click(screen.getAllByText(tag)[0])
-    expect(mockHistoryPush).toHaveBeenCalledWith(`/3.1/types`)
-    expect(screen.queryByText(typeTags[0])).not.toBeInTheDocument()
+    expect(mockHistoryPush).toHaveBeenCalledWith(`/${specKey}/types`)
+    expect(
+      screen.queryByRole('link', { name: typeTags[0] })
+    ).not.toBeInTheDocument()
   })
 
   test('it highlights text matching search pattern', () => {

--- a/packages/api-explorer/src/components/SideNav/SideNavTypes.tsx
+++ b/packages/api-explorer/src/components/SideNav/SideNavTypes.tsx
@@ -55,7 +55,12 @@ export const SideNavTypes = styled(
     const handleOpen = () => {
       const _isOpen = !isOpen
       setIsOpen(_isOpen)
-      if (_isOpen) history.push(`/${specKey}/types/${tag}`)
+      if (_isOpen) {
+        // do for types as well, else statement remove name
+        history.push(`/${specKey}/types/${tag}`)
+      } else {
+        history.push(`/${specKey}/types`)
+      }
     }
 
     useEffect(() => {

--- a/packages/api-explorer/src/components/SideNav/SideNavTypes.tsx
+++ b/packages/api-explorer/src/components/SideNav/SideNavTypes.tsx
@@ -56,7 +56,6 @@ export const SideNavTypes = styled(
       const _isOpen = !isOpen
       setIsOpen(_isOpen)
       if (_isOpen) {
-        // do for types as well, else statement remove name
         history.push(`/${specKey}/types/${tag}`)
       } else {
         history.push(`/${specKey}/types`)


### PR DESCRIPTION
## 👋👋 Thank you for contributing to Looker sdk-codegen (⚡️🍣)

Enables side navigation methods panels to open and close properly. Previously, users were unable to close the expanded panel once opened.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a bug/issue
- [ ] Ensure the tests and linter pass


