### PR TITLE
chore: request time display cleanup

### DIFF
--- a/packages/run-it/src/components/ResponseExplorer/ResponseExplorer.tsx
+++ b/packages/run-it/src/components/ResponseExplorer/ResponseExplorer.tsx
@@ -149,6 +149,7 @@ export const ResponseExplorer: FC<ResponseExplorerProps> = ({
       : undefined
 
   const timed = (response: IRawResponse) => {
+    if (!(response.responseCompleted || response.requestStarted)) return ''
     const diff = (response.responseCompleted - response.requestStarted) / 1000
     return `Seconds: ${diff.toFixed(3)}`
   }


### PR DESCRIPTION
Don't display time if timestamps are missing