### PR TITLE
chore: reset release config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,7 +12,7 @@
     "packages/extension-utils": { "release-as": "" },
     "packages/hackathon": { },
     "packages/run-it": { "release-as": "" },
-    "packages/sdk": { "release-as": "22.10.1" },
+    "packages/sdk": { },
     "packages/sdk-codegen": { "release-as": "" },
     "packages/sdk-codegen-scripts": { "release-as": "" },
     "packages/sdk-codegen-utils": { "release-as": "" },


### PR DESCRIPTION
release config is back to the default config after 22.10.1