### PR TITLE
fix: Set Go SDK's User-Agent header

### DIFF
--- a/go/rtl/auth.go
+++ b/go/rtl/auth.go
@@ -134,6 +134,10 @@ func (s *AuthSession) Do(result interface{}, method, ver, path string, reqPars m
 	// set query params
 	setQuery(req.URL, reqPars)
 
+	if options != nil && options.AgentTag != "" {
+		req.Header.Set("User-Agent", options.AgentTag)
+	}
+
 	// do the actual http call
 	res, err := s.Client.Do(req)
 	if err != nil {

--- a/go/rtl/auth.go
+++ b/go/rtl/auth.go
@@ -130,14 +130,16 @@ func (s *AuthSession) Do(result interface{}, method, ver, path string, reqPars m
 
 	// set headers
 	req.Header.Add("Content-Type", contentTypeHeader)
-	
+
+	if s.Config.AgentTag != "" {
+		req.Header.Set("User-Agent", s.Config.AgentTag)
+	}
 	if options != nil && options.AgentTag != "" {
 		req.Header.Set("User-Agent", options.AgentTag)
 	}
 
 	// set query params
 	setQuery(req.URL, reqPars)
-
 
 	// do the actual http call
 	res, err := s.Client.Do(req)

--- a/go/rtl/auth.go
+++ b/go/rtl/auth.go
@@ -128,15 +128,16 @@ func (s *AuthSession) Do(result interface{}, method, ver, path string, reqPars m
 		return err
 	}
 
-	// set content-type header
+	// set headers
 	req.Header.Add("Content-Type", contentTypeHeader)
+	
+	if options != nil && options.AgentTag != "" {
+		req.Header.Set("User-Agent", options.AgentTag)
+	}
 
 	// set query params
 	setQuery(req.URL, reqPars)
 
-	if options != nil && options.AgentTag != "" {
-		req.Header.Set("User-Agent", options.AgentTag)
-	}
 
 	// do the actual http call
 	res, err := s.Client.Do(req)

--- a/go/rtl/auth_test.go
+++ b/go/rtl/auth_test.go
@@ -127,29 +127,58 @@ func TestAuthSession_Do_UserAgent(t *testing.T) {
 	const path = "/someMethod"
 	const apiVersion = "/4.0"
 
-	t.Run("Do() sets User-Agent header with AgentTag option", func(t *testing.T) {
+	t.Run("Do() sets User-Agent header with AuthSession config's AgentTag", func(t *testing.T) {
 		mux := http.NewServeMux()
 		setupApi40Login(mux, foreverValidTestToken, http.StatusOK)
 		server := httptest.NewServer(mux)
 		defer server.Close()
 
-		options := ApiSettings{
-			BaseUrl:    server.URL,
-			ApiVersion: apiVersion,
-			AgentTag:   "some-agent-tag",
-		}
-
 		mux.HandleFunc("/api"+apiVersion+path, func(w http.ResponseWriter, r *http.Request) {
 			userAgentHeader := r.Header.Get("User-Agent")
-			expectedHeader := options.AgentTag
+			expectedHeader := "some-agent-tag"
 			if userAgentHeader != expectedHeader {
 				t.Errorf("User-Agent header not correct. got=%v want=%v", userAgentHeader, expectedHeader)
 			}
 		})
 
-		s := NewAuthSession(options)
+		s := NewAuthSession(ApiSettings{
+			BaseUrl:    server.URL,
+			ApiVersion: apiVersion,
+			AgentTag:   "some-agent-tag",
+		})
 
 		var r string
+		err := s.Do(&r, "GET", apiVersion, path, nil, nil, nil)
+
+		if err != nil {
+			t.Errorf("Do() call failed: %v", err)
+		}
+	})
+
+	t.Run("Do() sets User-Agent header with Do's option's AgentTag, which will overwrite  AuthSession config", func(t *testing.T) {
+		mux := http.NewServeMux()
+		setupApi40Login(mux, foreverValidTestToken, http.StatusOK)
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		mux.HandleFunc("/api"+apiVersion+path, func(w http.ResponseWriter, r *http.Request) {
+			userAgentHeader := r.Header.Get("User-Agent")
+			expectedHeader := "new-agent-tag"
+			if userAgentHeader != expectedHeader {
+				t.Errorf("User-Agent header not correct. got=%v want=%v", userAgentHeader, expectedHeader)
+			}
+		})
+
+		s := NewAuthSession(ApiSettings{
+			BaseUrl:    server.URL,
+			ApiVersion: apiVersion,
+			AgentTag:   "some-agent-tag",
+		})
+
+		var r string
+		options := ApiSettings{
+			AgentTag:   "new-agent-tag",
+		}
 		err := s.Do(&r, "GET", apiVersion, path, nil, nil, &options)
 
 		if err != nil {


### PR DESCRIPTION
Implement `AgentTag` defined in settings and set Go SDK's outgoing `Do` requests with the User-Agent header. 

Fixes issue: https://github.com/looker-open-source/sdk-codegen/issues/1274