### PR TITLE
feat: show Looker release version providing API specification

### DIFF
--- a/packages/api-explorer/src/scenes/HomeScene/HomeScene.tsx
+++ b/packages/api-explorer/src/scenes/HomeScene/HomeScene.tsx
@@ -27,6 +27,7 @@ import type { ApiModel } from '@looker/sdk-codegen'
 import type { FC } from 'react'
 import React from 'react'
 import { useParams } from 'react-router-dom'
+import { Space, Span, Tooltip } from '@looker/components'
 import { ApixSection, DocMarkdown, DocTitle } from '../../components'
 
 interface DocHomeProps {
@@ -39,10 +40,18 @@ interface DocHomeParams {
 
 export const HomeScene: FC<DocHomeProps> = ({ api }) => {
   const { specKey } = useParams<DocHomeParams>()
+  const lookerVersion = 'x-looker-release-version'
 
   return (
     <ApixSection>
-      <DocTitle>{api.spec.info.title}</DocTitle>
+      <Space>
+        <DocTitle>{api.spec.info.title}</DocTitle>
+        {api.spec.info[lookerVersion] && (
+          <Tooltip content="Looker version providing this specification">
+            <Span fontSize="small">{api.spec.info[lookerVersion]}</Span>
+          </Tooltip>
+        )}
+      </Space>
       {api.spec.info.description && (
         <DocMarkdown source={api.spec.info.description} specKey={specKey} />
       )}


### PR DESCRIPTION
Updates the API Explorer home page to show the Looker release version that produced the specification being viewed, if the `x-looker-release-version` tag is present in the `info` section of the spec
