### PR TITLE
Fix: Oauth message on failed verify

### DIFF
--- a/packages/extension-utils/src/OAuthConfigForm/OAuthConfigForm.tsx
+++ b/packages/extension-utils/src/OAuthConfigForm/OAuthConfigForm.tsx
@@ -317,35 +317,33 @@ export const OAuthConfigForm = ({
               />
             </Fieldset>
           </Form>
-          {fields.fetchedUrl &&
-            fields.fetchIntent === CRITICAL &&
-            fields.fetchResult !== '' && (
-              <>
-                <Paragraph fontSize="small">
-                  On {fields.fetchedUrl}, enable {clientLabel} as a{' '}
-                  <Link
-                    href="https://github.com/looker-open-source/sdk-codegen/blob/main/docs/cors.md#reference-implementation"
-                    target="_blank"
-                  >
-                    Looker OAuth client
-                  </Link>{' '}
-                  by adding "{(window as any).location.origin}" to the{' '}
-                  <Link href={`${fields.webUrl}/admin/embed`} target="_blank">
-                    Embedded Domain Allowlist
-                  </Link>
-                  . If API Explorer is also installed, the configuration below
-                  can be used to{' '}
-                  <Link
-                    href={`${fields.fetchedUrl}/extensions/marketplace_extension_api_explorer::api-explorer/4.0/methods/Auth/register_oauth_client_app`}
-                    target="_blank"
-                  >
-                    register this API Explorer instance
-                  </Link>{' '}
-                  as an OAuth client.
-                </Paragraph>
-                <CodeCopy key="appConfig" language="json" code={appConfig} />
-              </>
-            )}
+          {fields.fetchedUrl && (
+            <>
+              <Paragraph fontSize="small">
+                On {fields.fetchedUrl}, enable {clientLabel} as a{' '}
+                <Link
+                  href="https://github.com/looker-open-source/sdk-codegen/blob/main/docs/cors.md#reference-implementation"
+                  target="_blank"
+                >
+                  Looker OAuth client
+                </Link>{' '}
+                by adding "{(window as any).location.origin}" to the{' '}
+                <Link href={`${fields.webUrl}/admin/embed`} target="_blank">
+                  Embedded Domain Allowlist
+                </Link>
+                . If API Explorer is also installed, the configuration below can
+                be used to{' '}
+                <Link
+                  href={`${fields.fetchedUrl}/extensions/marketplace_extension_api_explorer::api-explorer/4.0/methods/Auth/register_oauth_client_app`}
+                  target="_blank"
+                >
+                  register this API Explorer instance
+                </Link>{' '}
+                as an OAuth client.
+              </Paragraph>
+              <CodeCopy key="appConfig" language="json" code={appConfig} />
+            </>
+          )}
           <Space>
             <Tooltip content="Clear the configuration values">
               <ButtonTransparent

--- a/packages/extension-utils/src/OAuthConfigForm/OAuthConfigForm.tsx
+++ b/packages/extension-utils/src/OAuthConfigForm/OAuthConfigForm.tsx
@@ -57,6 +57,7 @@ const POSITIVE: MessageBarIntent = 'positive'
 
 interface IFieldValues {
   baseUrl: string
+  fetchedUrl: string
   webUrl: string
   fetchIntent: MessageBarIntent
   fetchResult: string
@@ -64,6 +65,7 @@ interface IFieldValues {
 
 const defaultFieldValues: IFieldValues = {
   baseUrl: '',
+  fetchedUrl: '',
   webUrl: '',
   fetchResult: '',
   fetchIntent: POSITIVE,
@@ -189,6 +191,9 @@ export const OAuthConfigForm = ({
     updateMessage('inform', '')
     const versionsUrl = `${fields.baseUrl}/versions`
     try {
+      updateFields({
+        fetchedUrl: fields.baseUrl,
+      })
       const { web_server_url: webUrl, api_server_url: baseUrl } =
         (await getVersions(versionsUrl)) as ILookerVersions
       updateMessage(POSITIVE, 'Configuration is valid')
@@ -312,33 +317,35 @@ export const OAuthConfigForm = ({
               />
             </Fieldset>
           </Form>
-          {!!fields.webUrl && (
-            <>
-              <Paragraph fontSize="small">
-                On {fields.webUrl}, enable {clientLabel} as a{' '}
-                <Link
-                  href="https://github.com/looker-open-source/sdk-codegen/blob/main/docs/cors.md#reference-implementation"
-                  target="_blank"
-                >
-                  Looker OAuth client
-                </Link>{' '}
-                by adding "{(window as any).location.origin}" to the{' '}
-                <Link href={`${fields.webUrl}/admin/embed`} target="_blank">
-                  Embedded Domain Allowlist
-                </Link>
-                . If API Explorer is also installed, the configuration below can
-                be used to{' '}
-                <Link
-                  href={`${fields.webUrl}/extensions/marketplace_extension_api_explorer::api-explorer/4.0/methods/Auth/register_oauth_client_app`}
-                  target="_blank"
-                >
-                  register this API Explorer instance
-                </Link>{' '}
-                as an OAuth client.
-              </Paragraph>
-              <CodeCopy key="appConfig" language="json" code={appConfig} />
-            </>
-          )}
+          {fields.fetchedUrl &&
+            fields.fetchIntent === CRITICAL &&
+            fields.fetchResult !== '' && (
+              <>
+                <Paragraph fontSize="small">
+                  On {fields.fetchedUrl}, enable {clientLabel} as a{' '}
+                  <Link
+                    href="https://github.com/looker-open-source/sdk-codegen/blob/main/docs/cors.md#reference-implementation"
+                    target="_blank"
+                  >
+                    Looker OAuth client
+                  </Link>{' '}
+                  by adding "{(window as any).location.origin}" to the{' '}
+                  <Link href={`${fields.webUrl}/admin/embed`} target="_blank">
+                    Embedded Domain Allowlist
+                  </Link>
+                  . If API Explorer is also installed, the configuration below
+                  can be used to{' '}
+                  <Link
+                    href={`${fields.fetchedUrl}/extensions/marketplace_extension_api_explorer::api-explorer/4.0/methods/Auth/register_oauth_client_app`}
+                    target="_blank"
+                  >
+                    register this API Explorer instance
+                  </Link>{' '}
+                  as an OAuth client.
+                </Paragraph>
+                <CodeCopy key="appConfig" language="json" code={appConfig} />
+              </>
+            )}
           <Space>
             <Tooltip content="Clear the configuration values">
               <ButtonTransparent


### PR DESCRIPTION
This PR fixes the OauthConfigForm's help message. This work was highlighted in https://github.com/looker-open-source/sdk-codegen/pull/1280
