### PR TITLE
chore: Added workflows to label new/reopened issues

### DIFF
--- a/.github/workflows/p3-issue-label.yml
+++ b/.github/workflows/p3-issue-label.yml
@@ -1,0 +1,21 @@
+name: Label all new/reopened issues with P3
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+jobs:
+  label_issues_p3:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["p3"]
+            })

--- a/.github/workflows/triage-issue-label.yml
+++ b/.github/workflows/triage-issue-label.yml
@@ -1,0 +1,20 @@
+name: Label issues that need triage
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  label_issues_p3:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["need triage"]
+            })


### PR DESCRIPTION
New issues get "p3" and "need triage". Reopened issues get "p3". Went with simpler approach of 2 workflows instead of figuring out how to do branching logic in a workflow.
