### PR TITLE
chore: establish a pattern for localizing frameless components

### DIFF
--- a/packages/embed-components/package.json
+++ b/packages/embed-components/package.json
@@ -34,17 +34,18 @@
   },
   "homepage": "https://github.com/looker-open-source/sdk-codegen/tree/master/packages/embed-components",
   "devDependencies": {
-    "redux-saga-tester": "^1.0.874",
+    "@looker/components-test-utils": "^1.5.27",
     "@looker/sdk-node": "*",
     "@testing-library/react": "^11.2.7",
-    "@looker/components-test-utils": "^1.5.27",
-    "react-redux": "^7.2.9",
+    "@testing-library/user-event": "^14.4.3",
     "@types/react-redux": "^7.1.25",
-    "@testing-library/user-event": "^14.4.3"
+    "react-redux": "^7.2.9",
+    "redux-saga-tester": "^1.0.874"
   },
   "dependencies": {
     "@looker/components": "^4.1.3",
     "@looker/embed-services": "*",
+    "@looker/i18n": "^1.0.0",
     "@looker/redux": "^0.0.1",
     "@looker/sdk": "*",
     "@looker/sdk-rtl": "*",
@@ -52,6 +53,7 @@
     "@styled-icons/material-outlined": "^10.47.0",
     "react": "16.14.0",
     "react-dom": "16.14.0",
+    "react-i18next": "11.8.15",
     "styled-components": "^5.3.1",
     "typed-redux-saga": "^1.5.0"
   },

--- a/packages/embed-components/src/QuickEmbed/QuickEmbed.spec.tsx
+++ b/packages/embed-components/src/QuickEmbed/QuickEmbed.spec.tsx
@@ -95,7 +95,7 @@ describe('QuickEmbed', () => {
     expect(
       screen.getByRole('button', { name: 'Copy Link' })
     ).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument()
   })
 
   it('does not render theme selector for non-themable content', () => {

--- a/packages/embed-components/src/QuickEmbed/QuickEmbed.tsx
+++ b/packages/embed-components/src/QuickEmbed/QuickEmbed.tsx
@@ -40,6 +40,7 @@ import {
 } from '@looker/components'
 import { Link } from '@styled-icons/material-outlined'
 import { EmbedUrl } from '@looker/embed-services'
+import { useTranslation } from '../utils'
 import { useThemesStoreState, SelectTheme, useThemeActions } from '../Theme'
 
 interface QuickEmbedProps {
@@ -47,6 +48,7 @@ interface QuickEmbedProps {
 }
 
 export const QuickEmbed = ({ onClose }: QuickEmbedProps) => {
+  const { t } = useTranslation('QuickEmbed')
   const service = new EmbedUrl()
   const [toggleValue, setToggle] = useState(false)
   const [embedUrl, setEmbedUrl] = useState<string>(service.embedUrl(false))
@@ -77,14 +79,16 @@ export const QuickEmbed = ({ onClose }: QuickEmbedProps) => {
   return (
     <Section padding="large">
       <Heading as="h3" fontWeight="medium">
-        Get embed URL
+        {t('Get embed URL')}
       </Heading>
 
       <SpaceVertical pt="medium" pb="medium" gap="xsmall">
         {service.isThemable && (
           <>
             <Span fontWeight="normal" fontSize="xsmall">
-              Apply theme to {service.contentType.toLocaleLowerCase()} URL
+              {t(`Apply theme to contentType URL`, {
+                contentType: service.contentType.toLocaleLowerCase(),
+              })}
             </Span>
             <SelectTheme />
           </>
@@ -104,14 +108,14 @@ export const QuickEmbed = ({ onClose }: QuickEmbedProps) => {
 
       <Space gap="xxsmall" fontWeight="normal" fontSize="small">
         <ToggleSwitch onChange={handleToggle} on={toggleValue} />
-        Include current params in URL
+        {t('Include current params in URL')}
       </Space>
 
       <Space mt="large" between>
         <CopyToClipboard content={embedUrl}>
-          <ButtonOutline iconBefore={<Link />}>Copy Link</ButtonOutline>
+          <ButtonOutline iconBefore={<Link />}>{t('Copy Link')}</ButtonOutline>
         </CopyToClipboard>
-        <Button onClick={onClose}>Cancel</Button>
+        <Button onClick={onClose}>{t('Close')}</Button>
       </Space>
     </Section>
   )

--- a/packages/embed-components/src/locales/index.ts
+++ b/packages/embed-components/src/locales/index.ts
@@ -23,7 +23,5 @@
  SOFTWARE.
 
  */
-export * from './GlobalStore'
-export * from './Theme'
-export * from './QuickEmbed'
-export * from './locales'
+export * from './resources/en'
+export * from './resources/it-IT'

--- a/packages/embed-components/src/locales/resources/en.ts
+++ b/packages/embed-components/src/locales/resources/en.ts
@@ -23,7 +23,17 @@
  SOFTWARE.
 
  */
-export * from './GlobalStore'
-export * from './Theme'
-export * from './QuickEmbed'
-export * from './locales'
+import { en as componentsLocale } from '@looker/components'
+import { mergeLocaleObjects } from '@looker/i18n'
+
+const resources = {
+  QuickEmbed: {
+    'Get embed URL': 'Get embed URL',
+    'Apply theme to contentType URL': 'Apply theme to {{contentType}} URL',
+    'Include current params in URL': 'Include current params in URL',
+    'Copy Link': 'Copy Link',
+    Close: 'Close',
+  },
+}
+
+export const en = mergeLocaleObjects([componentsLocale], 'en', resources)

--- a/packages/embed-components/src/locales/resources/it-IT.ts
+++ b/packages/embed-components/src/locales/resources/it-IT.ts
@@ -28,9 +28,9 @@ import { itIT as componentsLocale } from '@looker/components'
 
 const resources = {
   QuickEmbed: {
-    'Get embed URL': 'Ottieni embed URL',
+    'Get embed URL': "Ottieni l'embed URL",
     'Apply theme to contentType URL': 'Applica il tema a {{contentType}} URL',
-    'Include current params in URL': "Includi i parametri correntin nell'URL",
+    'Include current params in URL': "Includi i parametri correnti nell'URL",
     'Copy Link': 'Copia Link',
     Close: 'Chiudi',
   },

--- a/packages/embed-components/src/locales/resources/it-IT.ts
+++ b/packages/embed-components/src/locales/resources/it-IT.ts
@@ -23,7 +23,17 @@
  SOFTWARE.
 
  */
-export * from './GlobalStore'
-export * from './Theme'
-export * from './QuickEmbed'
-export * from './locales'
+import { mergeLocaleObjects } from '@looker/i18n'
+import { itIT as componentsLocale } from '@looker/components'
+
+const resources = {
+  QuickEmbed: {
+    'Get embed URL': 'Ottieni embed URL',
+    'Apply theme to contentType URL': 'Applica il tema a {{contentType}} URL',
+    'Include current params in URL': "Includi i parametri correntin nell'URL",
+    'Copy Link': 'Copia Link',
+    Close: 'Chiudi',
+  },
+}
+
+export const itIT = mergeLocaleObjects([componentsLocale], 'it-IT', resources)

--- a/packages/embed-components/src/utils/index.ts
+++ b/packages/embed-components/src/utils/index.ts
@@ -23,7 +23,4 @@
  SOFTWARE.
 
  */
-export * from './GlobalStore'
-export * from './Theme'
-export * from './QuickEmbed'
-export * from './locales'
+export * from './useTranslation'

--- a/packages/embed-components/src/utils/useTranslation.ts
+++ b/packages/embed-components/src/utils/useTranslation.ts
@@ -23,7 +23,13 @@
  SOFTWARE.
 
  */
-export * from './GlobalStore'
-export * from './Theme'
-export * from './QuickEmbed'
-export * from './locales'
+import type { Namespace, UseTranslationOptions } from 'react-i18next'
+import { useTranslationBase } from '@looker/i18n'
+import { en } from '../locales'
+
+export const useTranslation = (
+  ns?: Namespace,
+  options?: UseTranslationOptions
+) => {
+  return useTranslationBase(en, ns, options)
+}


### PR DESCRIPTION
To test:
1. Go to `EmbedPlayground.tsx` 
2. Import `itIT` from `@looker/embed-components`
3. On L88 pass `itIT` to `ComponentsProvider` by destructuring it like so :
```
  return (<ComponentsProvider {...itIT}> ...)
```

Screenshot:
<img width="591" alt="image" src="https://github.com/looker-open-source/sdk-codegen/assets/19397662/493ca5ea-8301-49f5-a6e2-9d4f68b629f2">

This is a first pass. Next is getting this closer to Looker's implementation of localization. Credit to Meredith for all the references she provided for this!