### PR TITLE
fix: oauth timeout

### DIFF
--- a/packages/extension-sdk/package.json
+++ b/packages/extension-sdk/package.json
@@ -39,7 +39,7 @@
     "@types/semver": "^7.3.4"
   },
   "dependencies": {
-    "@looker/chatty": "^2.3.0",
+    "@looker/chatty": "2.3.7",
     "@looker/sdk": "^22.20.0",
     "@looker/sdk-rtl": "^21.4.0",
     "deepmerge": "^4.2.2",

--- a/packages/extension-sdk/src/connect/extension_host_api.spec.ts
+++ b/packages/extension-sdk/src/connect/extension_host_api.spec.ts
@@ -579,17 +579,21 @@ describe('extension_host_api tests', () => {
       response_type: 'token',
     }
     await hostApi.oauth2Authenticate(authEndpoint, authParameters)
-    expect(sendAndReceiveSpy).toHaveBeenCalledWith('EXTENSION_API_REQUEST', {
-      payload: {
+    expect(sendAndReceiveSpy).toHaveBeenCalledWith(
+      'EXTENSION_API_REQUEST',
+      {
         payload: {
-          authEndpoint,
-          authParameters,
-          httpMethod: 'POST',
+          payload: {
+            authEndpoint,
+            authParameters,
+            httpMethod: 'POST',
+          },
+          type: 'oauth2_authenticate',
         },
-        type: 'oauth2_authenticate',
+        type: 'INVOKE_EXTERNAL_API',
       },
-      type: 'INVOKE_EXTERNAL_API',
-    })
+      { signal: new AbortController().signal }
+    )
     done()
   })
 
@@ -602,17 +606,21 @@ describe('extension_host_api tests', () => {
       response_type: 'id_token',
     }
     await hostApi.oauth2Authenticate(authEndpoint, authParameters)
-    expect(sendAndReceiveSpy).toHaveBeenCalledWith('EXTENSION_API_REQUEST', {
-      payload: {
+    expect(sendAndReceiveSpy).toHaveBeenCalledWith(
+      'EXTENSION_API_REQUEST',
+      {
         payload: {
-          authEndpoint,
-          authParameters,
-          httpMethod: 'POST',
+          payload: {
+            authEndpoint,
+            authParameters,
+            httpMethod: 'POST',
+          },
+          type: 'oauth2_authenticate',
         },
-        type: 'oauth2_authenticate',
+        type: 'INVOKE_EXTERNAL_API',
       },
-      type: 'INVOKE_EXTERNAL_API',
-    })
+      { signal: new AbortController().signal }
+    )
     done()
   })
 
@@ -645,17 +653,21 @@ describe('extension_host_api tests', () => {
       response_type: 'token',
     }
     await hostApi.oauth2Authenticate(authEndpoint, authParameters, 'GET')
-    expect(sendAndReceiveSpy).toHaveBeenCalledWith('EXTENSION_API_REQUEST', {
-      payload: {
+    expect(sendAndReceiveSpy).toHaveBeenCalledWith(
+      'EXTENSION_API_REQUEST',
+      {
         payload: {
-          authEndpoint,
-          authParameters,
-          httpMethod: 'GET',
+          payload: {
+            authEndpoint,
+            authParameters,
+            httpMethod: 'GET',
+          },
+          type: 'oauth2_authenticate',
         },
-        type: 'oauth2_authenticate',
+        type: 'INVOKE_EXTERNAL_API',
       },
-      type: 'INVOKE_EXTERNAL_API',
-    })
+      { signal: new AbortController().signal }
+    )
     done()
   })
 

--- a/packages/extension-sdk/src/connect/extension_host_api.ts
+++ b/packages/extension-sdk/src/connect/extension_host_api.ts
@@ -24,7 +24,7 @@
 
  */
 
-import type { ChattyHostConnection } from '@looker/chatty'
+import type { ChattyHostConnection, Options } from '@looker/chatty'
 import intersects from 'semver/ranges/intersects'
 import { FetchProxyImpl } from './fetch_proxy'
 import type {
@@ -442,7 +442,7 @@ export class ExtensionHostApiImpl implements ExtensionHostApi {
         },
       },
       // Adding the signal disables the default timeout
-      new AbortController().signal
+      { signal: new AbortController().signal }
     )
   }
 
@@ -466,7 +466,7 @@ export class ExtensionHostApiImpl implements ExtensionHostApi {
   private async sendAndReceive(
     type: string,
     payload?: any,
-    signal?: AbortSignal
+    options?: Options
   ): Promise<any> {
     if (!this._lookerHostData) {
       return Promise.reject(new Error('Looker host connection not established'))
@@ -475,9 +475,7 @@ export class ExtensionHostApiImpl implements ExtensionHostApi {
       type,
       payload,
     }
-    const chattyPayload = signal
-      ? [messagePayload, { signal }]
-      : [messagePayload]
+    const chattyPayload = options ? [messagePayload, options] : [messagePayload]
     return this.chattyHost
       .sendAndReceive(ExtensionEvent.EXTENSION_API_REQUEST, ...chattyPayload)
       .then((values) => values[0])

--- a/packages/extension-sdk/src/connect/extension_host_api.ts
+++ b/packages/extension-sdk/src/connect/extension_host_api.ts
@@ -431,14 +431,19 @@ export class ExtensionHostApiImpl implements ExtensionHostApi {
     if (errorMessage) {
       return Promise.reject(new Error(errorMessage))
     }
-    return this.sendAndReceive(ExtensionRequestType.INVOKE_EXTERNAL_API, {
-      type: 'oauth2_authenticate',
-      payload: {
-        authEndpoint,
-        authParameters,
-        httpMethod,
+    return this.sendAndReceive(
+      ExtensionRequestType.INVOKE_EXTERNAL_API,
+      {
+        type: 'oauth2_authenticate',
+        payload: {
+          authEndpoint,
+          authParameters,
+          httpMethod,
+        },
       },
-    })
+      // Adding the signal disables the default timeout
+      new AbortController().signal
+    )
   }
 
   async oauth2ExchangeCodeForToken(
@@ -458,15 +463,23 @@ export class ExtensionHostApiImpl implements ExtensionHostApi {
     })
   }
 
-  private async sendAndReceive(type: string, payload?: any): Promise<any> {
+  private async sendAndReceive(
+    type: string,
+    payload?: any,
+    signal?: AbortSignal
+  ): Promise<any> {
     if (!this._lookerHostData) {
       return Promise.reject(new Error('Looker host connection not established'))
     }
+    const messagePayload = {
+      type,
+      payload,
+    }
+    const chattyPayload = signal
+      ? [messagePayload, { signal }]
+      : [messagePayload]
     return this.chattyHost
-      .sendAndReceive(ExtensionEvent.EXTENSION_API_REQUEST, {
-        type,
-        payload,
-      })
+      .sendAndReceive(ExtensionEvent.EXTENSION_API_REQUEST, ...chattyPayload)
       .then((values) => values[0])
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2297,10 +2297,10 @@
     npmlog "^4.1.2"
     write-file-atomic "^2.3.0"
 
-"@looker/chatty@^2.3.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@looker/chatty/-/chatty-2.3.0.tgz#380ff86bff34d8866f641fae3e53997266a3de3c"
-  integrity sha512-UO7pwQ+KU4UoV3+MSq7YVnWR74Pl1Jj15QO821W8Y+pW431KoHydiA7UUJmQnPEJDCgHLxepPs43jvJI/NMRhQ==
+"@looker/chatty@2.3.7":
+  version "2.3.7"
+  resolved "https://registry.yarnpkg.com/@looker/chatty/-/chatty-2.3.7.tgz#8005af4c8aa3cd92b4f1c47caed44df8984e351e"
+  integrity sha512-M6WHWKFsnnk06hsgImZDfyu6fExbitcI/zzKQe87YzmJG5kGz9rqeBwkwsZhaWP5IxVh5TiqoXX9bReN4BEKFA==
   dependencies:
     core-js "^3.6.4"
     debug "^2.2.0"
@@ -5578,6 +5578,11 @@ cosmiconfig@^7.0.0:
     parse-json "^5.0.0"
     path-type "^4.0.0"
     yaml "^1.10.0"
+
+countries-states-json@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/countries-states-json/-/countries-states-json-1.2.3.tgz#3a3c4e0189cc8cd5747c6426dc5cfbc1282cfb62"
+  integrity sha512-c5uxZfjxbOEHdLN4wdtIoezkJgt7QQf6beS3p/WKV7xYyk4jiBq86tFtVpvy8uMupIGeJcaA0Lhq3mkTZEhrlA==
 
 create-emotion@^10.0.14, create-emotion@^10.0.27:
   version "10.0.27"
@@ -12297,6 +12302,15 @@ prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.8.1"
+
+prop-types@^15.8.1:
+  version "15.8.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
+  integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.13.1"
 
 property-information@^5.0.0, property-information@^5.3.0:
   version "5.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5579,11 +5579,6 @@ cosmiconfig@^7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
-countries-states-json@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/countries-states-json/-/countries-states-json-1.2.3.tgz#3a3c4e0189cc8cd5747c6426dc5cfbc1282cfb62"
-  integrity sha512-c5uxZfjxbOEHdLN4wdtIoezkJgt7QQf6beS3p/WKV7xYyk4jiBq86tFtVpvy8uMupIGeJcaA0Lhq3mkTZEhrlA==
-
 create-emotion@^10.0.14, create-emotion@^10.0.27:
   version "10.0.27"
   resolved "https://registry.yarnpkg.com/create-emotion/-/create-emotion-10.0.27.tgz#cb4fa2db750f6ca6f9a001a33fbf1f6c46789503"
@@ -12302,15 +12297,6 @@ prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.8.1"
-
-prop-types@^15.8.1:
-  version "15.8.1"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
-  integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
-  dependencies:
-    loose-envify "^1.4.0"
-    object-assign "^4.1.1"
-    react-is "^16.13.1"
 
 property-information@^5.0.0, property-information@^5.3.0:
   version "5.6.0"


### PR DESCRIPTION
Fixes an issue with OAUTH calls whereby the call initially fail because the chatty timeout (30 seconds) is exceeded.

The fix is to rely on the new AbortController signal feature added to chatty. When a signal is provided, chatty does not timeout and instead relies on signal abort to cancel the call. For OAUTH a signal is provided which bypasses the timeout. The abort is never called but this does not matter as the OAUTH processing monitors the OAUTH child window and knows when a user has terminated the flow in a manner other than a successful login.
