### PR TITLE
docs: correct Ruby SDK link in examples

### DIFF
--- a/examples/ruby/README.md
+++ b/examples/ruby/README.md
@@ -4,7 +4,7 @@ You can find Ruby language examples in this folder.
 
 
 Using Looker docs: https://docs.looker.com/reference/api-and-integration/api-reference   
-Using official Looker Ruby SDK: https://github.com/looker/looker-sdk-ruby/
+Using official Looker Ruby SDK: https://github.com/looker-open-source/looker-sdk-ruby
 
 Use cases with Looker API:
 ___________


### PR DESCRIPTION
Updated the Ruby SDK examples readme to point to the new location of the Ruby SDK