### PR TITLE
feat: error code document retrieval

### DIFF
--- a/packages/sdk-rtl/src/apiMethods.spec.ts
+++ b/packages/sdk-rtl/src/apiMethods.spec.ts
@@ -32,7 +32,7 @@ import { DefaultSettings } from './apiSettings'
 
 describe('ApiMethods', () => {
   const hostname = 'https://looker.sdk'
-  const apiVersion = '3.1'
+  const apiVersion = '4.0'
   const settings = { base_url: hostname } as IApiSettings
   const session = { settings: settings } as IAuthSession
   const fullPath = 'https://github.com/looker-open-source/sdk-codegen'

--- a/packages/sdk-rtl/src/browserTransport.ts
+++ b/packages/sdk-rtl/src/browserTransport.ts
@@ -279,7 +279,7 @@ export class BrowserTransport extends BaseTransport {
   async request<TSuccess, TError>(
     method: HttpMethod,
     path: string,
-    queryParams?: any,
+    queryParams?: Values,
     body?: any,
     authenticator?: Authenticator,
     options?: Partial<ITransportSettings>

--- a/packages/sdk-rtl/src/errorDoc.spec.ts
+++ b/packages/sdk-rtl/src/errorDoc.spec.ts
@@ -56,6 +56,8 @@ A 404 Error response from the /login endpoint most often means that an attempt t
 
 See [HTTP 404 - Not Found](https://docs.looker.com/r/reference/looker-http-codes/404) for general information about this HTTP response from Looker.`
 
+// class ErrorDocAccess extends ErrorDoc {}
+
 describe('ErrorDoc', () => {
   const external =
     'https://docs.looker.com/r/err/4.0/429/delete/bogus/:namespace/purge'
@@ -101,15 +103,15 @@ describe('ErrorDoc', () => {
   describe('content', () => {
     const no = ErrorDocNotFound
     it.each<[string, string, number]>([
-      [badLogin, '## API Response 404 for `login`', 2],
-      [internal, `${no}422/post/bogus/bulk`, 0],
-      [external, `${no}429/delete/bogus/:namespace/purge`, 0],
-      ['', `${no}bad error code link`, 0],
+      [badLogin, '## API Response 404 for `login`', 2], // valid mock url and content so load will be called twice
+      [internal, `${no}422/post/bogus/bulk`, 1], // invalid, default to not found
+      [external, `${no}429/delete/bogus/:namespace/purge`, 1], // invalid, default to not found
+      ['', `${no}bad error code link`, 0], // just bad all around
     ])('url:"%s" should be "%s"', async (url, expected, called) => {
+      const index = `_index` // use this to access the private property
+      errDoc[index] = undefined // reset the index so mock counts are correct
       const actual = await errDoc.content(url)
-      if (called) {
-        expect(requestMock).toHaveBeenCalledTimes(called)
-      }
+      expect(requestMock).toHaveBeenCalledTimes(called)
       await expect(actual).toMatch(expected)
     })
   })

--- a/packages/sdk-rtl/src/errorDoc.spec.ts
+++ b/packages/sdk-rtl/src/errorDoc.spec.ts
@@ -43,11 +43,15 @@ import type {
 } from './transport'
 
 const sampleIndex: ErrorCodeIndex = {
+  '404': {
+    url: '404.md',
+  },
   '404/post/login': {
     url: 'login_404.md',
   },
 }
 
+const generic404 = `## Generic 404`
 const badLoginMd = `## API Response 404 for \`login\`
 
 ## Description
@@ -63,6 +67,7 @@ describe('ErrorDoc', () => {
     'https://docs.looker.com/r/err/4.0/429/delete/bogus/:namespace/purge'
   const internal = 'https://docs.looker.com/r/err/internal/422/post/bogus/bulk'
   const badLogin = 'https://docs.looker.com/r/err/4.0/404/post/login'
+  const another404 = 'https://docs.looker.com/r/err/4.0/404/post/another'
   const hostname = 'https://looker.sdk'
   const settings = { base_url: hostname } as IApiSettings
   const transport = new BrowserTransport(settings)
@@ -94,6 +99,9 @@ describe('ErrorDoc', () => {
             case `${ErrorCodesUrl}login_404.md`:
               value = badLoginMd
               break
+            case `${ErrorCodesUrl}404.md`:
+              value = generic404
+              break
           }
           return Promise.resolve({ ok: true, value })
         }
@@ -104,6 +112,7 @@ describe('ErrorDoc', () => {
     const no = ErrorDocNotFound
     it.each<[string, string, number]>([
       [badLogin, '## API Response 404 for `login`', 2], // valid mock url and content so load will be called twice
+      [another404, '## Generic 404', 2], // valid mock url and content that defaults to generic message so load will be called twice
       [internal, `${no}422/post/bogus/bulk`, 1], // invalid, default to not found
       [external, `${no}429/delete/bogus/:namespace/purge`, 1], // invalid, default to not found
       ['', `${no}bad error code link`, 0], // just bad all around

--- a/packages/sdk-rtl/src/errorDoc.spec.ts
+++ b/packages/sdk-rtl/src/errorDoc.spec.ts
@@ -46,8 +46,44 @@ const sampleIndex: ErrorCodeIndex = {
   '404': {
     url: '404.md',
   },
+  '400/get/content_metadata/{content_metadata_id}': {
+    url: 'content_metadata_400.md',
+  },
+  '422/post/folders': {
+    url: 'create_folder_422.md',
+  },
+  '422/post/groups': {
+    url: 'create_group_422.md',
+  },
+  '404/get/dashboards/{dashboard_id}/dashboard_filters': {
+    url: 'dashboard_dashboard_filters_404.md',
+  },
+  '404/delete/alerts/{alert_id}': {
+    url: 'delete_alert_404.md',
+  },
+  '404/delete/boards/{board_id}': {
+    url: 'delete_board_404.md',
+  },
+  '404/delete/dashboard_filters/{dashboard_filter_id}': {
+    url: 'delete_dashboard_filter_404.md',
+  },
+  '404/delete/looks/{look_id}': {
+    url: 'delete_look_404.md',
+  },
   '404/post/login': {
     url: 'login_404.md',
+  },
+  '404/get/roles/{role_id}': {
+    url: 'role_404.md',
+  },
+  '404/post/queries/run/{result_format}': {
+    url: 'run_inline_query_404.md',
+  },
+  '422/post/queries/run/{result_format}': {
+    url: 'run_inline_query_422.md',
+  },
+  '404/get/looks/{look_id}/run/{result_format}': {
+    url: 'run_look_404.md',
   },
 }
 
@@ -102,6 +138,9 @@ describe('ErrorDoc', () => {
             case `${ErrorCodesUrl}404.md`:
               value = generic404
               break
+            default:
+              value = `${ErrorDocNotFound}${path}`
+              break
           }
           return Promise.resolve({ ok: true, value })
         }
@@ -114,7 +153,7 @@ describe('ErrorDoc', () => {
       [badLogin, '## API Response 404 for `login`', 2], // valid mock url and content so load will be called twice
       [another404, '## Generic 404', 2], // valid mock url and content that defaults to generic message so load will be called twice
       [internal, `${no}422/post/bogus/bulk`, 1], // invalid, default to not found
-      [external, `${no}429/delete/bogus/:namespace/purge`, 1], // invalid, default to not found
+      [external, `${no}429/delete/bogus/{namespace}/purge`, 1], // invalid, default to not found
       ['', `${no}bad error code link`, 0], // just bad all around
     ])('url:"%s" should be "%s"', async (url, expected, called) => {
       const index = `_index` // use this to access the private property
@@ -166,6 +205,17 @@ describe('ErrorDoc', () => {
     })
   })
 
+  describe('specPath', () => {
+    it.each<[string, string]>([
+      ['/x/:f/y/:z', '/x/{f}/y/{z}'],
+      ['/x/{f}/y/{z}', '/x/{f}/y/{z}'],
+      ['/x/:foo/y/:zoo', '/x/{foo}/y/{zoo}'],
+      ['', ''],
+    ])('path: "%s" should be "%s"', (path, expected) =>
+      expect(errDoc.specPath(path)).toEqual(expected)
+    )
+  })
+
   describe('errorKey', () => {
     it('resolves internal paths', () => {
       const actual = errDoc.errorKey(internal)
@@ -173,7 +223,7 @@ describe('ErrorDoc', () => {
     })
     it('resolves external paths', () => {
       const actual = errDoc.errorKey(external)
-      expect(actual).toEqual('429/delete/bogus/:namespace/purge')
+      expect(actual).toEqual('429/delete/bogus/{namespace}/purge')
     })
   })
 

--- a/packages/sdk-rtl/src/errorDoc.spec.ts
+++ b/packages/sdk-rtl/src/errorDoc.spec.ts
@@ -1,0 +1,78 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2022 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+
+import { APIMethods } from './apiMethods'
+import type { IApiSettings } from './apiSettings'
+import type { IAuthSession } from './authSession'
+import { ErrorDoc } from './errorDoc'
+
+/**
+ *
+ *
+ * https://docs.looker.com/r/err/4.0/429/delete/artifact/:namespace/purge
+ *
+ *
+ */
+describe('ErrorDoc', () => {
+  const external = 'https://docs.looker.com/r/err/4.0/422/post/board_items/bulk'
+  const internal =
+    'https://docs.looker.com/r/err/internal/422/post/board_items/bulk'
+  const hostname = 'https://looker.sdk'
+  // const apiVersion = '4.0'
+  const settings = { base_url: hostname } as IApiSettings
+  const session = { settings: settings } as IAuthSession
+  const api = new APIMethods(session, 'mock')
+  const errDoc = new ErrorDoc(api)
+  // api.apiVersion = apiVersion
+  // api.apiPath = `${settings.base_url}/api/${apiVersion}`
+  describe('parse', () => {
+    it('has a valid regex', () => {
+      const ex = String.raw`(?<redirector>https:\/\/docs\.looker\.com\/r\/err\/)(?<apiVersion>.*)\/(?<statusCode>d{3})(?<apiPath>.*)`
+      const rx = RegExp(ex, 'i')
+      expect(rx).toBeDefined()
+      let actual = external.match(rx)
+      expect(actual).toBeDefined()
+      actual = internal.match(rx)
+      expect(actual).toBeDefined()
+    })
+
+    it('does not fail', () => {
+      const actual = errDoc.parse('')
+      expect(actual).toBeDefined()
+    })
+
+    it('handles internal pats', () => {
+      const actual = errDoc.parse(
+        'https://docs.looker.com/r/err/internal/422/post/board_items/bulk'
+      )
+      expect(actual).toBeDefined()
+      expect(actual.redirector).toEqual('https://docs.looker.com/r/err/')
+      expect(actual.apiVersion).toEqual('internal')
+      expect(actual.statusCode).toEqual('422')
+      expect(actual.apiPath).toEqual('post/board_items/bulk')
+    })
+  })
+})

--- a/packages/sdk-rtl/src/errorDoc.ts
+++ b/packages/sdk-rtl/src/errorDoc.ts
@@ -96,8 +96,8 @@ const ErrorDocPatternExpression = String.raw`(?<redirector>https:\/\/docs\.looke
 export const ErrorDocRx = RegExp(ErrorDocPatternExpression, 'i')
 
 export class ErrorDoc implements IErrorDoc {
-  private transport: BaseTransport
   private _index?: ErrorCodeIndex = undefined
+  private transport: BaseTransport
   constructor(
     public sdk: IAPIMethods,
     public readonly cdnUrl: string = ErrorCodesUrl

--- a/packages/sdk-rtl/src/errorDoc.ts
+++ b/packages/sdk-rtl/src/errorDoc.ts
@@ -93,6 +93,16 @@ export interface IErrorDoc {
   content(docUrl: string): Promise<string>
 
   /**
+   * Ensure API request path matches the OpenAPI path pattern
+   *
+   * @example
+   * `/entity/:id/part/:part` should be `/entity/{id}/part/{part}`
+   *
+   * @param path to convert to a spec path
+   */
+  specPath(path: string): string
+
+  /**
    * get the lookup key for the documentation_url
    * @param docUrl value of documentation_url from error payload
    */
@@ -143,10 +153,15 @@ export class ErrorDoc implements IErrorDoc {
     return this._index
   }
 
+  specPath(path: string): string {
+    const result = path.replace(/:\w+/g, (found) => `{${found.substr(1)}}`)
+    return result
+  }
+
   errorKey(docUrl: string): string {
     const bits = this.parse(docUrl)
     if (!bits.redirector) return ''
-    return `${bits.statusCode}${bits.apiPath}`
+    return this.specPath(`${bits.statusCode}${bits.apiPath}`)
   }
 
   private notFound(key: string): string {

--- a/packages/sdk-rtl/src/errorDoc.ts
+++ b/packages/sdk-rtl/src/errorDoc.ts
@@ -1,0 +1,174 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2022 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+
+import type { IApiModel } from '@looker/sdk-codegen'
+import type { BaseTransport } from './baseTransport'
+import type { IAPIMethods } from './apiMethods'
+import { sdkOk } from './transport'
+
+export interface IErrorDocItem {
+  url: string
+}
+
+type ErrorCodeIndex = Record<string, IErrorDocItem>
+export const ErrorCodesUrl = 'https://marketplace-api.looker.com/errorcodes/'
+export const ErrorCodesIndexUrl = `${ErrorCodesUrl}index.json`
+
+export interface IErrorDocLink {
+  /** base redirector url */
+  redirector: string
+  /** api version of the error link */
+  apiVersion: string
+  /** HTTP status code */
+  statusCode: string
+  /** REST API Path */
+  apiPath: string
+}
+
+export interface IErrorDoc {
+  /** Index of all know error codes */
+  index: ErrorCodeIndex
+
+  /**
+   * Extract error url into its parts
+   * @param docUrl value of documentation_url from error payload
+   */
+  parse(docUrl: string): IErrorDocLink
+
+  /**
+   * full url to resolve error document
+   * @param item resolved index item (used by content())
+   */
+  contentUrl(item: IErrorDocItem): string
+
+  /**
+   * Markdown of error document
+   * @param docUrl value of documentation_url from error payload
+   */
+  content(docUrl: string): Promise<string>
+
+  /**
+   * get the lookup key for the documentation_url
+   * @param docUrl value of documentation_url from error payload
+   */
+  errorKey(docUrl: string): string
+
+  /** Fetch and parse the error codes documentation index from the CDN */
+  load(): Promise<ErrorCodeIndex>
+
+  /** get the name of the method from the error doc url
+   *
+   * @param docUrl value of documentation_url from error payload
+   * @param api API specification for looking up the method
+   */
+  methodName(docUrl: string, api: IApiModel): string
+}
+
+/** Error document link pattern */
+export const ErrorDocPattern =
+  /(?<redirector>https:\/\/docs\.looker\.com\/r\/err\/)(?<apiVersion>.*)\/(?<statusCode>\d{3})(?<apiPath>.*)/i
+
+export class ErrorDoc implements IErrorDoc {
+  private transport: BaseTransport
+  private _index: ErrorCodeIndex = {}
+  constructor(
+    public sdk: IAPIMethods,
+    public readonly cdnUrl: string = ErrorCodesUrl
+  ) {
+    this.transport = sdk.authSession.transport as BaseTransport
+  }
+
+  public async load(): Promise<ErrorCodeIndex> {
+    try {
+      const result = await sdkOk(
+        this.transport.request<ErrorCodeIndex, Error>('GET', this.indexUrl)
+      )
+      return result
+    } catch (e: any) {
+      return {}
+    }
+  }
+
+  public get indexUrl() {
+    return `${this.cdnUrl}index.json`
+  }
+
+  public get index() {
+    if (Object.keys(this._index).length === 0) {
+      this.load()
+        .then((response) => (this._index = response))
+        .catch((reason) => console.error(reason))
+    }
+    return this._index
+  }
+
+  errorKey(docUrl: string): string {
+    const bits = this.parse(docUrl)
+    if (!bits.redirector) return ''
+    return `${bits.statusCode}/${bits.apiPath}`
+  }
+
+  private notFound(key: string): string {
+    return `### No documentation found: ${key}`
+  }
+
+  async content(docUrl: string): Promise<string> {
+    const key = this.errorKey(docUrl)
+    if (!key) {
+      return Promise.resolve(this.notFound('bad error code link'))
+    }
+    const item = this.index[docUrl]
+    if (!item) {
+      return Promise.resolve(this.notFound(key))
+    }
+    try {
+      const url = this.contentUrl(item)
+      const md = await sdkOk(this.transport.request<string, Error>('GET', url))
+      return md
+    } catch (e: any) {
+      return Promise.resolve(this.notFound(e.message))
+    }
+  }
+
+  contentUrl(item: IErrorDocItem): string {
+    return `${this.cdnUrl}${item.url}`
+  }
+
+  methodName(docUrl: string, _api: IApiModel): string {
+    return docUrl
+  }
+
+  parse(docUrl: string): IErrorDocLink {
+    const match = docUrl.match(ErrorDocPattern)
+    const result: IErrorDocLink = {
+      redirector: match?.groups?.redirector || '',
+      apiVersion: match?.groups?.apiVersion || '',
+      statusCode: match?.groups?.statusCode || '',
+      apiPath: match?.groups?.apiPath || '',
+    }
+    return result
+  }
+}


### PR DESCRIPTION
Retrieves the best match error code document for the provided error url from an API error payload

See `errorDoc.spec.ts` for an implementation example
