### PR TITLE
chore: support new cloud redirect host

### DIFF
--- a/kotlin/src/main/com/looker/rtl/ErrorDoc.kt
+++ b/kotlin/src/main/com/looker/rtl/ErrorDoc.kt
@@ -116,7 +116,7 @@ class ErrorDoc(val sdk: APIMethods, val cdnUrl: String = ErrorCodesUrl): IErrorD
 
         /** API error document_url link pattern */
         private const val ErrorDocPatternExpression =
-            """(?<redirector>https:\/\/docs\.looker\.com\/r\/err\/)(?<apiVersion>.*)\/(?<statusCode>\d{3})(?<apiPath>.*)"""
+            """(?<redirector>https://docs\.looker\.com/r/err/|https://cloud\.google\.com/looker/docs/r/err/)(?<apiVersion>.*)/(?<statusCode>\d{3})(?<apiPath>.*)"""
         val ErrorDocRx = Regex(ErrorDocPatternExpression, RegexOption.IGNORE_CASE)
     }
 

--- a/kotlin/src/main/com/looker/rtl/Transport.kt
+++ b/kotlin/src/main/com/looker/rtl/Transport.kt
@@ -321,7 +321,13 @@ class Transport(val options: TransportOptions) {
 
         val requestPath = makeUrl(path, queryParams, authenticator)
 
-        val auth = authenticator ?: ::defaultAuthenticator
+        var auth = authenticator ?: ::defaultAuthenticator
+        if (path.startsWith("http://", true) ||
+            path.startsWith("https://", true)) {
+            // if a full path is passed in, this is a straight fetch, not an API call
+            // so don't authenticate
+            auth = ::defaultAuthenticator
+        }
 
         val finishedRequest = auth(RequestSettings(method, requestPath, headers))
 

--- a/kotlin/src/test/TestErrorDoc.kt
+++ b/kotlin/src/test/TestErrorDoc.kt
@@ -38,6 +38,7 @@ val errorCodeType = object : TypeToken<ErrorCodeIndex>() {}.type
 class TestErrorDoc {
     val external = "https://docs.looker.com/r/err/4.0/429/delete/bogus/:namespace/purge"
     val internal = "https://docs.looker.com/r/err/internal/422/post/bogus/bulk"
+    val cloud = "https://cloud.google.com/looker/docs/r/err/internal/422/post/bogus/bulk"
     val badLogin = "https://docs.looker.com/r/err/4.0/404/post/login"
     val config = TestConfig()
     val errDoc = ErrorDoc(config.sdk)
@@ -52,6 +53,11 @@ class TestErrorDoc {
         assertEquals("/delete/bogus/:namespace/purge", actual.apiPath)
         actual = errDoc.parse(internal)
         assertEquals("https://docs.looker.com/r/err/", actual.redirector)
+        assertEquals("internal", actual.apiVersion)
+        assertEquals("422", actual.statusCode)
+        assertEquals("/post/bogus/bulk", actual.apiPath)
+        actual = errDoc.parse(cloud)
+        assertEquals("https://cloud.google.com/looker/docs/r/err/", actual.redirector)
         assertEquals("internal", actual.apiVersion)
         assertEquals("422", actual.statusCode)
         assertEquals("/post/bogus/bulk", actual.apiPath)

--- a/packages/sdk-rtl/src/errorDoc.spec.ts
+++ b/packages/sdk-rtl/src/errorDoc.spec.ts
@@ -61,6 +61,8 @@ describe('ErrorDoc', () => {
   const internal = 'https://docs.looker.com/r/err/internal/422/post/bogus/bulk'
   const badLogin = 'https://docs.looker.com/r/err/4.0/404/post/login'
   const another404 = 'https://docs.looker.com/r/err/4.0/404/post/another'
+  const cloud404 =
+    'https://cloud.google.com/looker/docs/r/err/4.0/404/post/another'
   const partial404 = '/err/4.0/404/post/another'
   const hostname = 'https://looker.sdk'
   const settings = { base_url: hostname } as IApiSettings
@@ -110,6 +112,7 @@ describe('ErrorDoc', () => {
     it.each<[string, string, number]>([
       [badLogin, '## API Response 404 for `login`', 2], // valid mock url and content so load will be called twice
       [another404, '## Generic 404', 2], // valid mock url and content that defaults to generic message so load will be called twice
+      [cloud404, '## Generic 404', 2], // valid mock url and content that defaults to generic message so load will be called twice
       [partial404, '## Generic 404', 2], // valid mock url and content that defaults to generic message so load will be called twice
       [internal, `${no}422/post/bogus/bulk`, 1], // invalid, default to not found
       [external, `${no}429/delete/bogus/{namespace}/purge`, 1], // invalid, default to not found
@@ -161,6 +164,17 @@ describe('ErrorDoc', () => {
         apiVersion: '4.0',
         statusCode: '429',
         apiPath: '/delete/bogus/:namespace/purge',
+      })
+    })
+
+    it('resolves cloud paths', () => {
+      const actual = errDoc.parse(cloud404)
+      expect(actual).toBeDefined()
+      expect(actual).toEqual({
+        redirector: 'https://cloud.google.com/looker/docs/r/err/',
+        apiVersion: '4.0',
+        statusCode: '404',
+        apiPath: '/post/another',
       })
     })
 

--- a/packages/sdk-rtl/src/errorDoc.ts
+++ b/packages/sdk-rtl/src/errorDoc.ts
@@ -42,7 +42,7 @@ export type ErrorCodeIndex = Record<string, IErrorDocItem>
 export const ErrorDocNotFound = '### No documentation found for '
 
 /** API error document_url link pattern */
-const ErrorDocPatternExpression = String.raw`(?<redirector>(https:\/\/docs\.looker\.com\/r)?\/err\/)(?<apiVersion>.*)\/(?<statusCode>\d{3})(?<apiPath>.*)`
+const ErrorDocPatternExpression = String.raw`(?<redirector>(https:\/\/docs\.looker\.com\/r|https:\/\/cloud\.google\.com\/looker\/docs\/r)?\/err\/)(?<apiVersion>.*)\/(?<statusCode>\d{3})(?<apiPath>.*)`
 export const ErrorDocRx = RegExp(ErrorDocPatternExpression, 'i')
 
 export interface IErrorDocLink {


### PR DESCRIPTION
ErrorDoc implementations support both docs.looker.com and cloud.google.com redirect host patterns
