### PR TITLE
fix: IErrorDetail fields should not be null

### DIFF
--- a/packages/sdk-rtl/src/lookerSDKError.ts
+++ b/packages/sdk-rtl/src/lookerSDKError.ts
@@ -45,10 +45,10 @@ type AugmentErrorOptions<
   : never
 
 interface IErrorDetail {
-  field?: string | null
-  code?: string | null
-  message?: string | null
-  documentation_url: string | null
+  field?: string
+  code?: string
+  message?: string
+  documentation_url: string
 }
 
 // This specifies SDK custom error options


### PR DESCRIPTION
fields should not be null if we have `errors` info in the response