### PR TITLE
chore: update workflows for node 16

### DIFF
--- a/.github/workflows/apix-ci.yml
+++ b/.github/workflows/apix-ci.yml
@@ -35,7 +35,7 @@ jobs:
       matrix:
         os:
           - ubuntu
-        node-version: [12.x]
+        node-version: [16.x]
 
     steps:
       - name: Cancel Previous Runs

--- a/.github/workflows/codegen-ci.yml
+++ b/.github/workflows/codegen-ci.yml
@@ -65,7 +65,7 @@ jobs:
 
       - uses: actions/setup-node@v1
         with:
-          node-version: 15.x
+          node-version: 16.x
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/hackathon-ci.yml
+++ b/.github/workflows/hackathon-ci.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         os:
           - ubuntu
-        node-version: [12.x]
+        node-version: [16.x]
 
     steps:
       - name: Cancel Previous Runs

--- a/.github/workflows/lerna-publish.yml
+++ b/.github/workflows/lerna-publish.yml
@@ -52,7 +52,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: 15
+          node-version: 16
           registry-url: https://wombat-dressing-room.appspot.com
 
       - name: Install dependencies and build

--- a/.github/workflows/resources-ci.yml
+++ b/.github/workflows/resources-ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 16
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/tssdk-ci.yml
+++ b/.github/workflows/tssdk-ci.yml
@@ -39,7 +39,7 @@ jobs:
       matrix:
         os:
           - ubuntu
-        node-version: [12.x, 14.x, 15.x]
+        node-version: [14.x, 15.x, 16.x]
 
     steps:
       - name: Cancel Previous Runs
@@ -118,7 +118,7 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [16.x]
         os:
           - ubuntu
         looker: ${{ fromJson(needs.setup.outputs.matrix_json) }}


### PR DESCRIPTION
API Explorer workflows are now failing when they should have in PR #1117 

This PR is to fix it