### PR TITLE
chore: Update sdk Readme and kickoff Release 23.0.0

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -66,7 +66,7 @@ The `looker.ini` configuration file and environment variables are _never_ used i
 
 ### Developing with multiple API versions
 
-Starting with Looker release 7.2, the experimental version of API 4.0 is available. To support iterative migration to API 4.0 from API 3.1, the single Looker SDK package now supports multiple API versions for the generated SDK classes. Both API 3.1 and API 4.0 are supported for Node and browser-based use.
+Version API 4.0 is available and API 3.1 is deprecated. To support iterative migration to API 4.0 from API 3.1, the single Looker SDK package now supports multiple API versions for the generated SDK classes. Both API 3.1 and API 4.0 are supported for Node and browser-based use.
 
 `LookerBrowserSDK.init31()` and `Looker31SDK()` initialize the API 3.1 implementation of the SDK.
 


### PR DESCRIPTION
This is a change to the sdk readme. Since we link the versions of all our calendar versioned packages, this change plus the below "Release-As" git commit body footer will tell release-please to set all calendar versions packages to 23.0.0.

Release-As: 23.0.0