### PR TITLE
fix: Implement Go SDK timeout

### DIFF
--- a/go/rtl/auth.go
+++ b/go/rtl/auth.go
@@ -124,15 +124,15 @@ func (s *AuthSession) Do(result interface{}, method, ver, path string, reqPars m
 	}
 
 	// create request context with timeout
-	var timeout int32 = 120 //seconds
+	var timeoutInSeconds int32 = 120 //seconds
 	if s.Config.Timeout != 0 {
-		timeout = s.Config.Timeout
+		timeoutInSeconds = s.Config.Timeout
 	}
 	if options != nil && options.Timeout != 0 {
-		timeout = options.Timeout
+		timeoutInSeconds = options.Timeout
 	}
 
-	ctx, cncl := context.WithTimeout(context.Background(), time.Second * time.Duration(timeout))
+	ctx, cncl := context.WithTimeout(context.Background(), time.Second * time.Duration(timeoutInSeconds))
 	defer cncl()
 
 	// create new request

--- a/go/rtl/auth.go
+++ b/go/rtl/auth.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"reflect"
+	"time"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
@@ -122,8 +123,20 @@ func (s *AuthSession) Do(result interface{}, method, ver, path string, reqPars m
 		}
 	}
 
+	// create request context with timeout
+	var timeout int32 = 120 //seconds
+	if s.Config.Timeout != 0 {
+		timeout = s.Config.Timeout
+	}
+	if options != nil && options.Timeout != 0 {
+		timeout = options.Timeout
+	}
+
+	ctx, cncl := context.WithTimeout(context.Background(), time.Second * time.Duration(timeout))
+	defer cncl()
+
 	// create new request
-	req, err := http.NewRequest(method, u, bytes.NewBufferString(bodyString))
+	req, err := http.NewRequestWithContext(ctx, method, u, bytes.NewBufferString(bodyString))
 	if err != nil {
 		return err
 	}

--- a/go/rtl/auth_test.go
+++ b/go/rtl/auth_test.go
@@ -52,13 +52,13 @@ func TestAuthSession_Do_Authorization(t *testing.T) {
 			}
 		})
 
-		s := NewAuthSession(ApiSettings{
+		session := NewAuthSession(ApiSettings{
 			BaseUrl:    server.URL,
 			ApiVersion: apiVersion,
 		})
 
 		var r string
-		err := s.Do(&r, "GET", apiVersion, path, nil, nil, nil)
+		err := session.Do(&r, "GET", apiVersion, path, nil, nil, nil)
 
 		if err != nil {
 			t.Errorf("Do() call failed: %v", err)
@@ -93,13 +93,13 @@ func TestAuthSession_Do_Authorization(t *testing.T) {
 			fmt.Fprint(w, string(s))
 		})
 
-		s := NewAuthSession(ApiSettings{
+		session := NewAuthSession(ApiSettings{
 			BaseUrl:    server.URL,
 			ApiVersion: apiVersion,
 		})
 
 		var r string
-		err := s.Do(&r, "GET", apiVersion, path, nil, nil, nil)
+		err := session.Do(&r, "GET", apiVersion, path, nil, nil, nil)
 
 		if err != nil {
 			t.Errorf("First Do() call failed: %v", err)
@@ -108,7 +108,7 @@ func TestAuthSession_Do_Authorization(t *testing.T) {
 		// wait till previous token is definitely expired
 		time.Sleep(2 * time.Second)
 
-		err = s.Do(&r, "GET", apiVersion, path, nil, nil, nil)
+		err = session.Do(&r, "GET", apiVersion, path, nil, nil, nil)
 
 		if err != nil {
 			t.Errorf("Second Do() call failed: %v", err)
@@ -143,14 +143,14 @@ func TestAuthSession_Do_UserAgent(t *testing.T) {
 			}
 		})
 
-		s := NewAuthSession(ApiSettings{
+		session := NewAuthSession(ApiSettings{
 			BaseUrl:    server.URL,
 			ApiVersion: apiVersion,
 			AgentTag:   "some-agent-tag",
 		})
 
 		var r string
-		err := s.Do(&r, "GET", apiVersion, path, nil, nil, nil)
+		err := session.Do(&r, "GET", apiVersion, path, nil, nil, nil)
 
 		if err != nil {
 			t.Errorf("Do() call failed: %v", err)
@@ -171,7 +171,7 @@ func TestAuthSession_Do_UserAgent(t *testing.T) {
 			}
 		})
 
-		s := NewAuthSession(ApiSettings{
+		session := NewAuthSession(ApiSettings{
 			BaseUrl:    server.URL,
 			ApiVersion: apiVersion,
 			AgentTag:   "some-agent-tag",
@@ -181,7 +181,7 @@ func TestAuthSession_Do_UserAgent(t *testing.T) {
 		options := ApiSettings{
 			AgentTag:   "new-agent-tag",
 		}
-		err := s.Do(&r, "GET", apiVersion, path, nil, nil, &options)
+		err := session.Do(&r, "GET", apiVersion, path, nil, nil, &options)
 
 		if err != nil {
 			t.Errorf("Do() call failed: %v", err)
@@ -219,13 +219,13 @@ func TestAuthSession_Do_Parse(t *testing.T) {
 			fmt.Fprint(w, string(s))
 		})
 
-		s := NewAuthSession(ApiSettings{
+		session := NewAuthSession(ApiSettings{
 			BaseUrl:    server.URL,
 			ApiVersion: apiVersion,
 		})
 
 		var result stringStruct
-		s.Do(&result, "GET", apiVersion, path, nil, nil, nil)
+		session.Do(&result, "GET", apiVersion, path, nil, nil, nil)
 
 		if *result.Field != stringField {
 			t.Error("num type field was not unmarshaled correctly into string type field")
@@ -247,13 +247,13 @@ func TestAuthSession_Do_Parse(t *testing.T) {
 			fmt.Fprint(w, string(s))
 		})
 
-		s := NewAuthSession(ApiSettings{
+		session := NewAuthSession(ApiSettings{
 			BaseUrl:    server.URL,
 			ApiVersion: apiVersion,
 		})
 
 		var result numStruct
-		s.Do(&result, "GET", apiVersion, path, nil, nil, nil)
+		session.Do(&result, "GET", apiVersion, path, nil, nil, nil)
 
 		if *result.Field != numField {
 			t.Error("string type field was not unmarshaled correctly into num type field")
@@ -299,7 +299,7 @@ func TestAuthSession_Do_Parse(t *testing.T) {
 			fmt.Fprint(w, string(s))
 		})
 
-		s := NewAuthSession(ApiSettings{
+		session := NewAuthSession(ApiSettings{
 			BaseUrl:    server.URL,
 			ApiVersion: apiVersion,
 		})
@@ -331,7 +331,7 @@ func TestAuthSession_Do_Parse(t *testing.T) {
 
 		var result expectedStructType
 
-		s.Do(&result, "GET", apiVersion, path, nil, nil, nil)
+		session.Do(&result, "GET", apiVersion, path, nil, nil, nil)
 
 		if !reflect.DeepEqual(result, expectedStruct) {
 			t.Error("fields of mixed types were not unmarshaled correctly into the right types")
@@ -349,14 +349,14 @@ func TestAuthSession_Do_Parse(t *testing.T) {
 			fmt.Fprint(w, "a response")
 		})
 
-		s := NewAuthSession(ApiSettings{
+		session := NewAuthSession(ApiSettings{
 			BaseUrl:    server.URL,
 			ApiVersion: apiVersion,
 		})
 
 		var result string
 
-		err := s.Do(&result, "GET", apiVersion, path, nil, nil, nil)
+		err := session.Do(&result, "GET", apiVersion, path, nil, nil, nil)
 
 		if err != nil {
 			t.Errorf("Do() failed. error=%v", err)
@@ -384,7 +384,7 @@ func TestAuthSession_Do_Parse(t *testing.T) {
 			fmt.Fprint(w, string(s))
 		})
 
-		s := NewAuthSession(ApiSettings{
+		session := NewAuthSession(ApiSettings{
 			BaseUrl:    server.URL,
 			ApiVersion: apiVersion,
 		})
@@ -392,7 +392,7 @@ func TestAuthSession_Do_Parse(t *testing.T) {
 		var result interface{}
 		var expectedField float64 = 10
 
-		err := s.Do(&result, "GET", apiVersion, path, nil, nil, nil)
+		err := session.Do(&result, "GET", apiVersion, path, nil, nil, nil)
 
 		if err != nil {
 			t.Errorf("Do() failed. error=%v", err)
@@ -422,7 +422,7 @@ func TestAuthSession_Do_Parse(t *testing.T) {
 			fmt.Fprint(w, string(s))
 		})
 
-		s := NewAuthSession(ApiSettings{
+		session := NewAuthSession(ApiSettings{
 			BaseUrl:    server.URL,
 			ApiVersion: apiVersion,
 		})
@@ -442,7 +442,7 @@ func TestAuthSession_Do_Parse(t *testing.T) {
 
 		var result expectedStructType
 
-		err := s.Do(&result, "GET", apiVersion, path, nil, nil, nil)
+		err := session.Do(&result, "GET", apiVersion, path, nil, nil, nil)
 
 		if err != nil {
 			t.Errorf("Do() failed. error=%v", err)
@@ -472,7 +472,7 @@ func TestAuthSession_Do_Content_Type(t *testing.T) {
 			}
 		})
 
-		s := NewAuthSession(ApiSettings{
+		session := NewAuthSession(ApiSettings{
 			BaseUrl:    server.URL,
 			ApiVersion: apiVersion,
 		})
@@ -484,7 +484,7 @@ func TestAuthSession_Do_Content_Type(t *testing.T) {
 			key:    "value",
 		}
 
-		err := s.Do(&r, "GET", apiVersion, path, nil, body, nil)
+		err := session.Do(&r, "GET", apiVersion, path, nil, body, nil)
 
 		if err != nil {
 			t.Errorf("Do() call failed: %v", err)
@@ -505,13 +505,13 @@ func TestAuthSession_Do_Content_Type(t *testing.T) {
 			}
 		})
 
-		s := NewAuthSession(ApiSettings{
+		session := NewAuthSession(ApiSettings{
 			BaseUrl:    server.URL,
 			ApiVersion: apiVersion,
 		})
 
 		var r string
-		err := s.Do(&r, "GET", apiVersion, path, nil, "body", nil)
+		err := session.Do(&r, "GET", apiVersion, path, nil, "body", nil)
 
 		if err != nil {
 			t.Errorf("Do() call failed: %v", err)
@@ -533,19 +533,18 @@ func TestAuthSession_Do_Timeout(t *testing.T) {
 			time.Sleep(4 * time.Second)
 		})
 
-		s := NewAuthSession(ApiSettings{
+		session := NewAuthSession(ApiSettings{
 			BaseUrl:    server.URL,
 			ApiVersion: apiVersion,
-			Timeout: 1,
+			Timeout: 1, // seconds
 		})
 
-		var r string
-		err := s.Do(&r, "GET", apiVersion, path, nil, nil, nil)
+		err := session.Do(nil, "GET", apiVersion, path, nil, nil, nil)
 
 		if err == nil {
 			t.Errorf("Do() call did not error/timeout")
 		} else if !errors.Is(err, context.DeadlineExceeded) {
-            t.Errorf("Do() call did not error with context.DeadlineExceeded")
+            t.Errorf("Do() call did not error with context.DeadlineExceeded, got=%v", err)
         }
 	})
 
@@ -559,21 +558,21 @@ func TestAuthSession_Do_Timeout(t *testing.T) {
 			time.Sleep(4 * time.Second)
 		})
 
-		s := NewAuthSession(ApiSettings{
+		session := NewAuthSession(ApiSettings{
 			BaseUrl:    server.URL,
 			ApiVersion: apiVersion,
 		})
 
 		options := ApiSettings{
-			Timeout: 1,
+			Timeout: 1, //seconds
 		}
-		var r string
-		err := s.Do(&r, "GET", apiVersion, path, nil, nil, &options)
+
+		err := session.Do(nil, "GET", apiVersion, path, nil, nil, &options)
 
 		if err == nil {
 			t.Errorf("Do() call did not error/timeout")
 		} else if !errors.Is(err, context.DeadlineExceeded) {
-            t.Errorf("Do() call did not error with context.DeadlineExceeded")
+            t.Errorf("Do() call did not error with context.DeadlineExceeded, got=%v", err)
         }
 	})
 }


### PR DESCRIPTION
Implement the Timeout field in our config/settings. Make use of request context to control timeout.  Timeout defaults to 120 seconds. Hopefully the unit tests are not flaky with the new timeout tests.

Fixes https://github.com/looker-open-source/sdk-codegen/issues/692