### PR TITLE
chore: improve body hint for RunIt request form

### DIFF
--- a/packages/run-it/src/components/RequestForm/formUtils.spec.tsx
+++ b/packages/run-it/src/components/RequestForm/formUtils.spec.tsx
@@ -260,7 +260,7 @@ describe('Complex Item', () => {
     await waitFor(() => {
       expect(
         screen.getByText(
-          'Empty values are automatically removed from the request.'
+          'Empty values are automatically removed from the request, except for properties with `false` boolean values, which must be completely removed from the JSON body if they should not be passed.'
         )
       ).toBeInTheDocument()
     })

--- a/packages/run-it/src/components/RequestForm/formUtils.tsx
+++ b/packages/run-it/src/components/RequestForm/formUtils.tsx
@@ -240,7 +240,7 @@ export const createComplexItem = (
       label={
         <Space>
           {input.name}
-          <Tooltip content="Empty values are automatically removed from the request.">
+          <Tooltip content="Empty values are automatically removed from the request, except for properties with `false` boolean values, which must be completely removed from the JSON body if they should not be passed.">
             <Icon
               data-testid="body-param-tooltip"
               icon={<Info />}


### PR DESCRIPTION
explains that `false` boolean properties must be removed from JSON body requests for API Explorer if they shouldn't be passed to the API call
