### PR TITLE
chore: Release extension-playground

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -20,6 +20,7 @@
     "packages/api-explorer": {},
     "packages/code-editor": {},
     "packages/extension-api-explorer": {},
+    "packages/extension-playground": {},
     "packages/extension-sdk": {
       "component": "extension-sdk",
       "versioning": "always-bump-patch"


### PR DESCRIPTION
extension-playground's package.json is set to:
```
    "@looker/extension-sdk": "^22.4.2",
    "@looker/extension-sdk-react": "^22.4.2",
    "@looker/sdk": "^22.4.2",
```
We need release-please to update it's package.json or else what happens is right now, on calling `yarn`, we download the pinned versions and they are added to our lock file since the latest calendar version is 23.0.0 which doesn't work with the caret `^` that pins to the 22 major version. This probably pulls in the old build issue. I'm hoping this fixes that. 

This change will also release extension-playground as 1.0.0.