### PR TITLE
fix: WhollyArtifact/Hack App table name fix

### DIFF
--- a/packages/hackathon/artifact.ipynb
+++ b/packages/hackathon/artifact.ipynb
@@ -9,7 +9,9 @@
     "DATA = {\n",
     "    'client_id':'',\n",
     "    'client_secret':''\n",
-    "}"
+    "}\n",
+    "\n",
+    "BASE_URL = 'http://localhost:19999'"
    ]
   },
   {
@@ -21,18 +23,18 @@
     "# Login\n",
     "import requests \n",
     "\n",
-    "response = requests.post('http://localhost:19999/login',data=DATA)\n",
-    "\n",
+    "response = requests.post(BASE_URL + '/api/4.0/login',data=DATA)\n",
+    "print(response.status_code)\n",
     "access_token = response.json()['access_token']\n",
     "headers= {\n",
     "    'Authorization': 'token ' + access_token,\n",
     "    'x-looker-appid': 'marketplace_extension_hackathon::hackathon'\n",
     "}\n",
     "response = requests.get(\n",
-    "    'http://localhost:19999/api/4.0/artifact/namespaces',\n",
+    "    BASE_URL + '/api/4.0/artifact/namespaces',\n",
     "    headers=headers)\n",
     "\n",
-    "print(response.status_code)"
+    "print(response.json())"
    ]
   },
   {
@@ -45,7 +47,7 @@
     "TABLE_NAME = 'User'\n",
     "\n",
     "response = requests.get(\n",
-    "    'http://localhost:19999/api/4.0/artifact/hackathon/search',\n",
+    "    BASE_URL + '/api/4.0/artifact/hackathon/search',\n",
     "    data={'key': TABLE_NAME + '%'},\n",
     "    headers=headers)\n",
     "\n",
@@ -130,7 +132,7 @@
     "    del v['_id'] \n",
     "    artifacts.append(toArtifact(key, v))\n",
     "\n",
-    "response = requests.put('http://localhost:19999/api/4.0/artifacts/hackathon', headers=headers, json=artifacts) \n",
+    "response = requests.put(BASE_URL + '/api/4.0/artifacts/hackathon', headers=headers, json=artifacts) \n",
     "\n",
     "print(response.status_code)\n"
    ]
@@ -142,25 +144,25 @@
    "outputs": [],
    "source": [
     "# TO PURGE ALL TABLES. BE CAREFUL\n",
-    "response = requests.delete('http://localhost:19999/api/4.0/artifact/Hackathon/purge',headers=headers)\n",
+    "response = requests.delete(BASE_URL + '/api/4.0/artifact/Hackathon/purge',headers=headers)\n",
     "print(response.status_code)\n",
     "\n",
-    "response = requests.delete('http://localhost:19999/api/4.0/artifact/Judging/purge',headers=headers)\n",
+    "response = requests.delete(BASE_URL + '/api/4.0/artifact/Judging/purge',headers=headers)\n",
     "print(response.status_code)\n",
     "\n",
-    "response = requests.delete('http://localhost:19999/api/4.0/artifact/Project/purge',headers=headers)\n",
+    "response = requests.delete(BASE_URL + '/api/4.0/artifact/Project/purge',headers=headers)\n",
     "print(response.status_code)\n",
     "\n",
-    "response = requests.delete('http://localhost:19999/api/4.0/artifact/Registration/purge',headers=headers)\n",
+    "response = requests.delete(BASE_URL + '/api/4.0/artifact/Registration/purge',headers=headers)\n",
     "print(response.status_code)\n",
     "\n",
-    "response = requests.delete('http://localhost:19999/api/4.0/artifact/TeamMember/purge',headers=headers)\n",
+    "response = requests.delete(BASE_URL + '/api/4.0/artifact/TeamMember/purge',headers=headers)\n",
     "print(response.status_code)\n",
     "\n",
-    "response = requests.delete('http://localhost:19999/api/4.0/artifact/Technology/purge',headers=headers)\n",
+    "response = requests.delete(BASE_URL + '/api/4.0/artifact/Technology/purge',headers=headers)\n",
     "print(response.status_code)\n",
     "\n",
-    "response = requests.delete('http://localhost:19999/api/4.0/artifact/User/purge',headers=headers)\n",
+    "response = requests.delete(BASE_URL + '/api/4.0/artifact/User/purge',headers=headers)\n",
     "print(response.status_code)\n"
    ]
   },

--- a/packages/hackathon/src/models/Hackathons.ts
+++ b/packages/hackathon/src/models/Hackathons.ts
@@ -67,6 +67,10 @@ export class Hackathon extends SheetRow<IHackathon> {
     this.assign(values)
   }
 
+  tableName() {
+    return 'Hackathon'
+  }
+
   isActive() {
     const now = new Date().getTime()
     return this.date.getTime() <= now && this.judging_stops.getTime() >= now

--- a/packages/hackathon/src/models/Judgings.ts
+++ b/packages/hackathon/src/models/Judgings.ts
@@ -89,6 +89,10 @@ export class Judging extends SheetRow<IJudging> {
     this.assign(values)
   }
 
+  tableName() {
+    return 'Judging'
+  }
+
   private data() {
     return getActiveSheet()
   }

--- a/packages/hackathon/src/models/Projects.ts
+++ b/packages/hackathon/src/models/Projects.ts
@@ -97,6 +97,10 @@ export class Project extends SheetRow<Project> {
     this.assign(values)
   }
 
+  tableName() {
+    return 'Project'
+  }
+
   get $team_count() {
     return `${this.$team.length}/${this.$hackathon?.max_team_size || 5}`
   }

--- a/packages/hackathon/src/models/Registrations.ts
+++ b/packages/hackathon/src/models/Registrations.ts
@@ -56,6 +56,10 @@ export class Registration extends SheetRow<IRegistration> {
     this.assign(values)
   }
 
+  tableName() {
+    return 'Registration'
+  }
+
   prepare(): IRegistration {
     super.prepare()
     if (this.date_registered === noDate) this.date_registered = new Date()

--- a/packages/hackathon/src/models/TeamMembers.ts
+++ b/packages/hackathon/src/models/TeamMembers.ts
@@ -60,6 +60,10 @@ export class TeamMember extends SheetRow<ITeamMember> {
     this.assign(values)
   }
 
+  tableName() {
+    return 'TeamMember'
+  }
+
   get $name() {
     if (!this.$user) {
       throw new Error(`$user is not assigned for user_id ${this.user_id}`)

--- a/packages/hackathon/src/models/Technologies.ts
+++ b/packages/hackathon/src/models/Technologies.ts
@@ -49,6 +49,10 @@ export class Technology extends SheetRow<ITechnology> {
     this.assign(values)
   }
 
+  tableName() {
+    return 'Technology'
+  }
+
   toObject(): ITechnologyProps {
     return super.toObject() as ITechnologyProps
   }

--- a/packages/hackathon/src/models/Users.ts
+++ b/packages/hackathon/src/models/Users.ts
@@ -62,6 +62,10 @@ export class User extends SheetRow<IUser> {
     this.assign(values)
   }
 
+  tableName() {
+    return 'User'
+  }
+
   get $name(): string {
     return `${this.first_name} ${this.last_name}`
   }

--- a/packages/wholly-artifact/src/RowModel.ts
+++ b/packages/wholly-artifact/src/RowModel.ts
@@ -181,8 +181,12 @@ export interface IRowModel extends IRowModelProps {
   namespace(): string
 
   /**
-   * Prefix (table name, basically) to use for artifact key generation.
-   * Based on the object constructor. No need to override, usually.
+   * RowModel prefix to use for generating new key values. For example, a prefix() that returns `Hackathon` would
+   * result in a key assignment like `Hackathon:9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d`
+   *
+   * When using artifact collections like data tables, artifact key values are intended to be hidden from the UI.
+   * This prefix is purely used for making it feasible to query an artifact collection by its prefix key value
+   * Must be implemented.
    */
   tableName(): string
 


### PR DESCRIPTION
WhollyArtifact's RowModel derives it's tablename from the name of the constructor `constructor.name`. Turns out a constructor's name is generated by minified code, so that's a no go. Found out about this while migrating our hack.looker.com hack app, since it requires bundled/minified js. 

- Updated WhollyArtifact package to remove Rowmodel's tablename implementation
- Updated hack app to specify tablename for each RowModel.
- Also updated artifact notebook for convenience.