### PR TITLE
feat: add request time tracking

### DIFF
--- a/packages/extension-api-explorer/package.json
+++ b/packages/extension-api-explorer/package.json
@@ -17,8 +17,8 @@
   "dependencies": {
     "@looker/api-explorer": "^0.9.41",
     "@looker/components": "^3.0.8",
-    "@looker/extension-sdk": "^22.20.0",
-    "@looker/extension-sdk-react": "^22.20.0",
+    "@looker/extension-sdk": "*",
+    "@looker/extension-sdk-react": "*",
     "@looker/extension-utils": "^0.1.18",
     "@looker/icons": "^1.5.3",
     "@looker/run-it": "^0.9.41",

--- a/packages/hackathon/src/authToken/extensionProxyTransport.ts
+++ b/packages/hackathon/src/authToken/extensionProxyTransport.ts
@@ -126,7 +126,9 @@ export class ExtensionProxyTransport extends BaseTransport {
     }
     const req = this.extensionSDK.fetchProxy(props.url, fetchParams)
 
+    const requestStarted = Date.now()
     const res: FetchProxyDataResponse = await req
+    const responseCompleted = Date.now()
 
     const contentType = String(res.headers['content-type'])
     // const mode = responseMode(contentType)
@@ -141,6 +143,8 @@ export class ExtensionProxyTransport extends BaseTransport {
       statusCode: res.status,
       statusMessage: `${res.status} fetched`,
       headers: res.headers,
+      requestStarted,
+      responseCompleted,
     }
   }
 

--- a/packages/run-it/src/components/ResponseExplorer/ResponseExplorer.spec.tsx
+++ b/packages/run-it/src/components/ResponseExplorer/ResponseExplorer.spec.tsx
@@ -43,6 +43,8 @@ const response: IRawResponse = {
     link: 'nah, not really',
     'x-total-count': '0',
   },
+  requestStarted: 1000,
+  responseCompleted: 2000,
 }
 
 describe('ResponseExplorer', () => {

--- a/packages/run-it/src/components/ResponseExplorer/ResponseExplorer.tsx
+++ b/packages/run-it/src/components/ResponseExplorer/ResponseExplorer.tsx
@@ -147,6 +147,12 @@ export const ResponseExplorer: FC<ResponseExplorerProps> = ({
     response.contentType === 'application/json'
       ? JSON.parse(response.body)
       : undefined
+
+  const timed = (response: IRawResponse) => {
+    const diff = (response.responseCompleted - response.requestStarted) / 1000
+    return `Seconds: ${diff.toFixed(3)}`
+  }
+
   return (
     <>
       {!response && <DarkSpan>No response was received</DarkSpan>}
@@ -171,7 +177,7 @@ export const ResponseExplorer: FC<ResponseExplorerProps> = ({
             )}
             {`${verb || ''} ${path || ''} (${response.statusCode}: ${
               response.statusMessage
-            })`}
+            }) ${timed(response)}`}
           </RunItHeading>
           <CollapserCard
             divider={false}

--- a/packages/run-it/src/test-data/responses.ts
+++ b/packages/run-it/src/test-data/responses.ts
@@ -35,6 +35,8 @@ export const testJsonResponse: IRawResponse = {
   statusCode: 200,
   statusMessage: 'OK',
   body: Buffer.from('[{"key1": "value1" }]'),
+  requestStarted: 1000,
+  responseCompleted: 2000,
 }
 
 export const testOneRowComplexJson: IRawResponse = {
@@ -97,6 +99,8 @@ export const testOneRowComplexJson: IRawResponse = {
     "schedule": true
   }
 }`),
+  requestStarted: 1000,
+  responseCompleted: 2000,
 }
 
 export const testTextResponse: IRawResponse = {
@@ -108,6 +112,8 @@ export const testTextResponse: IRawResponse = {
   statusCode: 200,
   statusMessage: 'OK',
   body: Buffer.from('some text data'),
+  requestStarted: 1000,
+  responseCompleted: 2000,
 }
 
 export const testHtmlResponse: IRawResponse = {
@@ -124,6 +130,8 @@ export const testHtmlResponse: IRawResponse = {
       '<tr><td>2019-12-22</td><td>39</td></tr>\n' +
       '</table>'
   ),
+  requestStarted: 1000,
+  responseCompleted: 2000,
 }
 
 export const testSqlResponse: IRawResponse = {
@@ -139,6 +147,8 @@ export const testSqlResponse: IRawResponse = {
 FROM demo_db.inventory_items  AS inventory_items
 LEFT JOIN demo_db.products  AS products ON inventory_items.product_id = products.id
 LIMIT 500`),
+  requestStarted: 1000,
+  responseCompleted: 2000,
 }
 
 export const testImageResponse = (contentType = 'image/png'): IRawResponse => ({
@@ -150,6 +160,8 @@ export const testImageResponse = (contentType = 'image/png'): IRawResponse => ({
   statusCode: 200,
   statusMessage: 'OK',
   body: Buffer.from('some image data'),
+  requestStarted: 1000,
+  responseCompleted: 2000,
 })
 
 export const testUnknownResponse: IRawResponse = {
@@ -161,6 +173,8 @@ export const testUnknownResponse: IRawResponse = {
   statusCode: 200,
   statusMessage: 'OK',
   body: Buffer.from('some data'),
+  requestStarted: 1000,
+  responseCompleted: 2000,
 }
 
 export const testErrorResponse: IRawResponse = {
@@ -174,6 +188,8 @@ export const testErrorResponse: IRawResponse = {
   ok: false,
   statusCode: 404,
   statusMessage: 'some status message',
+  requestStarted: 1000,
+  responseCompleted: 2000,
 }
 
 export const testBogusJsonResponse: IRawResponse = {
@@ -185,4 +201,6 @@ export const testBogusJsonResponse: IRawResponse = {
   statusCode: 200,
   statusMessage: 'OK',
   body: Buffer.from('<html><body>I AM A LYING JSON RESPONSE</body></html>'),
+  requestStarted: 1000,
+  responseCompleted: 2000,
 }

--- a/packages/sdk-node/src/nodeTransport.spec.ts
+++ b/packages/sdk-node/src/nodeTransport.spec.ts
@@ -87,6 +87,8 @@ describe('NodeTransport', () => {
       statusCode: StatusCode.OK,
       statusMessage: 'Mocked success',
       body: 'body',
+      requestStarted: 1000,
+      responseCompleted: 2000,
     }
 
     test('ok is ok', () => {

--- a/packages/sdk-node/src/nodeTransport.ts
+++ b/packages/sdk-node/src/nodeTransport.ts
@@ -105,8 +105,12 @@ export class NodeTransport extends BaseTransport {
     )
     const req = rp(init).promise()
     let rawResponse: IRawResponse
+
+    const requestStarted = Date.now()
+    let responseCompleted
     try {
       const res = await req
+      responseCompleted = Date.now()
       const resTyped = res as rq.Response
       rawResponse = {
         method,
@@ -117,6 +121,8 @@ export class NodeTransport extends BaseTransport {
         statusCode: resTyped.statusCode,
         statusMessage: resTyped.statusMessage,
         headers: res.headers,
+        requestStarted,
+        responseCompleted,
       }
       // Update OK with response statusCode check
       rawResponse.ok = this.ok(rawResponse)
@@ -125,6 +131,7 @@ export class NodeTransport extends BaseTransport {
       let statusCode = 404
       let contentType = 'text'
       let body
+      responseCompleted = Date.now()
       if (e instanceof StatusCodeError) {
         statusCode = e.statusCode
         if (e.error instanceof Buffer) {
@@ -153,6 +160,8 @@ export class NodeTransport extends BaseTransport {
         statusCode,
         statusMessage,
         headers: {},
+        requestStarted,
+        responseCompleted,
       }
     }
     return this.observer ? this.observer(rawResponse) : rawResponse

--- a/packages/sdk-rtl/src/browserTransport.spec.ts
+++ b/packages/sdk-rtl/src/browserTransport.spec.ts
@@ -77,6 +77,8 @@ describe('BrowserTransport', () => {
   "num4": 4
 }
 `,
+      requestStarted: 1000,
+      responseCompleted: 2000,
     }
     const untyped: any = await sdkOk(xp.parseResponse(resp))
     expect(untyped.string1).toBe(1)

--- a/packages/sdk-rtl/src/browserTransport.ts
+++ b/packages/sdk-rtl/src/browserTransport.ts
@@ -188,7 +188,9 @@ export class BrowserTransport extends BaseTransport {
       props // Weird package issues with unresolved imports for RequestInit :(
     )
 
+    const requestStarted = Date.now()
     const res = await req
+    const responseCompleted = Date.now()
 
     // Start tracking the time it takes to convert the response
     const started = BrowserTransport.markStart(
@@ -214,6 +216,8 @@ export class BrowserTransport extends BaseTransport {
       statusMessage: res.statusText,
       startMark: started,
       headers,
+      requestStarted,
+      responseCompleted,
     }
     // Update OK with response statusCode check
     response.ok = this.ok(response)

--- a/packages/sdk-rtl/src/paging.spec.ts
+++ b/packages/sdk-rtl/src/paging.spec.ts
@@ -96,6 +96,8 @@ const mockRawResponse = (url?: string, body?: any): IRawResponse => {
     statusMessage: 'Mocking',
     contentType: 'application/json',
     url: 'https://mocked',
+    requestStarted: 1000,
+    responseCompleted: 2000,
   }
   if (url) {
     result.url = url

--- a/packages/sdk-rtl/src/transport.ts
+++ b/packages/sdk-rtl/src/transport.ts
@@ -181,6 +181,10 @@ export interface IRawResponse {
   startMark?: string
   /** Response headers */
   headers: IRequestHeaders
+  /** Request start time */
+  requestStarted: number
+  /** Completion time for request */
+  responseCompleted: number
 }
 
 /** IRawResponse observer function type */

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -45,6 +45,5 @@
       "release-type": "python",
       "package-name": "looker_sdk"
     }
-  },
-  "release-as": "22.20.0"
+  }
 }


### PR DESCRIPTION
The TypeScript SDKs have two new properties for tracking the "raw" request time:

- `requestStarted` timestamp right before the request begins
- `responseCompleted` timestamp right after the response is downloaded, and before the payload is parsed (in most cases)

API Explorer will also display the elapsed time in seconds for API requests on the RunIt response tab now
