### PR TITLE
chore: fix API Explorer tests

### DIFF
--- a/packages/api-explorer/src/components/DocMethodSummary/DocSummaryStatus.spec.tsx
+++ b/packages/api-explorer/src/components/DocMethodSummary/DocSummaryStatus.spec.tsx
@@ -33,7 +33,7 @@ import { DocSummaryStatus } from './DocSummaryStatus'
 describe('DocMethodSummaryStatus', () => {
   test.each`
     status          | method                              | expectedLabel        | expectedContent
-    ${'beta'}       | ${api40.methods.workspace}          | ${'beta item'}       | ${'This beta item is under development and subject to change.'}
+    ${'beta'}       | ${api40.methods.invalidate_tokens}  | ${'beta item'}       | ${'This beta item is under development and subject to change.'}
     ${'stable'}     | ${api.methods.login}                | ${'stable item'}     | ${'This item is considered stable for this API version.'}
     ${'deprecated'} | ${api.methods.backup_configuration} | ${'deprecated item'} | ${'This item has been deprecated and will be removed in the future.'}
   `(

--- a/packages/api-explorer/src/components/DocStatus/DocStatus.spec.tsx
+++ b/packages/api-explorer/src/components/DocStatus/DocStatus.spec.tsx
@@ -32,7 +32,7 @@ import { DocStatus } from './DocStatus'
 
 describe('DocStatus', () => {
   test('it renders a badge with the status and a tooltip on hover', async () => {
-    renderWithTheme(<DocStatus method={api40.methods.create_dashboard} />)
+    renderWithTheme(<DocStatus method={api40.methods.invalidate_tokens} />)
     const badge = screen.getByText('BETA')
     fireEvent.mouseOver(badge)
     await waitFor(() => {


### PR DESCRIPTION
Some tests that check beta status broke because the methods were no longer beta

We'll need to snapshot the specs or mock them in the future to avoid this breaking again


