### PR TITLE
chore: update release please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,7 +8,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@b1f383133aa4cc90eca1d35ae7ac7d96c1e83d72
+      - uses: google-github-actions/release-please-action@v3
         with:
           command: manifest
           monorepo-tags: true


### PR DESCRIPTION
Our old release please version is now blocked because it was node 12. This updates it to the new version.
