### PR TITLE
fix: Handle Go SDK 204 no responses correctly

### DIFF
--- a/go/integration/integration_test.go
+++ b/go/integration/integration_test.go
@@ -165,6 +165,66 @@ func TestIntegrationGoSDK(t *testing.T) {
 		}
 	})
 
+	t.Run("CRUD User Attribute Group Value", func(t *testing.T) {
+		name := "foo"
+		group, err := sdk.CreateGroup(v4.WriteGroup{
+			Name: &name,
+		}, "", nil)
+		if err != nil {
+			t.Errorf("CreateGroup() failed. error=%v", err)
+		}
+
+		groupId := group.Id
+		group, err = sdk.Group(*groupId, "", nil)
+		if err != nil {
+			t.Errorf("Group() failed. error=%v", err)
+		}
+
+		attributeName := "bar"
+		attributeLabel := "bar"
+		attributeType := "string"
+		ua, err := sdk.CreateUserAttribute(v4.WriteUserAttribute{
+			Name:  attributeName,
+			Label: attributeLabel,
+			Type:  attributeType,
+		}, "", nil)
+		if err != nil {
+			t.Errorf("CreateUserAttribute failed. error=%v", err)
+		}
+
+		uaId := ua.Id
+		ua, err = sdk.UserAttribute(*uaId, "", nil)
+		if err != nil {
+			t.Errorf("UserAttribute() failed. error=%v", err)
+		}
+
+		value := "baz"
+		_, err = sdk.UpdateUserAttributeGroupValue(*groupId, *uaId, v4.UserAttributeGroupValue{
+			GroupId:         groupId,
+			UserAttributeId: uaId,
+			Value:           &value,
+		}, nil)
+		if err != nil {
+			t.Errorf("UpdateUserAttributeGroupValue() failed. error=%v", err)
+		}
+
+		err = sdk.DeleteUserAttributeGroupValue(*groupId, *uaId, nil)
+		if err != nil {
+			t.Errorf("DeleteUserAttributeGroupValue() failed. error=%v", err)
+		}
+
+		_, err = sdk.DeleteUserAttribute(*uaId, nil)
+		if err != nil {
+			t.Errorf("DeleteUserAttribute() failed. error=%v", err)
+		}
+
+		_, err = sdk.DeleteGroup(*groupId, nil)
+		if err != nil {
+			t.Errorf("DeleteGroup() failed. error=%v", err)
+		}
+
+	})
+
 	t.Run("Me()", func(t *testing.T) {
 		user, err := sdk.Me("", nil)
 

--- a/go/rtl/auth.go
+++ b/go/rtl/auth.go
@@ -118,7 +118,7 @@ func (s *AuthSession) Do(result interface{}, method, ver, path string, reqPars m
 		return fmt.Errorf("response error. status=%s. error=%s", res.Status, string(b))
 	}
 
-	if res.StatusCode == 204 { // for delete endpoints there's no response body
+	if res.StatusCode == 204 { // 204 No Content. DELETE endpoints returns response with no body
 		return nil
 	}
 

--- a/go/rtl/auth.go
+++ b/go/rtl/auth.go
@@ -118,6 +118,10 @@ func (s *AuthSession) Do(result interface{}, method, ver, path string, reqPars m
 		return fmt.Errorf("response error. status=%s. error=%s", res.Status, string(b))
 	}
 
+	if res.StatusCode == 204 { // for delete endpoints there's no response body
+		return nil
+	}
+
 	// TODO: Make parsing content-type aware. Requires change to go model generation to use interface{} for all union types.
 	// Github Issue: https://github.com/looker-open-source/sdk-codegen/issues/1022
 	switch v := result.(type) {


### PR DESCRIPTION
Changes copied from **approved** PR from forked repo https://github.com/looker-open-source/sdk-codegen/pull/1074

Original commit message: 
I added status code handling in the Go SDK to deal with delete endpoints' response body.
In Looker API, delete endpoints call returns empty response body with status code 204 when the API call is succeeded.
Such API call will be failed with EOF error in the current implementation because of reading empty response body.