### PR TITLE
fix: various path navigation issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "webpack": "^5.10.0",
     "webpack-bundle-analyzer": "^4.4.1",
     "webpack-merge": "^5.7.3",
-    "yarn-deduplicate": "^3.1.0"
+    "yarn-deduplicate": "^6.0.0"
   },
   "dependencies": {},
   "lint-staged": {

--- a/packages/api-explorer/src/components/SelectorContainer/SdkLanguageSelector.tsx
+++ b/packages/api-explorer/src/components/SelectorContainer/SdkLanguageSelector.tsx
@@ -27,6 +27,7 @@ import type { FC } from 'react'
 import React, { useEffect, useState } from 'react'
 import { Select } from '@looker/components'
 import { useSelector } from 'react-redux'
+import { useLocation } from 'react-router-dom'
 import { selectSdkLanguage } from '../../state'
 import { allAlias, useNavigation } from '../../utils'
 import { allSdkLanguageOptions } from './utils'
@@ -35,6 +36,7 @@ import { allSdkLanguageOptions } from './utils'
  * Allows the user to select their preferred SDK language
  */
 export const SdkLanguageSelector: FC = () => {
+  const location = useLocation()
   const { navigate } = useNavigation()
   const selectedSdkLanguage = useSelector(selectSdkLanguage)
   const [language, setLanguage] = useState(selectedSdkLanguage)

--- a/packages/api-explorer/src/scenes/MethodScene/MethodScene.tsx
+++ b/packages/api-explorer/src/scenes/MethodScene/MethodScene.tsx
@@ -119,7 +119,7 @@ export const MethodScene: FC<MethodSceneProps> = ({ api }) => {
   }, [adaptor, setOn])
 
   useEffect(() => {
-    if (method.responses && errorCode) {
+    if (method?.responses && errorCode) {
       if (docResponsesRef.current) {
         window.setTimeout(() => {
           docResponsesRef.current!.scrollIntoView()

--- a/packages/api-explorer/src/scenes/MethodTagScene/MethodTagScene.spec.tsx
+++ b/packages/api-explorer/src/scenes/MethodTagScene/MethodTagScene.spec.tsx
@@ -41,7 +41,9 @@ jest.mock('react-router-dom', () => {
     ...ReactRouterDOM,
     useHistory: () => ({
       push: mockHistoryPush,
-      location,
+      location: {
+        pathname: '/4.0/methods/Look',
+      },
     }),
   }
 })
@@ -54,7 +56,7 @@ describe('MethodTagScene', () => {
       <Route path="/:specKey/methods/:methodTag">
         <MethodTagScene api={api} />
       </Route>,
-      ['/3.1/methods/ColorCollection']
+      ['/4.0/methods/ColorCollection']
     )
     expect(
       screen.getAllByRole('button', {
@@ -68,7 +70,7 @@ describe('MethodTagScene', () => {
       screen.getByText('/color_collections/standard').closest('a')
     ).toHaveAttribute(
       'href',
-      '/3.1/methods/ColorCollection/color_collections_standard'
+      '/4.0/methods/ColorCollection/color_collections_standard'
     )
   })
 
@@ -78,7 +80,7 @@ describe('MethodTagScene', () => {
       <Route path="/:specKey/methods/:methodTag">
         <MethodTagScene api={api} />
       </Route>,
-      ['/3.1/methods/ApiAuth']
+      ['/4.0/methods/ApiAuth']
     )
     expect(
       screen.getAllByRole('button', {
@@ -88,17 +90,18 @@ describe('MethodTagScene', () => {
   })
 
   test('it pushes filter to URL on toggle', async () => {
+    const site = '/4.0/methods/Look'
     renderWithRouterAndReduxProvider(
       <Route path="/:specKey/methods/:methodTag">
         <MethodTagScene api={api} />
       </Route>,
-      ['/3.1/methods/Look']
+      [site]
     )
     /** Filter by GET operation */
     userEvent.click(screen.getByRole('button', { name: 'GET' }))
     await waitFor(() => {
       expect(mockHistoryPush).toHaveBeenCalledWith({
-        pathname: location.pathname,
+        pathname: site,
         search: 't=get',
       })
     })
@@ -107,7 +110,7 @@ describe('MethodTagScene', () => {
     await waitFor(() => {
       // eslint-disable-next-line jest-dom/prefer-in-document
       expect(mockHistoryPush).toHaveBeenCalledWith({
-        pathname: location.pathname,
+        pathname: site,
         search: 't=delete',
       })
     })

--- a/packages/api-explorer/src/scenes/MethodTagScene/MethodTagScene.tsx
+++ b/packages/api-explorer/src/scenes/MethodTagScene/MethodTagScene.tsx
@@ -25,7 +25,7 @@
  */
 import type { FC } from 'react'
 import React, { useEffect, useState } from 'react'
-import { useHistory, useParams } from 'react-router-dom'
+import { useHistory, useLocation, useParams } from 'react-router-dom'
 import { Grid, ButtonToggle, ButtonItem } from '@looker/components'
 import type { ApiModel } from '@looker/sdk-codegen'
 import { useSelector } from 'react-redux'
@@ -46,6 +46,7 @@ interface MethodTagSceneParams {
 
 export const MethodTagScene: FC<MethodTagSceneProps> = ({ api }) => {
   const { specKey, methodTag } = useParams<MethodTagSceneParams>()
+  const location = useLocation()
   const history = useHistory()
   const methods = api.tags[methodTag]
   const { navigate, buildPathWithGlobalParams, navigateWithGlobalParams } =

--- a/packages/api-explorer/src/scenes/TypeTagScene/TypeTagScene.spec.tsx
+++ b/packages/api-explorer/src/scenes/TypeTagScene/TypeTagScene.spec.tsx
@@ -35,33 +35,26 @@ import { TypeTagScene } from './TypeTagScene'
 const opBtnNames = /ALL|SPECIFICATION|WRITE|REQUEST|ENUMERATED/
 
 const path = '/:specKey/types/:typeTag'
-
 const mockHistoryPush = jest.fn()
-
 jest.mock('react-router-dom', () => {
   const ReactRouterDOM = jest.requireActual('react-router-dom')
   return {
     ...ReactRouterDOM,
     useLocation: () => ({
-      pathname: '/4.0/types/Dashboard/DashboardBase',
+      pathname: '/4.0/types/Look',
     }),
-    useHistory: jest.fn().mockReturnValue({ push: jest.fn(), location }),
+    useHistory: () => ({
+      push: mockHistoryPush,
+      location: {
+        pathname: '/4.0/types/Look',
+      },
+    }),
   }
 })
 
-// jest.mock('react-router-dom', () => {
-//   const ReactRouterDOM = jest.requireActual('react-router-dom')
-//   return {
-//     ...ReactRouterDOM,
-//     useHistory: () => ({
-//       push: mockHistoryPush,
-//       location,
-//     }),
-//   }
-// })
-
 describe('TypeTagScene', () => {
   Element.prototype.scrollTo = jest.fn()
+  // const mockHistoryPush: jest.Mock = useHistory as jest.Mock
 
   test('it renders type buttons and all methods for a given type tag', () => {
     renderWithRouterAndReduxProvider(
@@ -99,17 +92,18 @@ describe('TypeTagScene', () => {
   })
 
   test('it pushes filter to URL on toggle', async () => {
+    const site = '/4.0/types/Look'
     renderWithRouterAndReduxProvider(
       <Route path={path}>
         <TypeTagScene api={api} />
       </Route>,
-      ['/4.0/types/Look']
+      [site]
     )
     /** Filter by SPECIFICATION */
     userEvent.click(screen.getByRole('button', { name: 'SPECIFICATION' }))
     await waitFor(() => {
       expect(mockHistoryPush).toHaveBeenCalledWith({
-        pathname: location.pathname,
+        pathname: site,
         search: 't=specification',
       })
     })
@@ -117,7 +111,7 @@ describe('TypeTagScene', () => {
     userEvent.click(screen.getByRole('button', { name: 'REQUEST' }))
     await waitFor(() => {
       expect(mockHistoryPush).toHaveBeenCalledWith({
-        pathname: location.pathname,
+        pathname: site,
         search: 't=request',
       })
     })

--- a/packages/api-explorer/src/scenes/TypeTagScene/TypeTagScene.spec.tsx
+++ b/packages/api-explorer/src/scenes/TypeTagScene/TypeTagScene.spec.tsx
@@ -37,16 +37,28 @@ const opBtnNames = /ALL|SPECIFICATION|WRITE|REQUEST|ENUMERATED/
 const path = '/:specKey/types/:typeTag'
 
 const mockHistoryPush = jest.fn()
+
 jest.mock('react-router-dom', () => {
   const ReactRouterDOM = jest.requireActual('react-router-dom')
   return {
     ...ReactRouterDOM,
-    useHistory: () => ({
-      push: mockHistoryPush,
-      location,
+    useLocation: () => ({
+      pathname: '/4.0/types/Dashboard/DashboardBase',
     }),
+    useHistory: jest.fn().mockReturnValue({ push: jest.fn(), location }),
   }
 })
+
+// jest.mock('react-router-dom', () => {
+//   const ReactRouterDOM = jest.requireActual('react-router-dom')
+//   return {
+//     ...ReactRouterDOM,
+//     useHistory: () => ({
+//       push: mockHistoryPush,
+//       location,
+//     }),
+//   }
+// })
 
 describe('TypeTagScene', () => {
   Element.prototype.scrollTo = jest.fn()
@@ -56,7 +68,7 @@ describe('TypeTagScene', () => {
       <Route path={path}>
         <TypeTagScene api={api} />
       </Route>,
-      ['/3.1/types/Dashboard']
+      ['/4.0/types/Dashboard']
     )
     expect(
       screen.getAllByRole('button', {
@@ -68,7 +80,7 @@ describe('TypeTagScene', () => {
     )
     expect(screen.getByText('DashboardBase').closest('a')).toHaveAttribute(
       'href',
-      '/3.1/types/Dashboard/DashboardBase'
+      '/4.0/types/Dashboard/DashboardBase'
     )
   })
 
@@ -77,7 +89,7 @@ describe('TypeTagScene', () => {
       <Route path={path}>
         <TypeTagScene api={api} />
       </Route>,
-      ['/3.1/types/DataAction']
+      ['/4.0/types/DataAction']
     )
     expect(
       screen.getAllByRole('button', {
@@ -91,7 +103,7 @@ describe('TypeTagScene', () => {
       <Route path={path}>
         <TypeTagScene api={api} />
       </Route>,
-      ['/3.1/types/Look']
+      ['/4.0/types/Look']
     )
     /** Filter by SPECIFICATION */
     userEvent.click(screen.getByRole('button', { name: 'SPECIFICATION' }))

--- a/packages/api-explorer/src/scenes/TypeTagScene/TypeTagScene.tsx
+++ b/packages/api-explorer/src/scenes/TypeTagScene/TypeTagScene.tsx
@@ -27,7 +27,7 @@ import type { FC } from 'react'
 import React, { useEffect, useState } from 'react'
 import { Grid, ButtonToggle, ButtonItem } from '@looker/components'
 import type { ApiModel } from '@looker/sdk-codegen'
-import { useParams } from 'react-router-dom'
+import { useLocation, useParams } from 'react-router-dom'
 import { useSelector } from 'react-redux'
 import { ApixSection, DocTitle, DocTypeSummary, Link } from '../../components'
 import { buildTypePath, isValidFilter, useNavigation } from '../../utils'
@@ -46,6 +46,7 @@ interface TypeTagSceneParams {
 
 export const TypeTagScene: FC<TypeTagSceneProps> = ({ api }) => {
   const { specKey, typeTag } = useParams<TypeTagSceneParams>()
+  const location = useLocation()
   const { navigate, buildPathWithGlobalParams, navigateWithGlobalParams } =
     useNavigation()
   const selectedTagFilter = useSelector(selectTagFilter)

--- a/packages/sdk-codegen/src/typescript.gen.spec.ts
+++ b/packages/sdk-codegen/src/typescript.gen.spec.ts
@@ -174,7 +174,10 @@ describe('typescript generator', () => {
       const inputs = {}
       const method = apiTestModel.methods.run_look
       const actual = gen.makeTheCall(method, inputs)
-      const expected = 'let response = await sdk.ok(sdk.run_look())'
+      const expected = `// functional SDK syntax is recommended for minimizing browser payloads
+let response = await sdk.ok(run_look(sdk))
+// monolithic SDK syntax can be also used for Node apps
+let response = await sdk.ok(sdk.run_look())`
       expect(actual).toEqual(expected)
     })
 
@@ -182,7 +185,10 @@ describe('typescript generator', () => {
       const inputs = { look_id: 17 }
       const method = apiTestModel.methods.look
       const actual = gen.makeTheCall(method, inputs)
-      const expected = `let response = await sdk.ok(sdk.look(17))`
+      const expected = `// functional SDK syntax is recommended for minimizing browser payloads
+let response = await sdk.ok(look(sdk,17))
+// monolithic SDK syntax can be also used for Node apps
+let response = await sdk.ok(sdk.look(17))`
       expect(actual).toEqual(expected)
     })
 
@@ -190,7 +196,11 @@ describe('typescript generator', () => {
       const inputs = { look_id: 17, fields }
       const method = apiTestModel.methods.look
       const actual = gen.makeTheCall(method, inputs)
-      const expected = `let response = await sdk.ok(sdk.look(
+      const expected = `// functional SDK syntax is recommended for minimizing browser payloads
+let response = await sdk.ok(look(sdk,
+  17, '${fields}'))
+// monolithic SDK syntax can be also used for Node apps
+let response = await sdk.ok(sdk.look(
   17, '${fields}'))`
       expect(actual).toEqual(expected)
     })
@@ -208,7 +218,19 @@ describe('typescript generator', () => {
       const inputs = { look_id: 17, body, fields }
       const method = apiTestModel.methods.update_look
       const actual = gen.makeTheCall(method, inputs)
-      const expected = `let response = await sdk.ok(sdk.update_look(
+      const expected = `// functional SDK syntax is recommended for minimizing browser payloads
+let response = await sdk.ok(update_look(sdk,
+  17, {
+    title: 'test title',
+    description: 'gen test',
+    query: {
+      model: 'the_look',
+      view: 'users',
+      total: true
+    }
+  }, 'id,user_id,title,description'))
+// monolithic SDK syntax can be also used for Node apps
+let response = await sdk.ok(sdk.update_look(
   17, {
     title: 'test title',
     description: 'gen test',
@@ -225,7 +247,14 @@ describe('typescript generator', () => {
       const inputs = { look_id: 17, result_format: 'png' }
       const method = apiTestModel.methods.run_look
       const actual = gen.makeTheCall(method, inputs)
-      const expected = `let response = await sdk.ok(sdk.run_look(
+      const expected = `// functional SDK syntax is recommended for minimizing browser payloads
+let response = await sdk.ok(run_look(sdk,
+  {
+    look_id: 17,
+    result_format: 'png'
+  }))
+// monolithic SDK syntax can be also used for Node apps
+let response = await sdk.ok(sdk.run_look(
   {
     look_id: 17,
     result_format: 'png'
@@ -242,7 +271,16 @@ describe('typescript generator', () => {
       }
       const method = apiTestModel.methods.create_query_task
       const actual = gen.makeTheCall(method, inputs)
-      const expected = `let response = await sdk.ok(sdk.create_query_task(
+      const expected = `// functional SDK syntax is recommended for minimizing browser payloads
+let response = await sdk.ok(create_query_task(sdk,
+  {
+    body: {
+      query_id: 1,
+      result_format: ResultFormat.csv
+    }
+  }))
+// monolithic SDK syntax can be also used for Node apps
+let response = await sdk.ok(sdk.create_query_task(
   {
     body: {
       query_id: 1,
@@ -258,7 +296,13 @@ describe('typescript generator', () => {
       }
       const method = apiTestModel.methods.all_users
       const actual = gen.makeTheCall(method, inputs)
-      const expected = `let response = await sdk.ok(sdk.all_users(
+      const expected = `// functional SDK syntax is recommended for minimizing browser payloads
+let response = await sdk.ok(all_users(sdk,
+  {
+    ids: new DelimArray<number>([1,2,3])
+  }))
+// monolithic SDK syntax can be also used for Node apps
+let response = await sdk.ok(sdk.all_users(
   {
     ids: new DelimArray<number>([1,2,3])
   }))`
@@ -295,7 +339,43 @@ describe('typescript generator', () => {
       const inputs = { body, fields }
       const method = apiTestModel.methods.create_merge_query
       const actual = gen.makeTheCall(method, inputs)
-      const expected = `let response = await sdk.ok(sdk.create_merge_query(
+      const expected = `// functional SDK syntax is recommended for minimizing browser payloads
+let response = await sdk.ok(create_merge_query(sdk,
+  {
+    body: {
+      pivots: [
+        'one',
+        'two',
+        'three'
+      ],
+      sorts: ['a'],
+      source_queries: [
+        {
+          merge_fields: [
+            {
+              field_name: 'merge_1',
+              source_field_name: 'source_1'
+            }
+          ],
+          name: 'first query',
+          query_id: 1
+        },
+        {
+          merge_fields: [
+            {
+              field_name: 'merge_2',
+              source_field_name: 'source_2'
+            }
+          ],
+          name: 'second query',
+          query_id: 2
+        }
+      ]
+    },
+    fields: 'id,user_id,title,description'
+  }))
+// monolithic SDK syntax can be also used for Node apps
+let response = await sdk.ok(sdk.create_merge_query(
   {
     body: {
       pivots: [
@@ -340,7 +420,18 @@ describe('typescript generator', () => {
       }
       const inputs = { body: query }
       const method = apiTestModel.methods.create_sql_query
-      const expected = `let response = await sdk.ok(sdk.create_sql_query(
+      const expected = `// functional SDK syntax is recommended for minimizing browser payloads
+let response = await sdk.ok(create_sql_query(sdk,
+  {
+    connection_name: 'looker',
+    model_name: 'the_look',
+    vis_config: {
+      first: 1,
+      second: 'two'
+    }
+  }))
+// monolithic SDK syntax can be also used for Node apps
+let response = await sdk.ok(sdk.create_sql_query(
   {
     connection_name: 'looker',
     model_name: 'the_look',

--- a/packages/sdk-codegen/src/typescript.gen.spec.ts
+++ b/packages/sdk-codegen/src/typescript.gen.spec.ts
@@ -176,7 +176,7 @@ describe('typescript generator', () => {
       const actual = gen.makeTheCall(method, inputs)
       const expected = `// functional SDK syntax is recommended for minimizing browser payloads
 let response = await sdk.ok(run_look(sdk))
-// monolithic SDK syntax can be also used for Node apps
+// monolithic SDK syntax can also be used for Node apps
 let response = await sdk.ok(sdk.run_look())`
       expect(actual).toEqual(expected)
     })
@@ -187,7 +187,7 @@ let response = await sdk.ok(sdk.run_look())`
       const actual = gen.makeTheCall(method, inputs)
       const expected = `// functional SDK syntax is recommended for minimizing browser payloads
 let response = await sdk.ok(look(sdk,17))
-// monolithic SDK syntax can be also used for Node apps
+// monolithic SDK syntax can also be used for Node apps
 let response = await sdk.ok(sdk.look(17))`
       expect(actual).toEqual(expected)
     })
@@ -199,7 +199,7 @@ let response = await sdk.ok(sdk.look(17))`
       const expected = `// functional SDK syntax is recommended for minimizing browser payloads
 let response = await sdk.ok(look(sdk,
   17, '${fields}'))
-// monolithic SDK syntax can be also used for Node apps
+// monolithic SDK syntax can also be used for Node apps
 let response = await sdk.ok(sdk.look(
   17, '${fields}'))`
       expect(actual).toEqual(expected)
@@ -229,7 +229,7 @@ let response = await sdk.ok(update_look(sdk,
       total: true
     }
   }, 'id,user_id,title,description'))
-// monolithic SDK syntax can be also used for Node apps
+// monolithic SDK syntax can also be used for Node apps
 let response = await sdk.ok(sdk.update_look(
   17, {
     title: 'test title',
@@ -253,7 +253,7 @@ let response = await sdk.ok(run_look(sdk,
     look_id: 17,
     result_format: 'png'
   }))
-// monolithic SDK syntax can be also used for Node apps
+// monolithic SDK syntax can also be used for Node apps
 let response = await sdk.ok(sdk.run_look(
   {
     look_id: 17,
@@ -279,7 +279,7 @@ let response = await sdk.ok(create_query_task(sdk,
       result_format: ResultFormat.csv
     }
   }))
-// monolithic SDK syntax can be also used for Node apps
+// monolithic SDK syntax can also be used for Node apps
 let response = await sdk.ok(sdk.create_query_task(
   {
     body: {
@@ -301,7 +301,7 @@ let response = await sdk.ok(all_users(sdk,
   {
     ids: new DelimArray<number>([1,2,3])
   }))
-// monolithic SDK syntax can be also used for Node apps
+// monolithic SDK syntax can also be used for Node apps
 let response = await sdk.ok(sdk.all_users(
   {
     ids: new DelimArray<number>([1,2,3])
@@ -374,7 +374,7 @@ let response = await sdk.ok(create_merge_query(sdk,
     },
     fields: 'id,user_id,title,description'
   }))
-// monolithic SDK syntax can be also used for Node apps
+// monolithic SDK syntax can also be used for Node apps
 let response = await sdk.ok(sdk.create_merge_query(
   {
     body: {
@@ -430,7 +430,7 @@ let response = await sdk.ok(create_sql_query(sdk,
       second: 'two'
     }
   }))
-// monolithic SDK syntax can be also used for Node apps
+// monolithic SDK syntax can also be used for Node apps
 let response = await sdk.ok(sdk.create_sql_query(
   {
     connection_name: 'looker',

--- a/packages/sdk-codegen/src/typescript.gen.ts
+++ b/packages/sdk-codegen/src/typescript.gen.ts
@@ -299,7 +299,7 @@ export class ${this.packageName}Stream extends APIMethods {
     const args = this.assignParams(method, inputs)
     const fun = `// functional SDK syntax is recommended for minimizing browser payloads
 let response = await sdk.ok(${method.name}(sdk${args ? ',' : ''}`
-    const mono = `// monolithic SDK syntax can be also used for Node apps
+    const mono = `// monolithic SDK syntax can also be used for Node apps
 let response = await sdk.ok(sdk.${method.name}(`
     return `${fun}${args}))\n${mono}${args}))`
   }

--- a/packages/sdk-codegen/src/typescript.gen.ts
+++ b/packages/sdk-codegen/src/typescript.gen.ts
@@ -296,9 +296,12 @@ export class ${this.packageName}Stream extends APIMethods {
 
   makeTheCall(method: IMethod, inputs: ArgValues): string {
     inputs = trimInputs(inputs)
-    const resp = `let response = await sdk.ok(sdk.${method.name}(`
     const args = this.assignParams(method, inputs)
-    return `${resp}${args}))`
+    const fun = `// functional SDK syntax is recommended for minimizing browser payloads
+let response = await sdk.ok(${method.name}(sdk${args ? ',' : ''}`
+    const mono = `// monolithic SDK syntax can be also used for Node apps
+let response = await sdk.ok(sdk.${method.name}(`
+    return `${fun}${args}))\n${mono}${args}))`
   }
 
   methodHeaderComment(method: IMethod, params: string[] = []) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3861,7 +3861,6 @@ ansi-escapes@^4.2.1, ansi-escapes@^4.3.0:
 
 ansi-html@0.0.7, "ansi-html@https://registry.yarnpkg.com/ansi-html-community/-/ansi-html-community-0.0.8.tgz#69fbc4d6ccbe383f9736934ae34c3f8290f1bf41":
   version "0.0.8"
-  uid "69fbc4d6ccbe383f9736934ae34c3f8290f1bf41"
   resolved "https://registry.yarnpkg.com/ansi-html-community/-/ansi-html-community-0.0.8.tgz#69fbc4d6ccbe383f9736934ae34c3f8290f1bf41"
 
 ansi-regex@5.0.1, ansi-regex@^2.0.0, ansi-regex@^3.0.0, ansi-regex@^4.1.0, ansi-regex@^5.0.0, ansi-regex@^5.0.1:
@@ -5088,7 +5087,7 @@ comma-separated-tokens@^1.0.0:
   resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz#632b80b6117867a158f1080ad498b2fbe7e3f5ea"
   integrity sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==
 
-commander@6.2.1, commander@^6.1.0, commander@^6.2.0:
+commander@6.2.1, commander@^6.2.0:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
   integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
@@ -5117,6 +5116,11 @@ commander@^7.0.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
   integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
+
+commander@^9.4.0:
+  version "9.4.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-9.4.1.tgz#d1dd8f2ce6faf93147295c0df13c7c21141cfbdd"
+  integrity sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -13267,10 +13271,10 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@7.x, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
-  version "7.3.7"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
-  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
+semver@7.x, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7:
+  version "7.3.8"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
+  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
   dependencies:
     lru-cache "^6.0.0"
 
@@ -14558,7 +14562,7 @@ tslib@2.1.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
   integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
 
-tslib@^2.3.0, tslib@^2.3.1:
+tslib@^2.3.0, tslib@^2.3.1, tslib@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
@@ -15641,14 +15645,15 @@ yargs@^16.1.1:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-yarn-deduplicate@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/yarn-deduplicate/-/yarn-deduplicate-3.1.0.tgz#3018d93e95f855f236a215b591fe8bc4bcabba3e"
-  integrity sha512-q2VZ6ThNzQpGfNpkPrkmV7x5HT9MOhCUsTxVTzyyZB0eSXz1NTodHn+r29DlLb+peKk8iXxzdUVhQG9pI7moFw==
+yarn-deduplicate@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/yarn-deduplicate/-/yarn-deduplicate-6.0.0.tgz#91bc0b7b374efe24796606df2c6b00eabb5aab62"
+  integrity sha512-HjGVvuy10hetOuXeexXXT77V+6FfgS+NiW3FsmQD88yfF2kBqTpChvMglyKUlQ0xXEcI77VJazll5qKKBl3ssw==
   dependencies:
     "@yarnpkg/lockfile" "^1.1.0"
-    commander "^6.1.0"
-    semver "^7.3.2"
+    commander "^9.4.0"
+    semver "^7.3.7"
+    tslib "^2.4.0"
 
 yauzl@^2.10.0:
   version "2.10.0"


### PR DESCRIPTION
- sdk selection was broken on the developer portal, because some scenes weren't using the react dom `location` for `location.pathname`, which caused the path to include `/api/explorer` when it shouldn't have
- This also fixes a crash bug when clicking on a method summary page from a type summary page
- also introduces **funSDK** syntax into the TypeScript `makeTheCall()` that now shows in RunIt
- also updates yarn-deduplicate