### PR TITLE
chore: separate unit and integration test configs

### DIFF
--- a/packages/api-explorer/jest-puppeteer.config.js
+++ b/packages/api-explorer/jest-puppeteer.config.js
@@ -23,7 +23,13 @@
  SOFTWARE.
 
  */
+
+const base = require('../../jest.config')
 module.exports = {
+  ...base,
+  rootDir: '../..',
+  preset: 'jest-puppeteer',
+  setupFilesAfterEnv: ['expect-puppeteer'],
   launch: {
     // `headless:false` and `slowMo:250` can be useful for "test-watch" usage
     headless: true,

--- a/packages/api-explorer/jest.config.js
+++ b/packages/api-explorer/jest.config.js
@@ -1,25 +1,27 @@
 /*
- * The MIT License (MIT)
- *
- * Copyright (c) 2020 Looker Data Sciences, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+
+ MIT License
+
+ Copyright (c) 2022 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
  */
 const base = require('../../jest.config')
 const packageName = require('./package.json').name.split('/')[1]
@@ -29,7 +31,7 @@ module.exports = {
   displayName: packageName,
   name: packageName,
   rootDir: '../..',
-  preset: 'jest-puppeteer',
-  setupFilesAfterEnv: ['expect-puppeteer'],
+  setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect'],
   testMatch: [`<rootDir>/packages/${packageName}/**/*.(spec|test).(ts|js)?(x)`],
+  testEnvironment: 'jsdom',
 }

--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -27,7 +27,7 @@
     "build": "tsc && webpack --config webpack.prod.config.js",
     "develop": "webpack serve --host=0.0.0.0 --https --disable-host-check --config webpack.dev.config.js",
     "docs": "typedoc --mode file --out docs",
-    "test:e2e": "yarn jest e2e",
+    "test:e2e": "yarn jest e2e --config=jest-puppeteer.config.js",
     "watch": "yarn lerna exec --scope @looker/api-explorer --stream 'BABEL_ENV=build babel src --root-mode upward --out-dir lib/esm --source-maps --extensions .ts,.tsx --no-comments --watch'",
     "deploy-dev-portal": "rm -f ../../../developer-portal/static/apix/dist/*.js* && cp -R ./dist/*.js* ../../../developer-portal/static/apix/dist"
   },


### PR DESCRIPTION
prior to this change, debugging a unit test from inside the IDE was not possible.

To verify the fix:
1) run `yarn test:apix` from the root of the monorepo
2) run `yarn test:apix-e2e` from the root of the monorepo
3) try debugging a test

