### PR TITLE
fix: Fix admin add user to correctly generate API3 keys.

### DIFF
--- a/packages/hackathon/src/data/add_user/sagas.ts
+++ b/packages/hackathon/src/data/add_user/sagas.ts
@@ -115,7 +115,7 @@ function* addUsersSaga(action: ReturnType<typeof addUsers>): SagaIterator {
         yield call([lookerSdk, lookerSdk.ok], result)
       }
 
-      if (!user.credentials_api3) {
+      if (!user.credentials_api3 || user.credentials_api3.length === 0) {
         const result = yield call(
           [lookerSdk, lookerSdk.create_user_credentials_api3],
           user.id as string


### PR DESCRIPTION
Turns out API will return empty array instead of null/undefined defined in the type.