### PR TITLE
chore: drop node 18 from TS SDK CI

### DIFF
--- a/.github/workflows/tssdk-ci.yml
+++ b/.github/workflows/tssdk-ci.yml
@@ -39,7 +39,7 @@ jobs:
       matrix:
         os:
           - ubuntu
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x]
 
     steps:
       - name: Cancel Previous Runs


### PR DESCRIPTION
There are some dependencies that don't support node 18.
