### PR TITLE
chore: add APIX badge support for alpha endpoints

### DIFF
--- a/packages/api-explorer/src/components/DocMethodSummary/utils.spec.tsx
+++ b/packages/api-explorer/src/components/DocMethodSummary/utils.spec.tsx
@@ -28,6 +28,7 @@ import { pickTooltipContent } from './utils'
 describe('DocMethodSummary utils', () => {
   test.each`
     status            | expected
+    ${'alpha'}        | ${'This alpha item is either for internal use, or not fully developed and may be significantly changed or completely removed in future releases.'}
     ${'beta'}         | ${'This beta item is under development and subject to change.'}
     ${'experimental'} | ${'This experimental item is not fully developed and may be significantly changed or completely removed in future releases.'}
     ${'deprecated'}   | ${'This item has been deprecated and will be removed in the future.'}

--- a/packages/api-explorer/src/components/DocMethodSummary/utils.tsx
+++ b/packages/api-explorer/src/components/DocMethodSummary/utils.tsx
@@ -68,6 +68,8 @@ export const pickStatus = (status: string) => {
  */
 export const pickTooltipContent = (status: string) => {
   switch (status.toLowerCase()) {
+    case 'alpha':
+      return 'This alpha item is either for internal use, or not fully developed and may be significantly changed or completely removed in future releases.'
     case 'beta':
       return 'This beta item is under development and subject to change.'
     case 'experimental':

--- a/packages/run-it/src/components/MethodBadge/MethodBadge.tsx
+++ b/packages/run-it/src/components/MethodBadge/MethodBadge.tsx
@@ -40,6 +40,7 @@ import styled, { css } from 'styled-components'
  * Status of endpoint method.
  */
 type MethodStatus =
+  | 'alpha'
   | 'beta'
   | 'stable'
   | 'experimental'
@@ -70,6 +71,7 @@ type ApixIntentNames =
 
 export const pickBadgeIntent = (type: HttpMethod | MethodStatus | string) => {
   switch (type) {
+    case 'alpha':
     case 'DELETE':
     case 'deprecated':
       return 'critical'

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,6 @@
   ],
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
-  "release-as": "22.16.0",
   "packages": {
     ".": {
       "release-as": ""


### PR DESCRIPTION
Tooltip, text color, and tests are updated for alpha endpoints

- also removed forced CalVer in release-please-config.json

APIX end to end tests are failing but that's not caused by anything I changed
