### PR TITLE
chore: disable python integ tests on 22.12, 22.14 and 22.16

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -112,6 +112,12 @@ jobs:
         os:
           - ubuntu
         looker: ${{ fromJson(needs.setup.outputs.matrix_json) }}
+        # Integ tests on versions 22.12 and beyond intermittently fail CIs - disable for now.
+        # New release version to be added manually after integration tests have been verified to pass locally.
+        exclude:
+          - looker: 22_12
+          - looker: 22_14
+          - looker: 22_16         
 
           # TODO uncomment `include:` when either macos or windows works to satisfaction.
           #include:


### PR DESCRIPTION
disable python integ tests on 22.12, 22.14 and 22.16