### PR TITLE
feat: Tag scene filter selection as URL search parameter

### DIFF
--- a/packages/api-explorer/src/ApiExplorer.tsx
+++ b/packages/api-explorer/src/ApiExplorer.tsx
@@ -91,7 +91,8 @@ export const ApiExplorer: FC<ApiExplorerProps> = ({
   const specs = useSelector(selectSpecs)
   const spec = useSelector(selectCurrentSpec)
   const { initLodesAction } = useLodeActions()
-  const { initSettingsAction, setSearchPatternAction } = useSettingActions()
+  const { initSettingsAction, setSearchPatternAction, setTagFilterAction } =
+    useSettingActions()
   const { initSpecsAction, setCurrentSpecAction } = useSpecActions()
 
   const location = useLocation()
@@ -126,7 +127,15 @@ export const ApiExplorer: FC<ApiExplorerProps> = ({
   useEffect(() => {
     const searchParams = new URLSearchParams(location.search)
     const searchPattern = searchParams.get('s') || ''
-    setSearchPatternAction({ searchPattern: searchPattern! })
+    const verbParam = searchParams.get('v') || 'ALL'
+    // TODO: need to validate verbParam, checking against all available
+    //       httpMethod and metaType options, default to ALL if not valid
+    setSearchPatternAction({
+      searchPattern: searchPattern!,
+    })
+    setTagFilterAction({
+      tagFilter: verbParam.toUpperCase(),
+    })
   }, [location.search])
 
   useEffect(() => {

--- a/packages/api-explorer/src/ApiExplorer.tsx
+++ b/packages/api-explorer/src/ApiExplorer.tsx
@@ -68,6 +68,7 @@ import {
   selectSpecs,
   selectCurrentSpec,
   selectSdkLanguage,
+  selectTagFilter,
 } from './state'
 import {
   getSpecKey,
@@ -99,6 +100,7 @@ export const ApiExplorer: FC<ApiExplorerProps> = ({
   const specs = useSelector(selectSpecs)
   const spec = useSelector(selectCurrentSpec)
   const selectedSdkLanguage = useSelector(selectSdkLanguage)
+  const selectedTagFilter = useSelector(selectTagFilter)
   const { initLodesAction } = useLodeActions()
   const {
     initSettingsAction,
@@ -136,10 +138,13 @@ export const ApiExplorer: FC<ApiExplorerProps> = ({
     // reconcile local storage state with URL or vice versa
     if (initialized) {
       const sdkParam = searchParams.get('sdk') || ''
+      const verbParam = searchParams.get('v') || ''
       const sdk = findSdk(sdkParam)
       const validSdkParam =
         !sdkParam.localeCompare(sdk.alias, 'en', { sensitivity: 'base' }) ||
         !sdkParam.localeCompare(sdk.language, 'en', { sensitivity: 'base' })
+      const validVerbParam = isValidFilter(location, verbParam)
+
       if (validSdkParam) {
         // sync store with URL
         setSdkLanguageAction({
@@ -150,6 +155,14 @@ export const ApiExplorer: FC<ApiExplorerProps> = ({
         const { alias } = findSdk(selectedSdkLanguage)
         navigate(location.pathname, {
           sdk: alias === allAlias ? null : alias,
+        })
+      }
+
+      if (validVerbParam) {
+        setTagFilterAction({ tagFilter: verbParam.toUpperCase() })
+      } else {
+        navigate(location.pathname, {
+          v: selectedTagFilter === 'ALL' ? null : selectedTagFilter,
         })
       }
     }
@@ -171,8 +184,6 @@ export const ApiExplorer: FC<ApiExplorerProps> = ({
     const { language: sdkLanguage } = findSdk(sdkParam)
     setSearchPatternAction({ searchPattern })
     setSdkLanguageAction({ sdkLanguage })
-    // TODO: need to validate verbParam, checking against all available
-    //       httpMethod and metaType options, default to ALL if not valid
     setTagFilterAction({
       tagFilter: isValidFilter(location, verbParam)
         ? verbParam.toUpperCase()

--- a/packages/api-explorer/src/ApiExplorer.tsx
+++ b/packages/api-explorer/src/ApiExplorer.tsx
@@ -68,7 +68,7 @@ import {
   selectSpecs,
   selectCurrentSpec,
 } from './state'
-import { getSpecKey, diffPath } from './utils'
+import { getSpecKey, diffPath, isValidFilter } from './utils'
 
 export interface ApiExplorerProps {
   adaptor: IApixAdaptor
@@ -134,7 +134,9 @@ export const ApiExplorer: FC<ApiExplorerProps> = ({
       searchPattern: searchPattern!,
     })
     setTagFilterAction({
-      tagFilter: verbParam.toUpperCase(),
+      tagFilter: isValidFilter(location, verbParam)
+        ? verbParam.toUpperCase()
+        : 'ALL',
     })
   }, [location.search])
 

--- a/packages/api-explorer/src/components/SelectorContainer/SelectorContainer.tsx
+++ b/packages/api-explorer/src/components/SelectorContainer/SelectorContainer.tsx
@@ -51,6 +51,9 @@ export const SelectorContainer: FC<SelectorContainerProps> = ({
   ...spaceProps
 }) => {
   const searchParams = new URLSearchParams(location.search)
+  // TODO: noticing that there are certain pages where we must delete extra params
+  //       before pushing its link, what's a way we can handle this?
+  searchParams.delete('v')
   return (
     <Space width="auto" {...spaceProps}>
       <SdkLanguageSelector />

--- a/packages/api-explorer/src/components/SideNav/SideNav.tsx
+++ b/packages/api-explorer/src/components/SideNav/SideNav.tsx
@@ -89,7 +89,7 @@ export const SideNav: FC<SideNavProps> = ({ headless = false, spec }) => {
     } else {
       if (parts[2] !== tabNames[index]) {
         parts[2] = tabNames[index]
-        navigate(parts.join('/'))
+        navigate(parts.join('/'), { v: null })
       }
     }
   }
@@ -115,10 +115,10 @@ export const SideNav: FC<SideNavProps> = ({ headless = false, spec }) => {
     const searchParams = new URLSearchParams(location.search)
     if (debouncedPattern && debouncedPattern !== searchParams.get('s')) {
       searchParams.set('s', debouncedPattern)
-      navigate(location.pathname, { search: searchParams.toString() })
+      navigate(location.pathname, { s: searchParams.get('s') })
     } else if (!debouncedPattern && searchParams.get('s')) {
       searchParams.delete('s')
-      navigate(location.pathname, { search: searchParams.toString() })
+      navigate(location.pathname, { s: null })
     }
   }, [location.search, debouncedPattern])
 

--- a/packages/api-explorer/src/components/SideNav/SideNav.tsx
+++ b/packages/api-explorer/src/components/SideNav/SideNav.tsx
@@ -84,7 +84,7 @@ export const SideNav: FC<SideNavProps> = ({ headless = false, spec }) => {
     if (parts[1] === 'diff') {
       if (parts[3] !== tabNames[index]) {
         parts[3] = tabNames[index]
-        navigate(parts.join('/'))
+        navigate(parts.join('/'), { v: null })
       }
     } else {
       if (parts[2] !== tabNames[index]) {

--- a/packages/api-explorer/src/components/SideNav/SideNavMethods.tsx
+++ b/packages/api-explorer/src/components/SideNav/SideNavMethods.tsx
@@ -32,7 +32,7 @@ import { useSelector } from 'react-redux'
 import { useLocation, useRouteMatch } from 'react-router-dom'
 import { useNavigation, highlightHTML, buildMethodPath } from '../../utils'
 import { Link } from '../Link'
-import { selectSearchPattern } from '../../state'
+import { selectSearchPattern, selectTagFilter } from '../../state'
 
 interface MethodsProps {
   methods: MethodList
@@ -48,6 +48,7 @@ export const SideNavMethods = styled(
     const navigate = useNavigation()
     const searchParams = new URLSearchParams(location.search)
     const searchPattern = useSelector(selectSearchPattern)
+    const selectedTagFilter = useSelector(selectTagFilter)
     const match = useRouteMatch<{ methodTag: string }>(
       `/:specKey/methods/:methodTag/:methodName?`
     )
@@ -82,20 +83,24 @@ export const SideNavMethods = styled(
         }
       >
         <ul>
-          {Object.values(methods).map((method) => (
-            <li key={method.name}>
-              <Link
-                to={`${buildMethodPath(
-                  specKey,
-                  tag,
-                  method.name,
-                  searchParams.toString()
-                )}`}
-              >
-                {highlightHTML(searchPattern, method.summary)}
-              </Link>
-            </li>
-          ))}
+          {Object.values(methods).map(
+            (method) =>
+              (selectedTagFilter === 'ALL' ||
+                selectedTagFilter === method.httpMethod) && (
+                <li key={method.name}>
+                  <Link
+                    to={buildMethodPath(
+                      specKey,
+                      tag,
+                      method.name,
+                      searchParams.toString()
+                    )}
+                  >
+                    {highlightHTML(searchPattern, method.summary)}
+                  </Link>
+                </li>
+              )
+          )}
         </ul>
       </Accordion2>
     )

--- a/packages/api-explorer/src/components/SideNav/SideNavMethods.tsx
+++ b/packages/api-explorer/src/components/SideNav/SideNavMethods.tsx
@@ -32,7 +32,7 @@ import { useSelector } from 'react-redux'
 import { useLocation, useRouteMatch } from 'react-router-dom'
 import { useNavigation, highlightHTML, buildMethodPath } from '../../utils'
 import { Link } from '../Link'
-import { selectSearchPattern, selectTagFilter } from '../../state'
+import { selectSearchPattern } from '../../state'
 
 interface MethodsProps {
   methods: MethodList
@@ -48,7 +48,6 @@ export const SideNavMethods = styled(
     const navigate = useNavigation()
     const searchParams = new URLSearchParams(location.search)
     const searchPattern = useSelector(selectSearchPattern)
-    const selectedTagFilter = useSelector(selectTagFilter)
     const match = useRouteMatch<{ methodTag: string }>(
       `/:specKey/methods/:methodTag/:methodName?`
     )
@@ -83,24 +82,23 @@ export const SideNavMethods = styled(
         }
       >
         <ul>
-          {Object.values(methods).map(
-            (method) =>
-              (selectedTagFilter === 'ALL' ||
-                selectedTagFilter === method.httpMethod) && (
-                <li key={method.name}>
-                  <Link
-                    to={buildMethodPath(
-                      specKey,
-                      tag,
-                      method.name,
-                      searchParams.toString()
-                    )}
-                  >
-                    {highlightHTML(searchPattern, method.summary)}
-                  </Link>
-                </li>
-              )
-          )}
+          {Object.values(methods).map((method) => (
+            <li key={method.name}>
+              <Link
+                to={() => {
+                  searchParams.delete('v')
+                  return buildMethodPath(
+                    specKey,
+                    tag,
+                    method.name,
+                    searchParams.toString()
+                  )
+                }}
+              >
+                {highlightHTML(searchPattern, method.summary)}
+              </Link>
+            </li>
+          ))}
         </ul>
       </Accordion2>
     )

--- a/packages/api-explorer/src/components/SideNav/SideNavTypes.tsx
+++ b/packages/api-explorer/src/components/SideNav/SideNavTypes.tsx
@@ -32,7 +32,7 @@ import { useLocation, useRouteMatch } from 'react-router-dom'
 import { useSelector } from 'react-redux'
 import { Link } from '../Link'
 import { highlightHTML, useNavigation, buildTypePath } from '../../utils'
-import { selectSearchPattern } from '../../state'
+import { selectSearchPattern, selectTagFilter } from '../../state'
 
 interface TypesProps {
   types: TypeList
@@ -48,6 +48,7 @@ export const SideNavTypes = styled(
     const navigate = useNavigation()
     const searchParams = new URLSearchParams(location.search)
     const searchPattern = useSelector(selectSearchPattern)
+    const selectedTagFilter = useSelector(selectTagFilter)
     const match = useRouteMatch<{ typeTag: string }>(
       `/:specKey/types/:typeTag/:typeName?`
     )
@@ -82,20 +83,24 @@ export const SideNavTypes = styled(
         }
       >
         <ul>
-          {Object.values(types).map((type) => (
-            <li key={type.name}>
-              <Link
-                to={`${buildTypePath(
-                  specKey,
-                  tag,
-                  type.name,
-                  searchParams.toString()
-                )}`}
-              >
-                {highlightHTML(searchPattern, type.name)}
-              </Link>
-            </li>
-          ))}
+          {Object.values(types).map(
+            (type) =>
+              (selectedTagFilter === 'ALL' ||
+                selectedTagFilter === type.metaType.toUpperCase()) && (
+                <li key={type.name}>
+                  <Link
+                    to={`${buildTypePath(
+                      specKey,
+                      tag,
+                      type.name,
+                      searchParams.toString()
+                    )}`}
+                  >
+                    {highlightHTML(searchPattern, type.name)}
+                  </Link>
+                </li>
+              )
+          )}
         </ul>
       </Accordion2>
     )

--- a/packages/api-explorer/src/components/SideNav/SideNavTypes.tsx
+++ b/packages/api-explorer/src/components/SideNav/SideNavTypes.tsx
@@ -32,7 +32,7 @@ import { useLocation, useRouteMatch } from 'react-router-dom'
 import { useSelector } from 'react-redux'
 import { Link } from '../Link'
 import { highlightHTML, useNavigation, buildTypePath } from '../../utils'
-import { selectSearchPattern, selectTagFilter } from '../../state'
+import { selectSearchPattern } from '../../state'
 
 interface TypesProps {
   types: TypeList
@@ -48,7 +48,6 @@ export const SideNavTypes = styled(
     const navigate = useNavigation()
     const searchParams = new URLSearchParams(location.search)
     const searchPattern = useSelector(selectSearchPattern)
-    const selectedTagFilter = useSelector(selectTagFilter)
     const match = useRouteMatch<{ typeTag: string }>(
       `/:specKey/types/:typeTag/:typeName?`
     )
@@ -83,24 +82,23 @@ export const SideNavTypes = styled(
         }
       >
         <ul>
-          {Object.values(types).map(
-            (type) =>
-              (selectedTagFilter === 'ALL' ||
-                selectedTagFilter === type.metaType.toUpperCase()) && (
-                <li key={type.name}>
-                  <Link
-                    to={`${buildTypePath(
-                      specKey,
-                      tag,
-                      type.name,
-                      searchParams.toString()
-                    )}`}
-                  >
-                    {highlightHTML(searchPattern, type.name)}
-                  </Link>
-                </li>
-              )
-          )}
+          {Object.values(types).map((type) => (
+            <li key={type.name}>
+              <Link
+                to={() => {
+                  searchParams.delete('v')
+                  return buildTypePath(
+                    specKey,
+                    tag,
+                    type.name,
+                    searchParams.toString()
+                  )
+                }}
+              >
+                {highlightHTML(searchPattern, type.name)}
+              </Link>
+            </li>
+          ))}
         </ul>
       </Accordion2>
     )

--- a/packages/api-explorer/src/scenes/MethodTagScene/MethodTagScene.spec.tsx
+++ b/packages/api-explorer/src/scenes/MethodTagScene/MethodTagScene.spec.tsx
@@ -32,6 +32,7 @@ import { api } from '../../test-data'
 import { renderWithRouterAndReduxProvider } from '../../test-utils'
 import { MethodTagScene } from './MethodTagScene'
 
+// TODO: use constant from path.ts
 const opBtnNames = /ALL|GET|POST|PUT|PATCH|DELETE/
 
 const mockHistoryPush = jest.fn()

--- a/packages/api-explorer/src/scenes/MethodTagScene/MethodTagScene.spec.tsx
+++ b/packages/api-explorer/src/scenes/MethodTagScene/MethodTagScene.spec.tsx
@@ -29,16 +29,28 @@ import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 import { api } from '../../test-data'
-import { renderWithRouter } from '../../test-utils'
+import { renderWithRouterAndReduxProvider } from '../../test-utils'
 import { MethodTagScene } from './MethodTagScene'
 
 const opBtnNames = /ALL|GET|POST|PUT|PATCH|DELETE/
+
+const mockHistoryPush = jest.fn()
+jest.mock('react-router-dom', () => {
+  const ReactRouterDOM = jest.requireActual('react-router-dom')
+  return {
+    ...ReactRouterDOM,
+    useHistory: () => ({
+      push: mockHistoryPush,
+      location,
+    }),
+  }
+})
 
 describe('MethodTagScene', () => {
   Element.prototype.scrollTo = jest.fn()
 
   test('it renders operation buttons and all methods for a given method tag', () => {
-    renderWithRouter(
+    renderWithRouterAndReduxProvider(
       <Route path="/:specKey/methods/:methodTag">
         <MethodTagScene api={api} />
       </Route>,
@@ -62,7 +74,7 @@ describe('MethodTagScene', () => {
 
   test('it only renders operation buttons for operations that exist under that tag', () => {
     /** ApiAuth contains two POST methods and a DELETE method */
-    renderWithRouter(
+    renderWithRouterAndReduxProvider(
       <Route path="/:specKey/methods/:methodTag">
         <MethodTagScene api={api} />
       </Route>,
@@ -75,30 +87,29 @@ describe('MethodTagScene', () => {
     ).toHaveLength(3)
   })
 
-  test('it filters methods by operation type', async () => {
-    renderWithRouter(
+  test('it pushes filter to URL on toggle', async () => {
+    renderWithRouterAndReduxProvider(
       <Route path="/:specKey/methods/:methodTag">
         <MethodTagScene api={api} />
       </Route>,
       ['/3.1/methods/Look']
     )
-    const allLookMethods = /^\/look.*/
-    expect(screen.getAllByText(allLookMethods)).toHaveLength(7)
     /** Filter by GET operation */
     userEvent.click(screen.getByRole('button', { name: 'GET' }))
     await waitFor(() => {
-      expect(screen.getAllByText(allLookMethods)).toHaveLength(4)
+      expect(mockHistoryPush).toHaveBeenCalledWith({
+        pathname: location.pathname,
+        search: 'v=get',
+      })
     })
     /** Filter by DELETE operation */
     userEvent.click(screen.getByRole('button', { name: 'DELETE' }))
     await waitFor(() => {
       // eslint-disable-next-line jest-dom/prefer-in-document
-      expect(screen.getAllByText(allLookMethods)).toHaveLength(1)
-    })
-    /** Restore original state */
-    userEvent.click(screen.getByRole('button', { name: 'ALL' }))
-    await waitFor(() => {
-      expect(screen.getAllByText(allLookMethods)).toHaveLength(7)
+      expect(mockHistoryPush).toHaveBeenCalledWith({
+        pathname: location.pathname,
+        search: 'v=delete',
+      })
     })
   })
 })

--- a/packages/api-explorer/src/scenes/MethodTagScene/MethodTagScene.spec.tsx
+++ b/packages/api-explorer/src/scenes/MethodTagScene/MethodTagScene.spec.tsx
@@ -32,7 +32,6 @@ import { api } from '../../test-data'
 import { renderWithRouterAndReduxProvider } from '../../test-utils'
 import { MethodTagScene } from './MethodTagScene'
 
-// TODO: use constant from path.ts
 const opBtnNames = /ALL|GET|POST|PUT|PATCH|DELETE/
 
 const mockHistoryPush = jest.fn()

--- a/packages/api-explorer/src/scenes/MethodTagScene/MethodTagScene.tsx
+++ b/packages/api-explorer/src/scenes/MethodTagScene/MethodTagScene.tsx
@@ -99,12 +99,15 @@ export const MethodTagScene: FC<MethodTagSceneProps> = ({ api }) => {
             selectedTagFilter === method.httpMethod) && (
             <Link
               key={index}
-              to={buildMethodPath(
-                specKey,
-                tag.name,
-                method.name,
-                searchParams.toString()
-              )}
+              to={() => {
+                searchParams.delete('v')
+                return buildMethodPath(
+                  specKey,
+                  tag.name,
+                  method.name,
+                  searchParams.toString()
+                )
+              }}
             >
               <Grid columns={1} py="xsmall">
                 <DocMethodSummary key={index} method={method} />

--- a/packages/api-explorer/src/scenes/TypeTagScene/TypeTagScene.spec.tsx
+++ b/packages/api-explorer/src/scenes/TypeTagScene/TypeTagScene.spec.tsx
@@ -36,6 +36,18 @@ const opBtnNames = /ALL|SPECIFICATION|WRITE|REQUEST|ENUMERATED/
 
 const path = '/:specKey/types/:typeTag'
 
+const mockHistoryPush = jest.fn()
+jest.mock('react-router-dom', () => {
+  const ReactRouterDOM = jest.requireActual('react-router-dom')
+  return {
+    ...ReactRouterDOM,
+    useHistory: () => ({
+      push: mockHistoryPush,
+      location,
+    }),
+  }
+})
+
 describe('TypeTagScene', () => {
   Element.prototype.scrollTo = jest.fn()
 
@@ -74,30 +86,28 @@ describe('TypeTagScene', () => {
     ).toHaveLength(2)
   })
 
-  test('it filters methods by operation type', async () => {
+  test('it pushes filter to URL on toggle', async () => {
     renderWithRouterAndReduxProvider(
       <Route path={path}>
         <TypeTagScene api={api} />
       </Route>,
       ['/3.1/types/Look']
     )
-    expect(screen.getAllByRole('heading', { level: 3 })).toHaveLength(
-      Object.keys(api.typeTags.Look).length
-    )
-
-    expect(screen.getAllByRole('heading', { level: 3 })).toHaveLength(
-      Object.keys(api.typeTags.Look).length
-    )
-
     /** Filter by SPECIFICATION */
     userEvent.click(screen.getByRole('button', { name: 'SPECIFICATION' }))
     await waitFor(() => {
-      expect(screen.getAllByRole('heading', { level: 3 })).toHaveLength(5)
+      expect(mockHistoryPush).toHaveBeenCalledWith({
+        pathname: location.pathname,
+        search: 'v=specification',
+      })
     })
     /** Filter by REQUEST */
     userEvent.click(screen.getByRole('button', { name: 'REQUEST' }))
     await waitFor(() => {
-      expect(screen.getAllByRole('heading', { level: 3 })).toHaveLength(2)
+      expect(mockHistoryPush).toHaveBeenCalledWith({
+        pathname: location.pathname,
+        search: 'v=request',
+      })
     })
   })
 })

--- a/packages/api-explorer/src/scenes/TypeTagScene/TypeTagScene.tsx
+++ b/packages/api-explorer/src/scenes/TypeTagScene/TypeTagScene.tsx
@@ -96,12 +96,15 @@ export const TypeTagScene: FC<TypeTagSceneProps> = ({ api }) => {
             selectedTagFilter === type.metaType.toString().toUpperCase()) && (
             <Link
               key={index}
-              to={buildTypePath(
-                specKey,
-                tag.name,
-                type.name,
-                searchParams.toString()
-              )}
+              to={() => {
+                searchParams.delete('v')
+                return buildTypePath(
+                  specKey,
+                  tag.name,
+                  type.name,
+                  searchParams.toString()
+                )
+              }}
             >
               <Grid columns={1} py="xsmall">
                 <DocTypeSummary key={index} type={type} />

--- a/packages/api-explorer/src/scenes/TypeTagScene/TypeTagScene.tsx
+++ b/packages/api-explorer/src/scenes/TypeTagScene/TypeTagScene.tsx
@@ -24,7 +24,7 @@
 
  */
 import type { FC } from 'react'
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Grid, ButtonToggle, ButtonItem } from '@looker/components'
 import type { ApiModel } from '@looker/sdk-codegen'
 import { useParams } from 'react-router-dom'
@@ -48,6 +48,7 @@ export const TypeTagScene: FC<TypeTagSceneProps> = ({ api }) => {
   const navigate = useNavigation()
   const searchParams = new URLSearchParams(location.search)
   const selectedTagFilter = useSelector(selectTagFilter)
+  const [tagFilter, setTagFilter] = useState(selectedTagFilter)
 
   const types = api.typeTags[typeTag]
   useEffect(() => {
@@ -57,7 +58,7 @@ export const TypeTagScene: FC<TypeTagSceneProps> = ({ api }) => {
   }, [types])
 
   useEffect(() => {
-    setValue(selectedTagFilter)
+    setTagFilter(selectedTagFilter)
   }, [selectedTagFilter])
 
   if (!types) {
@@ -78,7 +79,7 @@ export const TypeTagScene: FC<TypeTagSceneProps> = ({ api }) => {
       <ButtonToggle
         mb="small"
         mt="xlarge"
-        value={selectedTagFilter}
+        value={tagFilter}
         onChange={setValue}
       >
         <ButtonItem key="ALL" px="large" py="xsmall">

--- a/packages/api-explorer/src/state/settings/selectors.spec.ts
+++ b/packages/api-explorer/src/state/settings/selectors.spec.ts
@@ -24,7 +24,7 @@
 
  */
 import { createTestStore, preloadedState } from '../../test-utils'
-import { selectSdkLanguage, isInitialized } from './selectors'
+import { selectSdkLanguage, isInitialized, selectTagFilter } from './selectors'
 
 const testStore = createTestStore()
 
@@ -35,6 +35,10 @@ describe('Settings selectors', () => {
     expect(selectSdkLanguage(state)).toEqual(
       preloadedState.settings.sdkLanguage
     )
+  })
+
+  test('selectTagFilter selects', () => {
+    expect(selectTagFilter(state)).toEqual(preloadedState.settings.tagFilter)
   })
 
   test('isInitialized selects', () => {

--- a/packages/api-explorer/src/state/settings/selectors.ts
+++ b/packages/api-explorer/src/state/settings/selectors.ts
@@ -36,5 +36,8 @@ export const selectSearchPattern = (state: RootState) =>
 export const selectSearchCriteria = (state: RootState) =>
   selectSettingsState(state).searchCriteria
 
+export const selectTagFilter = (state: RootState) =>
+  selectSettingsState(state).tagFilter
+
 export const isInitialized = (state: RootState) =>
   selectSettingsState(state).initialized

--- a/packages/api-explorer/src/state/settings/slice.ts
+++ b/packages/api-explorer/src/state/settings/slice.ts
@@ -38,6 +38,7 @@ export interface UserDefinedSettings {
 export interface SettingState extends UserDefinedSettings {
   searchPattern: string
   searchCriteria: SearchCriterionTerm[]
+  tagFilter: string
   initialized: boolean
   error?: Error
 }
@@ -46,6 +47,7 @@ export const defaultSettings = {
   sdkLanguage: 'Python',
   searchPattern: '',
   searchCriteria: setToCriteria(SearchAll) as SearchCriterionTerm[],
+  tagFilter: 'ALL',
 }
 
 export const defaultSettingsState: SettingState = {
@@ -55,6 +57,7 @@ export const defaultSettingsState: SettingState = {
 
 type SetSearchPatternAction = Pick<SettingState, 'searchPattern'>
 type SetSdkLanguageAction = Pick<SettingState, 'sdkLanguage'>
+type SetTagFilterAction = Pick<SettingState, 'tagFilter'>
 
 export type InitSuccessPayload = UserDefinedSettings
 
@@ -83,6 +86,9 @@ export const settingsSlice = createSlice({
       action: PayloadAction<SetSearchPatternAction>
     ) {
       state.searchPattern = action.payload.searchPattern
+    },
+    setTagFilterAction(state, action: PayloadAction<SetTagFilterAction>) {
+      state.tagFilter = action.payload.tagFilter
     },
   },
 })

--- a/packages/api-explorer/src/test-data/tagFilters.ts
+++ b/packages/api-explorer/src/test-data/tagFilters.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +23,6 @@
  SOFTWARE.
 
  */
-export * from './specs'
-export { examples } from './examples'
-export * from './declarations'
-export * from './sdkLanguages'
-export * from './tagFilters'
+
+export const methodFilters = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE']
+export const typeFilters = ['SPECIFICATION', 'WRITE', 'REQUEST', 'ENUMERATED']

--- a/packages/api-explorer/src/utils/hooks.spec.ts
+++ b/packages/api-explorer/src/utils/hooks.spec.ts
@@ -60,19 +60,12 @@ describe('Navigate', () => {
     })
   })
 
-  test('clears existing params when given params are an empty object', () => {
-    navigate(route, {})
-    expect(mockHistoryPush).lastCalledWith({
-      pathname: route,
-    })
-  })
-
   test('sets query parameters when given a populated query params object', () => {
-    const newParams = 's=embedsso'
-    navigate(route, { search: newParams })
+    const searchParam = 'embedsso'
+    navigate(route, { s: searchParam })
     expect(mockHistoryPush).lastCalledWith({
       pathname: route,
-      search: newParams,
+      search: `s=${searchParam}`,
     })
   })
 })

--- a/packages/api-explorer/src/utils/hooks.ts
+++ b/packages/api-explorer/src/utils/hooks.ts
@@ -35,17 +35,27 @@ import { useHistory } from 'react-router-dom'
 export const useNavigation = () => {
   const history = useHistory()
 
-  const navigate = (path: string, queryParams?: { search?: string } | null) => {
+  const navigate = (
+    path: string,
+    queryParams?: { s?: string | null; v?: string | null } | null
+  ) => {
+    const urlParams = new URLSearchParams(history.location.search)
     if (queryParams === undefined) {
       // if params passed in is undefined, maintain existing parameters in the URL
-      const curParams = new URLSearchParams(history.location.search)
-      history.push({ pathname: path, search: curParams.toString() })
-    } else if (queryParams === null || Object.keys(queryParams).length === 0) {
-      // if params passed in is null or empty, remove all parameters from the URL
+      history.push({ pathname: path, search: urlParams.toString() })
+    } else if (queryParams === null) {
+      // if params passed in is null, remove all parameters from the URL
       history.push({ pathname: path })
     } else {
-      // if we have new parameters passed in, push them to the URL
-      history.push({ pathname: path, search: queryParams.search })
+      // push each key as new param to URL, excluding entries with value null
+      Object.keys(queryParams).forEach((key) => {
+        if (queryParams[key] === null || queryParams[key] === '') {
+          urlParams.delete(key)
+        } else {
+          urlParams.set(key, queryParams[key])
+        }
+      })
+      history.push({ pathname: path, search: urlParams.toString() })
     }
   }
 

--- a/packages/api-explorer/src/utils/path.spec.ts
+++ b/packages/api-explorer/src/utils/path.spec.ts
@@ -24,8 +24,14 @@
 
  */
 
-import { api } from '../test-data'
-import { buildMethodPath, buildPath, buildTypePath } from './path'
+import { api, methodFilters, typeFilters } from '../test-data'
+import {
+  buildMethodPath,
+  buildPath,
+  buildTypePath,
+  getSceneType,
+  isValidFilter,
+} from './path'
 
 describe('path utils', () => {
   const testParam = 's=test'
@@ -72,6 +78,49 @@ describe('path utils', () => {
     test('given a type it creates a type path', () => {
       const path = buildPath(api, api.types.Dashboard, '3.1')
       expect(path).toEqual('/3.1/types/Dashboard/Dashboard')
+    })
+  })
+
+  describe('getSceneType', () => {
+    test('returns correct scene type given location with pathname', () => {
+      const methodLocation = {
+        pathname: '/3.1/methods/RandomMethod',
+      } as Location
+      const typeLocation = { pathname: '/3.1/types/RandomType' } as Location
+      expect(getSceneType(methodLocation)).toEqual('methods')
+      expect(getSceneType(typeLocation)).toEqual('types')
+    })
+    test('returns empty string if there is no scene type', () => {
+      const noSceneTypePath = { pathname: '/' } as Location
+      expect(getSceneType(noSceneTypePath)).toEqual('')
+    })
+  })
+
+  describe('isValidFilter', () => {
+    const methodLocation = {
+      pathname: '/3.1/methods/RandomMethod',
+    } as Location
+    const typeLocation = { pathname: '/3.1/types/RandomType' } as Location
+
+    test("validates 'all' as a valid filter for methods and types", () => {
+      expect(isValidFilter(methodLocation, 'ALL')).toBe(true)
+      expect(isValidFilter(typeLocation, 'ALL')).toBe(true)
+    })
+
+    test.each(methodFilters)(
+      'validates %s as a valid method filter',
+      (filter) => {
+        expect(isValidFilter(methodLocation, filter)).toBe(true)
+      }
+    )
+
+    test('invalidates wrong parameter for methods and types', () => {
+      expect(isValidFilter(methodLocation, 'INVALID')).toBe(false)
+      expect(isValidFilter(typeLocation, 'INVALID')).toBe(false)
+    })
+
+    test.each(typeFilters)('validates %s as a valid type filter', (filter) => {
+      expect(isValidFilter(typeLocation, filter)).toBe(true)
     })
   })
 })

--- a/packages/api-explorer/src/utils/path.ts
+++ b/packages/api-explorer/src/utils/path.ts
@@ -29,41 +29,8 @@ import { firstMethodRef } from '@looker/sdk-codegen'
 import type { Location as HLocation } from 'history'
 import { matchPath } from 'react-router'
 
-// TODO: documenting, testing the below
-export const methodFilterOptions = /ALL|GET|POST|PUT|PATCH|DELETE/i
-export const typeFilterOptions = /ALL|SPECIFICATION|WRITE|REQUEST|ENUMERATED/i
-
-/**
- * Gets the scene type of the current page
- *
- * @param location browser location
- * @returns string representing the scene type
- */
-export const getSceneType = (location: HLocation | Location) => {
-  const match = matchPath<{ tabType: string }>(location.pathname, {
-    path: '/:specKey/:tabType',
-  })
-  return match ? match!.params.tabType : ''
-}
-
-/**
- * Confirms if filter parameter is valid for the page scene type
- *
- * @param location browser location
- * @param filter filter tag for page
- */
-export const isValidFilter = (
-  location: HLocation | Location,
-  filter: string
-) => {
-  const sceneType = getSceneType(location)
-  if (!sceneType) return false
-  else if (sceneType === 'methods') {
-    return methodFilterOptions.test(filter)
-  } else {
-    return typeFilterOptions.test(filter)
-  }
-}
+export const methodFilterOptions = /GET|POST|PUT|PATCH|DELETE/i
+export const typeFilterOptions = /SPECIFICATION|WRITE|REQUEST|ENUMERATED/i
 
 /**
  * Builds a path matching the route used by MethodScene
@@ -164,4 +131,36 @@ export const getSpecKey = (location: HLocation | Location): string | null => {
     match = pathname.match(/\/(?<specKey>\w+\.\w+).*/)
   }
   return match?.groups?.specKey || null
+}
+
+/**
+ * Gets the scene type of the current page
+ * @param location browser location
+ * @returns string representing the scene type
+ */
+export const getSceneType = (location: HLocation | Location) => {
+  const match = matchPath<{ tabType: string }>(location.pathname, {
+    path: '/:specKey/:tabType',
+  })
+  return match ? match!.params.tabType : ''
+}
+
+/**
+ * Confirms if filter is valid for the page scene type
+ * @param location browser location
+ * @param filter filter tag for page
+ */
+export const isValidFilter = (
+  location: HLocation | Location,
+  filter: string
+) => {
+  const sceneType = getSceneType(location)
+  if (!sceneType) return false
+  else if (!filter.localeCompare('all', 'en', { sensitivity: 'base' }))
+    return true
+  else if (sceneType === 'methods') {
+    return methodFilterOptions.test(filter)
+  } else {
+    return typeFilterOptions.test(filter)
+  }
 }

--- a/packages/api-explorer/src/utils/path.ts
+++ b/packages/api-explorer/src/utils/path.ts
@@ -27,6 +27,43 @@
 import type { ApiModel, IMethod, IType } from '@looker/sdk-codegen'
 import { firstMethodRef } from '@looker/sdk-codegen'
 import type { Location as HLocation } from 'history'
+import { matchPath } from 'react-router'
+
+// TODO: documenting, testing the below
+export const methodFilterOptions = /ALL|GET|POST|PUT|PATCH|DELETE/i
+export const typeFilterOptions = /ALL|SPECIFICATION|WRITE|REQUEST|ENUMERATED/i
+
+/**
+ * Gets the scene type of the current page
+ *
+ * @param location browser location
+ * @returns string representing the scene type
+ */
+export const getSceneType = (location: HLocation | Location) => {
+  const match = matchPath<{ tabType: string }>(location.pathname, {
+    path: '/:specKey/:tabType',
+  })
+  return match ? match!.params.tabType : ''
+}
+
+/**
+ * Confirms if filter parameter is valid for the page scene type
+ *
+ * @param location browser location
+ * @param filter filter tag for page
+ */
+export const isValidFilter = (
+  location: HLocation | Location,
+  filter: string
+) => {
+  const sceneType = getSceneType(location)
+  if (!sceneType) return false
+  else if (sceneType === 'methods') {
+    return methodFilterOptions.test(filter)
+  } else {
+    return typeFilterOptions.test(filter)
+  }
+}
 
 /**
  * Builds a path matching the route used by MethodScene


### PR DESCRIPTION
Provides the ability to share a link to a method/type tag landing page with an applied filter. For example, being able to load a tag scene and have its methods already filtered on `POST`. 