### PR TITLE
feat: error documentation redirect and support for detailed error content

### DIFF
--- a/packages/api-explorer/e2e/MethodScene.spec.ts
+++ b/packages/api-explorer/e2e/MethodScene.spec.ts
@@ -1,0 +1,80 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2022 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+import { goToPage, v40Url as v40, v40Url } from './helpers'
+
+jest.setTimeout(120000)
+
+describe('MethodScene', () => {
+  beforeEach(async () => {
+    await jestPuppeteer.resetBrowser()
+    await page.setDefaultNavigationTimeout(120000)
+  })
+
+  afterEach(async () => {
+    await page.evaluate(() => {
+      localStorage.clear()
+    })
+  })
+
+  it('fetches error detail markdown when error code query param is present', async () => {
+    const errorCode = '400'
+    await goToPage(`${v40Url}/methods/Content/content_metadata?e=${errorCode}`)
+
+    // confirm method scene loaded
+    await expect(page).toMatchElement('h2', { text: 'Get Content Metadata' })
+
+    // confirm correct response tab is selected
+    await expect(page).toMatchElement('button[aria-selected=true]', {
+      text: '400: Bad Request',
+    })
+    // confirm error detail md file was fetched
+    await expect(page).toMatchElement('h2', {
+      text: `API Response ${errorCode} for `,
+    })
+  })
+
+  it('removes error code query param when user navigates away from method', async () => {
+    const errorCode = 400
+    await goToPage(
+      `${v40}/err/${errorCode}/get/content_metadata/:content_metadata_id`
+    )
+
+    // confirm method scene loaded
+    await expect(page).toMatchElement('h2', { text: 'Get Content Metadata' })
+
+    // confirm url and query param are set correctly
+    await expect(page.url()).toEqual(
+      `${v40}/methods/Content/content_metadata?sdk=py&e=${errorCode}`
+    )
+
+    // navigate to another method
+    await expect(page).toClick('h4', { text: 'Dashboard' })
+    await expect(page).toMatchElement('h2', {
+      text: 'Dashboard: Manage Dashboards',
+    })
+    await expect(page.url()).toEqual(`${v40}/methods/Dashboard?sdk=py`)
+  })
+})

--- a/packages/api-explorer/e2e/diffScene.spec.ts
+++ b/packages/api-explorer/e2e/diffScene.spec.ts
@@ -45,13 +45,19 @@ describe('Diff Scene', () => {
     await page.setDefaultNavigationTimeout(120000)
   })
 
+  afterEach(async () => {
+    await page.evaluate(() => {
+      localStorage.clear()
+    })
+  })
+
   it('loads the default scene (/3.1/diff)', async () => {
     await goToPage(`${BASE_URL}/3.1/diff`)
     const body = await page.$('body')
 
     // "Base" input element
     {
-      await body.click()
+      await body?.click()
       const baseInputElement = await page.$(baseInputSelector)
       expect(baseInputElement).not.toBeNull()
       const baseInputValue = await page.evaluate(
@@ -63,18 +69,18 @@ describe('Diff Scene', () => {
       const baseOptionsOnLoad = await page.$(globalOptionsSelector)
       expect(baseOptionsOnLoad).toBeNull()
 
-      await baseInputElement.click()
+      await baseInputElement?.click()
       const baseOptionsOnClick = await page.$$(globalOptionsSelector)
       expect(baseOptionsOnClick).not.toHaveLength(0)
 
-      await body.click()
+      await body?.click()
       const baseOptionsOnClose = await page.$(globalOptionsSelector)
       expect(baseOptionsOnClose).toBeNull()
     }
 
     // "Comparison" input element
     {
-      await body.click()
+      await body?.click()
       const compInputElement = await page.$(compInputSelector)
       expect(compInputElement).not.toBeNull()
       const compInputValue = await page.evaluate(
@@ -86,11 +92,11 @@ describe('Diff Scene', () => {
       const compOptionsOnLoad = await page.$(globalOptionsSelector)
       expect(compOptionsOnLoad).toBeNull()
 
-      await compInputElement.click()
+      await compInputElement?.click()
       const compOptionsOnClick = await page.$$(globalOptionsSelector)
       expect(compOptionsOnClick).not.toHaveLength(0)
 
-      await body.click()
+      await body?.click()
       const compOptionsOnClose = await page.$(globalOptionsSelector)
       expect(compOptionsOnClose).toBeNull()
     }
@@ -151,7 +157,7 @@ describe('Diff Scene', () => {
           page.evaluate((el) => el.innerText.match(/^[a-z_]*/)[0], resultCard)
         )
       )
-      expect(page1Methods).toHaveLength(16)
+      expect(page1Methods).toHaveLength(15)
       expect(page1Methods).toContain('delete_board_item')
     }
 
@@ -179,7 +185,7 @@ describe('Diff Scene', () => {
       expect(methodText).toMatch(`delete_alert for 4.0`)
 
       // Click and validate destination
-      await methodLink.click()
+      await methodLink?.click()
       await page.waitForSelector(`div[class*=MethodBadge]`, { timeout: 5000 })
       const compUrl = page.url()
       expect(compUrl).toEqual(
@@ -200,14 +206,14 @@ describe('Diff Scene', () => {
     expect(compInputElement).not.toBeNull()
 
     // Click comparison input
-    await compInputElement.click()
+    await compInputElement?.click()
     const compOptionsOnClick = await page.$$(globalOptionsSelector)
     expect(compOptionsOnClick).not.toHaveLength(0)
     expect(compOptionsOnClick).not.toHaveLength(1)
 
     // Find an option containing the text 4.0
     const option40Index = await page.$$eval(globalOptionsSelector, (els) =>
-      els.findIndex((el) => el.textContent.match(/4\.0/))
+      els.findIndex((el) => el?.textContent?.match(/4\.0/))
     )
     const option40 = compOptionsOnClick[option40Index]
     expect(option40).not.toBeUndefined()
@@ -230,7 +236,7 @@ describe('Diff Scene', () => {
       )
     )
 
-    expect(diff31to40Page1Methods).toHaveLength(16)
+    expect(diff31to40Page1Methods).toHaveLength(15)
     expect(diff31to40Page1Methods).toContain('delete_board_item')
 
     // Click the switch button
@@ -241,7 +247,7 @@ describe('Diff Scene', () => {
       switchButtonElement
     )
     expect(switchButtonDisabled).toEqual(false)
-    await switchButtonElement.click()
+    await switchButtonElement?.click()
 
     // A more precise timing mechanism would be better: https://github.com/puppeteer/puppeteer/issues/5328
     await page.waitForTimeout(150)
@@ -256,7 +262,7 @@ describe('Diff Scene', () => {
       )
     )
 
-    expect(diff40to31Page1Methods).toHaveLength(16)
+    expect(diff40to31Page1Methods).toHaveLength(15)
     expect(diff40to31Page1Methods).toContain('delete_board_item')
   })
 })

--- a/packages/api-explorer/e2e/e2e.spec.ts
+++ b/packages/api-explorer/e2e/e2e.spec.ts
@@ -25,14 +25,12 @@
  */
 import '@testing-library/jest-dom'
 
-import { goToPage, pageReload, BASE_URL } from './helpers'
+import { goToPage, pageReload, v40Url as v40 } from './helpers'
 
 // https://github.com/smooth-code/jest-puppeteer/tree/master/packages/expect-puppeteer
 // https://github.com/puppeteer/puppeteer/blob/main/docs/api.md
 
 jest.setTimeout(120000)
-
-const v40 = `${BASE_URL}/4.0`
 
 describe('API Explorer', () => {
   beforeEach(async () => {
@@ -45,6 +43,7 @@ describe('API Explorer', () => {
       localStorage.clear()
     })
   })
+
   describe('general', () => {
     beforeEach(async () => {
       await goToPage(v40)
@@ -218,6 +217,30 @@ describe('API Explorer', () => {
       await expect(page).toMatchElement('h2', { text: 'Query' })
       await expect(page).toMatchElement('button', { text: 'Query' })
     })
+
+    it('redirects error routes to the correct method page', async () => {
+      const errorCode = 400
+      await goToPage(
+        `${v40}/err/${errorCode}/get/content_metadata/:content_metadata_id`
+      )
+
+      // confirm method scene loaded
+      await expect(page).toMatchElement('h2', { text: 'Get Content Metadata' })
+
+      // confirm url and query param are set correctly
+      await expect(page.url()).toEqual(
+        `${v40}/methods/Content/content_metadata?sdk=py&e=${errorCode}`
+      )
+
+      // confirm correct response tab is selected
+      await expect(page).toMatchElement('button[aria-selected=true]', {
+        text: '400: Bad Request',
+      })
+      // confirm error detail md file was fetched
+      await expect(page).toMatchElement('h2', {
+        text: `API Response ${errorCode} for `,
+      })
+    })
   })
 
   describe('outbound navigation', () => {
@@ -233,7 +256,7 @@ describe('API Explorer', () => {
       //   page.waitForNavigation({timeout:5000}),
       //   exampleLink.click()
       //   ])
-      await exampleLink.click()
+      await exampleLink?.click()
       await page.waitForTimeout(150)
 
       const body = await page.$('body')

--- a/packages/api-explorer/src/components/SideNav/SideNavMethods.spec.tsx
+++ b/packages/api-explorer/src/components/SideNav/SideNavMethods.spec.tsx
@@ -52,6 +52,10 @@ describe('SideNavMethods', () => {
   const methods = api.tags[tag]
   const specKey = '3.1'
 
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
   test('it renders provided methods', () => {
     renderWithRouterAndReduxProvider(
       <SideNavMethods methods={methods} tag={tag} specKey={specKey} />
@@ -72,10 +76,7 @@ describe('SideNavMethods', () => {
     const firstMethod = Object.values(methods)[0].schema.summary
     expect(screen.queryByText(firstMethod)).not.toBeInTheDocument()
     userEvent.click(screen.getByText(tag))
-    expect(mockHistoryPush).toHaveBeenCalledWith({
-      pathname: `/${specKey}/methods/${tag}`,
-      search: '',
-    })
+    expect(mockHistoryPush).toHaveBeenCalledWith(`/${specKey}/methods/${tag}`)
     expect(screen.getByRole('link', { name: firstMethod })).toBeInTheDocument()
     expect(screen.getAllByRole('link')).toHaveLength(
       Object.values(methods).length
@@ -97,10 +98,7 @@ describe('SideNavMethods', () => {
       Object.values(methods).length
     )
     userEvent.click(screen.getByText(tag))
-    expect(mockHistoryPush).toHaveBeenCalledWith({
-      pathname: `/${specKey}/methods`,
-      search: '',
-    })
+    expect(mockHistoryPush).toHaveBeenCalledWith(`/${specKey}/methods`)
     expect(screen.queryByText(firstMethod)).not.toBeInTheDocument()
     expect(screen.queryByRole('link')).not.toBeInTheDocument()
   })

--- a/packages/api-explorer/src/components/SideNav/SideNavMethods.tsx
+++ b/packages/api-explorer/src/components/SideNav/SideNavMethods.tsx
@@ -44,7 +44,8 @@ interface MethodsProps {
 
 export const SideNavMethods = styled(
   ({ className, methods, tag, specKey, defaultOpen = false }: MethodsProps) => {
-    const { navigate, buildPathWithGlobalParams } = useNavigation()
+    const { buildPathWithGlobalParams, navigateWithGlobalParams } =
+      useNavigation()
     const searchPattern = useSelector(selectSearchPattern)
     const match = useRouteMatch<{ methodTag: string }>(
       `/:specKey/methods/:methodTag/:methodName?`
@@ -54,9 +55,9 @@ export const SideNavMethods = styled(
       const _isOpen = !isOpen
       setIsOpen(_isOpen)
       if (_isOpen) {
-        navigate(`/${specKey}/methods/${tag}`)
+        navigateWithGlobalParams(`/${specKey}/methods/${tag}`)
       } else {
-        navigate(`/${specKey}/methods`)
+        navigateWithGlobalParams(`/${specKey}/methods`)
       }
     }
 
@@ -65,7 +66,7 @@ export const SideNavMethods = styled(
         ? defaultOpen || match.params.methodTag === tag
         : defaultOpen
       setIsOpen(status)
-    }, [defaultOpen])
+    }, [match, defaultOpen])
 
     /* TODO: Fix highlighting. It is applied but it is somehow being overridden */
     return (

--- a/packages/api-explorer/src/components/SideNav/SideNavMethods.tsx
+++ b/packages/api-explorer/src/components/SideNav/SideNavMethods.tsx
@@ -66,7 +66,7 @@ export const SideNavMethods = styled(
         ? defaultOpen || match.params.methodTag === tag
         : defaultOpen
       setIsOpen(status)
-    }, [match, defaultOpen])
+    }, [defaultOpen])
 
     /* TODO: Fix highlighting. It is applied but it is somehow being overridden */
     return (

--- a/packages/api-explorer/src/routes/AppRouter.tsx
+++ b/packages/api-explorer/src/routes/AppRouter.tsx
@@ -30,6 +30,7 @@ import { Redirect, Route, Switch } from 'react-router-dom'
 import type { ApiModel } from '@looker/sdk-codegen'
 
 import {
+  ErrorDetailScene,
   HomeScene,
   MethodScene,
   MethodTagScene,
@@ -52,6 +53,9 @@ export const AppRouter: FC<AppRouterProps> = ({
 }) => (
   <Switch>
     <Redirect from="/" to={`/${specKey}/`} exact />
+    <Route path="/:specKey/err/:statusCode/:verb/*">
+      <ErrorDetailScene api={api} />
+    </Route>
     <Route path={`/:specKey/${diffPath}/:compareSpecKey?`}>
       <DiffScene toggleNavigation={toggleNavigation} />
     </Route>

--- a/packages/api-explorer/src/scenes/ErrorDetailScene/ErrorDetailScene.tsx
+++ b/packages/api-explorer/src/scenes/ErrorDetailScene/ErrorDetailScene.tsx
@@ -1,0 +1,72 @@
+/*
+
+ MIT License
+
+ Copyright (c) 2022 Looker Data Sciences, Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+ */
+import { Redirect, useRouteMatch } from 'react-router-dom'
+import { getEnvAdaptor } from '@looker/extension-utils'
+import { ErrorDoc } from '@looker/sdk-rtl'
+import React from 'react'
+import type { IApiModel } from '@looker/sdk-codegen'
+
+import { useNavigation } from '../../utils'
+
+interface ErrorDetailSceneProps {
+  api: IApiModel
+}
+
+/**
+ * Scene responsible for redirecting users from an error doc link to a specific
+ * method scene
+ */
+export const ErrorDetailScene = ({ api }: ErrorDetailSceneProps) => {
+  const match = useRouteMatch<{
+    specKey: string
+    statusCode: string
+    verb: string
+  }>(`/:specKey/err/:statusCode/:verb/*`)
+  const methodPath = match?.params[0]
+  const adaptor = getEnvAdaptor()
+  const errorDoc = new ErrorDoc(adaptor.sdk)
+  const restPath = errorDoc.specPath(methodPath)
+
+  const methodId = `${match?.params.verb} /${restPath}`.toLocaleLowerCase()
+  const specKey = match?.params.specKey
+  const statusCode = match?.params.statusCode
+
+  const method = Object.values(api.methods).find(
+    (method) => method.id.toLocaleLowerCase() === methodId
+  )
+
+  const methodTag = method?.schema.tags[0]
+  const methodName = method?.operationId
+
+  const { buildPathWithGlobalParams } = useNavigation()
+
+  const redirectPath = buildPathWithGlobalParams(
+    `/${specKey}/methods/${methodTag}/${methodName}`,
+    { e: statusCode }
+  )
+
+  return <Redirect to={redirectPath} />
+}

--- a/packages/api-explorer/src/scenes/ErrorDetailScene/index.ts
+++ b/packages/api-explorer/src/scenes/ErrorDetailScene/index.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -23,11 +23,4 @@
  SOFTWARE.
 
  */
-export { highlightHTML } from './highlight'
-export * from './path'
-export * from './sdkLanguage'
-export { getLoded } from './lodeUtils'
-export { useWindowSize } from './useWindowSize'
-export * from './apixAdaptor'
-export * from './adaptorUtils'
-export { useNavigation, useGlobalStoreSync, useQuery } from './hooks'
+export { ErrorDetailScene } from './ErrorDetailScene'

--- a/packages/api-explorer/src/scenes/MethodScene/MethodScene.tsx
+++ b/packages/api-explorer/src/scenes/MethodScene/MethodScene.tsx
@@ -120,8 +120,7 @@ export const MethodScene: FC<MethodSceneProps> = ({ api }) => {
 
   useEffect(() => {
     if (method.responses && errorCode) {
-      const maybe = true
-      if (maybe && docResponsesRef.current) {
+      if (docResponsesRef.current) {
         window.setTimeout(() => {
           docResponsesRef.current!.scrollIntoView()
         }, 300)

--- a/packages/api-explorer/src/scenes/MethodScene/components/DocResponses/DocResponseTypes.tsx
+++ b/packages/api-explorer/src/scenes/MethodScene/components/DocResponses/DocResponseTypes.tsx
@@ -24,7 +24,6 @@
 
  */
 
-import type { FC } from 'react'
 import React, { useState, useEffect } from 'react'
 import { ButtonToggle, ButtonItem } from '@looker/components'
 import type {
@@ -37,6 +36,7 @@ import { ExploreType } from '../../../../components'
 
 interface DocResponseTypesProps {
   api: ApiModel
+  /** responses to render */
   responses: KeyedCollection<IMethodResponse>
 }
 
@@ -45,10 +45,7 @@ interface DocResponseTypesProps {
  * toggling media type and render the response
  * @param response
  */
-export const DocResponseTypes: FC<DocResponseTypesProps> = ({
-  api,
-  responses,
-}) => {
+export const DocResponseTypes = ({ api, responses }: DocResponseTypesProps) => {
   const mediaTypes = Object.keys(responses)
   const [selectedMediaType, setSelectedMediaType] = useState(mediaTypes[0])
   const [resps, setResps] = useState(responses)

--- a/packages/api-explorer/src/scenes/MethodScene/components/DocResponses/DocResponses.spec.tsx
+++ b/packages/api-explorer/src/scenes/MethodScene/components/DocResponses/DocResponses.spec.tsx
@@ -26,6 +26,10 @@
 import React from 'react'
 import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import {
+  registerTestEnvAdaptor,
+  unregisterEnvAdaptor,
+} from '@looker/extension-utils'
 
 import { api } from '../../../../test-data'
 import { renderWithRouter } from '../../../../test-utils'
@@ -33,9 +37,17 @@ import { DocResponses } from './DocResponses'
 import { buildResponseTree } from './utils'
 
 describe('DocResponses', () => {
+  beforeAll(() => {
+    registerTestEnvAdaptor()
+  })
+
+  afterAll(() => {
+    unregisterEnvAdaptor()
+  })
+
   test('it renders all response statuses and their types', async () => {
     const responses = api.methods.run_look.responses
-    renderWithRouter(<DocResponses api={api} responses={responses} />)
+    renderWithRouter(<DocResponses api={api} method={api.methods.run_look} />)
 
     expect(screen.getByText('Response Models')).toBeInTheDocument()
 
@@ -56,5 +68,86 @@ describe('DocResponses', () => {
         })
       ).toHaveLength(successRespTypes.length)
     })
+  })
+
+  test('selects tab corresponding to error code query param if present', async () => {
+    const sampleIndex = {
+      '404': {
+        url: '404.md',
+      },
+      '404/post/login': {
+        url: 'login_404.md',
+      },
+    }
+
+    const badLoginMd = `## API Response 404 for \`login\`
+
+## Description
+
+A 404 Error response from the /login endpoint most often means that an attempt to login at a valid Looker URL was made but the combination of client_id and client_secret provided do not match an existing valid credential on that instance.
+
+See [HTTP 404 - Not Found](https://docs.looker.com/r/reference/looker-http-codes/404) for general information about this HTTP response from Looker.`
+
+    const mockResponse = async (val: string): Promise<Response> => {
+      const resp: Response = {
+        bodyUsed: false,
+        ok: true,
+        redirected: false,
+        statusText: '',
+        url: '',
+        text(): Promise<string> {
+          return Promise.resolve(val)
+        },
+        status: 200,
+        headers: {} as Headers,
+        type: 'basic',
+        clone: function (): Response {
+          throw new Error('Function not implemented.')
+        },
+        body: null,
+        arrayBuffer: function (): Promise<ArrayBuffer> {
+          throw new Error('Function not implemented.')
+        },
+        blob: function (): Promise<Blob> {
+          throw new Error('Function not implemented.')
+        },
+        formData: function (): Promise<FormData> {
+          throw new Error('Function not implemented.')
+        },
+        json: function (): Promise<any> {
+          throw new Error('Function not implemented.')
+        },
+      }
+      return Promise.resolve(resp)
+    }
+    const fetcher = global.fetch
+    global.fetch = jest.fn((input: RequestInfo, _init?: RequestInit) => {
+      const url = input.toString()
+      let result = 'I dunno'
+      if (url.endsWith('index.json')) {
+        result = JSON.stringify(sampleIndex)
+      }
+      if (url.endsWith('login_404.md')) {
+        result = badLoginMd
+      }
+      return mockResponse(result)
+    })
+
+    renderWithRouter(
+      <DocResponses api={api} method={api.methods.login} errorCode="404" />
+    )
+    expect(screen.getByText('Response Models')).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: /^404: \w+/ })).toHaveAttribute(
+        'aria-selected',
+        'true'
+      )
+      expect(
+        screen.getByRole('heading', { name: 'Description' })
+      ).toBeInTheDocument()
+    })
+
+    global.fetch = fetcher
   })
 })

--- a/packages/api-explorer/src/scenes/index.ts
+++ b/packages/api-explorer/src/scenes/index.ts
@@ -23,6 +23,7 @@
  SOFTWARE.
 
  */
+export { ErrorDetailScene } from './ErrorDetailScene'
 export { HomeScene } from './HomeScene'
 export { MethodScene } from './MethodScene'
 export { TypeScene } from './TypeScene'

--- a/packages/api-explorer/src/utils/hooks/index.ts
+++ b/packages/api-explorer/src/utils/hooks/index.ts
@@ -25,3 +25,4 @@
  */
 export { useNavigation } from './navigation'
 export { useGlobalStoreSync } from './globalStoreSync'
+export { useQuery } from './useQuery'

--- a/packages/api-explorer/src/utils/hooks/navigation.spec.ts
+++ b/packages/api-explorer/src/utils/hooks/navigation.spec.ts
@@ -99,6 +99,12 @@ describe('useNavigation', () => {
         `${route}?${curParams.toString()}`
       )
     })
+
+    test('adds other parameters if present', () => {
+      curParams.delete('t')
+      const actual = buildPathWithGlobalParams(route, { e: 400 })
+      expect(actual).toEqual(`${route}?${curParams.toString()}&e=400`)
+    })
   })
 
   describe('navigateWithGlobalParams', () => {

--- a/packages/api-explorer/src/utils/hooks/navigation.ts
+++ b/packages/api-explorer/src/utils/hooks/navigation.ts
@@ -25,7 +25,7 @@
  */
 import { useHistory } from 'react-router-dom'
 
-const globalParams = ['s', 'sdk']
+const GLOBAL_PARAMS = ['s', 'sdk']
 
 interface QueryParamProps {
   /** Search Query **/
@@ -73,17 +73,35 @@ export const useNavigation = () => {
   /**
    * Builds path to a scene and removes any scene-specific URL parameters
    *
-   * @param path the destination path
+   * @param path        the destination path
+   * @param otherParams other query parameters to append to url
    * @returns a path excluding scene-specific search parameters
    */
-  const buildPathWithGlobalParams = (path: string) => {
+  const buildPathWithGlobalParams = (path: string, otherParams = {}) => {
     const params = new URLSearchParams(history.location.search)
+
     for (const key of params.keys()) {
-      if (!globalParams.includes(key)) {
+      if (!GLOBAL_PARAMS.includes(key)) {
         params.delete(key)
       }
     }
-    return `${path}?${params.toString()}`
+    const globalParams = params.toString()
+
+    let additionalParams = ''
+    Object.entries(otherParams).forEach(([key, value]) => {
+      additionalParams += `${key}=${value}`
+    })
+
+    let queryString = ''
+    if (globalParams) {
+      queryString = globalParams
+    }
+
+    if (additionalParams) {
+      queryString += globalParams ? `&${additionalParams}` : additionalParams
+    }
+
+    return `${path}${queryString ? `?${queryString}` : ''}`
   }
 
   /**

--- a/packages/api-explorer/src/utils/hooks/useQuery.ts
+++ b/packages/api-explorer/src/utils/hooks/useQuery.ts
@@ -2,7 +2,7 @@
 
  MIT License
 
- Copyright (c) 2021 Looker Data Sciences, Inc.
+ Copyright (c) 2022 Looker Data Sciences, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -23,11 +23,14 @@
  SOFTWARE.
 
  */
-export { highlightHTML } from './highlight'
-export * from './path'
-export * from './sdkLanguage'
-export { getLoded } from './lodeUtils'
-export { useWindowSize } from './useWindowSize'
-export * from './apixAdaptor'
-export * from './adaptorUtils'
-export { useNavigation, useGlobalStoreSync, useQuery } from './hooks'
+import { useMemo } from 'react'
+import { useLocation } from 'react-router-dom'
+
+/**
+ * Hook for retrieving query params
+ */
+export const useQuery = () => {
+  const { search } = useLocation()
+
+  return useMemo(() => new URLSearchParams(search), [search])
+}

--- a/packages/code-editor/src/Markdown/common.tsx
+++ b/packages/code-editor/src/Markdown/common.tsx
@@ -69,6 +69,7 @@ export const MDListItem = styled.li`
   color: ${({ theme }) => theme.colors.text5};
   max-width: 600px;
   margin-bottom: 4px;
+  line-height: 1.5;
 `
 
 export const MDTable = styled(Table).attrs(({ mb = 'large' }: TableProps) => ({

--- a/packages/extension-utils/src/APIErrorDisplay/APIErrorDisplay.spec.tsx
+++ b/packages/extension-utils/src/APIErrorDisplay/APIErrorDisplay.spec.tsx
@@ -24,16 +24,13 @@
 
  */
 
-import type { IAPIMethods, LookerSDKError } from '@looker/sdk-rtl'
+import type { LookerSDKError } from '@looker/sdk-rtl'
 import { screen, waitFor } from '@testing-library/react'
 import React from 'react'
 import { renderWithTheme } from '@looker/components-test-utils'
+
+import { registerTestEnvAdaptor, unregisterEnvAdaptor } from '../adaptorUtils'
 import { APIErrorDisplay } from './APIErrorDisplay'
-import type { IEnvironmentAdaptor } from '@looker/extension-utils'
-import {
-  registerEnvAdaptor,
-  unregisterEnvAdaptor,
-} from '@looker/extension-utils'
 
 const sampleIndex = {
   '404': {
@@ -119,7 +116,7 @@ describe('APIErrorDisplay', () => {
       message: 'simple error',
       documentation_url: 'https://docs.looker.com/r/err/4.0/404/post/login',
     }
-    registerEnvAdaptor({ sdk: {} as IAPIMethods } as IEnvironmentAdaptor)
+    registerTestEnvAdaptor()
     renderWithTheme(<APIErrorDisplay error={simple} showDoc={true} />)
     const heading = screen.getByRole('heading', { name: 'simple error' })
     expect(heading).toBeInTheDocument()

--- a/packages/extension-utils/src/APIErrorDisplay/index.ts
+++ b/packages/extension-utils/src/APIErrorDisplay/index.ts
@@ -26,3 +26,4 @@
 
 export * from './APIErrorDialog'
 export * from './APIErrorDisplay'
+export { apiErrorDisplayFetch } from './utils'


### PR DESCRIPTION
Navigating to `/:specKey/err/:errorCode/:verb/*` will redirect users to the correct method scene with an error query param containing the error code. 

To test, navigate to `/4.0/err/400/get/content_metadata/:content_metadata_id`. This change will:
- automatically redirect users to the correct method scene (`h/4.0/methods/Content/content_metadata?e=400` based on the example above)
- scroll the `Responses` section into view
- automatically select the tab based on the error code in the url 
- fetch and render detailed error markdown