### PR TITLE
feat: track request time if the transport doesn't

### DIFF
--- a/packages/run-it/src/utils/requestUtils.ts
+++ b/packages/run-it/src/utils/requestUtils.ts
@@ -196,6 +196,7 @@ export const runRequest = async (
     await sdk.ok(sdk.authSession.login())
   }
   const url = `${basePath}${pathify(endpoint, pathParams)}`
+  const requestStarted = Date.now()
   const raw = await sdk.authSession.transport.rawRequest(
     httpMethod,
     url,
@@ -203,6 +204,10 @@ export const runRequest = async (
     body,
     (props) => sdk.authSession.authenticate(props)
   )
+  const responseCompleted = Date.now()
+  // populate timing info if it's not already provided by the transport
+  if (!raw.requestStarted) raw.requestStarted = requestStarted
+  if (!raw.responseCompleted) raw.responseCompleted = responseCompleted
   return raw
 }
 


### PR DESCRIPTION
This way we still get a reasonable timing metric from the API request in the RunIt response explorer