### PR TITLE
Add onCopy prop for QuickEmbed

### DIFF
--- a/packages/embed-components/src/QuickEmbed/QuickEmbed.spec.tsx
+++ b/packages/embed-components/src/QuickEmbed/QuickEmbed.spec.tsx
@@ -24,7 +24,7 @@
 
  */
 import React from 'react'
-import { screen, waitFor } from '@testing-library/react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { useThemeActions, useThemesStoreState } from '../Theme/state'
@@ -50,6 +50,8 @@ describe('QuickEmbed', () => {
     ...overrides,
   })
   const onClose = jest.fn()
+  const onCopy = jest.fn()
+  document.execCommand = jest.fn()
 
   beforeEach(() => {
     jest.spyOn(window, 'location', 'get').mockReturnValue({
@@ -69,7 +71,7 @@ describe('QuickEmbed', () => {
   })
 
   it('renders', () => {
-    renderWithTheme(<QuickEmbed onClose={onClose} />)
+    renderWithTheme(<QuickEmbed onClose={onClose} onCopy={onCopy} />)
 
     expect(
       screen.getByRole('heading', { name: 'Get embed URL' })
@@ -103,7 +105,7 @@ describe('QuickEmbed', () => {
       href: 'https://example.com/looks/42',
       pathname: '/looks/42',
     } as Location)
-    renderWithTheme(<QuickEmbed onClose={onClose} />)
+    renderWithTheme(<QuickEmbed onClose={onClose} onCopy={onCopy} />)
 
     expect(
       screen.getByRole('heading', { name: 'Get embed URL' })
@@ -124,7 +126,7 @@ describe('QuickEmbed', () => {
     ;(useThemesStoreState as jest.Mock).mockReturnValue(
       getMockStoreState({ selectedTheme: customTheme1 })
     )
-    renderWithTheme(<QuickEmbed onClose={onClose} />)
+    renderWithTheme(<QuickEmbed onClose={onClose} onCopy={onCopy} />)
 
     expect(
       screen.getByRole('heading', { name: 'Get embed URL' })
@@ -152,5 +154,25 @@ describe('QuickEmbed', () => {
         'https://example.com/embed/dashboards/42?foo=bar&theme=custom_theme_1'
       )
     })
+  })
+
+  it('close button function triggers on click', () => {
+    renderWithTheme(<QuickEmbed onClose={onClose} onCopy={onCopy} />)
+    const closeBtn = screen.getByRole('button', { name: 'Close' })
+
+    expect(closeBtn).toBeInTheDocument()
+    fireEvent.click(closeBtn)
+
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('copy button function triggers on click', () => {
+    renderWithTheme(<QuickEmbed onClose={onClose} onCopy={onCopy} />)
+    const copyBtn = screen.getByRole('button', { name: 'Copy Link' })
+
+    expect(copyBtn).toBeInTheDocument()
+    fireEvent.click(copyBtn)
+
+    expect(onCopy).toHaveBeenCalled()
   })
 })

--- a/packages/embed-components/src/QuickEmbed/QuickEmbed.spec.tsx
+++ b/packages/embed-components/src/QuickEmbed/QuickEmbed.spec.tsx
@@ -166,6 +166,16 @@ describe('QuickEmbed', () => {
     expect(onClose).toHaveBeenCalled()
   })
 
+  it('onCopy not called when not passed in', () => {
+    renderWithTheme(<QuickEmbed onClose={onClose} />)
+    const copyBtn = screen.getByRole('button', { name: 'Copy Link' })
+
+    expect(copyBtn).toBeInTheDocument()
+    fireEvent.click(copyBtn)
+
+    expect(onCopy).not.toHaveBeenCalled()
+  })
+
   it('copy button function triggers on click', () => {
     renderWithTheme(<QuickEmbed onClose={onClose} onCopy={onCopy} />)
     const copyBtn = screen.getByRole('button', { name: 'Copy Link' })

--- a/packages/embed-components/src/QuickEmbed/QuickEmbed.spec.tsx
+++ b/packages/embed-components/src/QuickEmbed/QuickEmbed.spec.tsx
@@ -24,7 +24,7 @@
 
  */
 import React from 'react'
-import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { renderWithTheme } from '@looker/components-test-utils'
 import { useThemeActions, useThemesStoreState } from '../Theme/state'
@@ -156,32 +156,32 @@ describe('QuickEmbed', () => {
     })
   })
 
-  it('close button function triggers on click', () => {
+  it('close button function triggers on click', async () => {
     renderWithTheme(<QuickEmbed onClose={onClose} onCopy={onCopy} />)
     const closeBtn = screen.getByRole('button', { name: 'Close' })
 
     expect(closeBtn).toBeInTheDocument()
-    fireEvent.click(closeBtn)
+    await userEvent.click(closeBtn)
 
     expect(onClose).toHaveBeenCalled()
   })
 
-  it('onCopy not called when not passed in', () => {
+  it('onCopy not called when not passed in', async () => {
     renderWithTheme(<QuickEmbed onClose={onClose} />)
     const copyBtn = screen.getByRole('button', { name: 'Copy Link' })
 
     expect(copyBtn).toBeInTheDocument()
-    fireEvent.click(copyBtn)
+    await userEvent.click(copyBtn)
 
     expect(onCopy).not.toHaveBeenCalled()
   })
 
-  it('copy button function triggers on click', () => {
+  it('copy button function triggers on click', async () => {
     renderWithTheme(<QuickEmbed onClose={onClose} onCopy={onCopy} />)
     const copyBtn = screen.getByRole('button', { name: 'Copy Link' })
 
     expect(copyBtn).toBeInTheDocument()
-    fireEvent.click(copyBtn)
+    await userEvent.click(copyBtn)
 
     expect(onCopy).toHaveBeenCalled()
   })

--- a/packages/embed-components/src/QuickEmbed/QuickEmbed.tsx
+++ b/packages/embed-components/src/QuickEmbed/QuickEmbed.tsx
@@ -43,10 +43,12 @@ import { EmbedUrl } from '@looker/embed-services'
 import { useThemesStoreState, SelectTheme, useThemeActions } from '../Theme'
 
 interface QuickEmbedProps {
-  // A function triggered when close button is clicked.
+  /** A function triggered when close button is clicked. */
   onClose: () => void
-  /** An optional callback triggered when the copy button is clicked.
-   * The copy to clipboard action is already handled */
+  /**
+   * An optional callback triggered when the copy button is clicked.
+   * The copy to clipboard action is already handled
+   */
   onCopy?: () => void
 }
 

--- a/packages/embed-components/src/QuickEmbed/QuickEmbed.tsx
+++ b/packages/embed-components/src/QuickEmbed/QuickEmbed.tsx
@@ -43,9 +43,10 @@ import { EmbedUrl } from '@looker/embed-services'
 import { useThemesStoreState, SelectTheme, useThemeActions } from '../Theme'
 
 interface QuickEmbedProps {
-  // function called when close button clicked
+  // A function triggered when close button is clicked.
   onClose: () => void
-  // function called when copy button is clicked. (copy to clipboard already handled)
+  /** An optional callback triggered when the copy button is clicked.
+   * The copy to clipboard action is already handled */
   onCopy?: () => void
 }
 

--- a/packages/embed-components/src/QuickEmbed/QuickEmbed.tsx
+++ b/packages/embed-components/src/QuickEmbed/QuickEmbed.tsx
@@ -44,9 +44,10 @@ import { useThemesStoreState, SelectTheme, useThemeActions } from '../Theme'
 
 interface QuickEmbedProps {
   onClose: () => void
+  onCopy: () => void
 }
 
-export const QuickEmbed = ({ onClose }: QuickEmbedProps) => {
+export const QuickEmbed = ({ onClose, onCopy }: QuickEmbedProps) => {
   const service = new EmbedUrl()
   const [toggleValue, setToggle] = useState(false)
   const [embedUrl, setEmbedUrl] = useState<string>(service.embedUrl(false))
@@ -108,9 +109,11 @@ export const QuickEmbed = ({ onClose }: QuickEmbedProps) => {
       </Space>
 
       <Space mt="large" between>
-        <CopyToClipboard content={embedUrl}>
-          <ButtonOutline iconBefore={<Link />}>Copy Link</ButtonOutline>
-        </CopyToClipboard>
+        <Space onClick={onCopy} width="fit-content">
+          <CopyToClipboard content={embedUrl}>
+            <ButtonOutline iconBefore={<Link />}>Copy Link</ButtonOutline>
+          </CopyToClipboard>
+        </Space>
         <Button onClick={onClose}>Close</Button>
       </Space>
     </Section>

--- a/packages/embed-components/src/QuickEmbed/QuickEmbed.tsx
+++ b/packages/embed-components/src/QuickEmbed/QuickEmbed.tsx
@@ -43,8 +43,10 @@ import { EmbedUrl } from '@looker/embed-services'
 import { useThemesStoreState, SelectTheme, useThemeActions } from '../Theme'
 
 interface QuickEmbedProps {
+  // function called when close button clicked
   onClose: () => void
-  onCopy: () => void
+  // function called when copy button is clicked. (copy to clipboard already handled)
+  onCopy?: () => void
 }
 
 export const QuickEmbed = ({ onClose, onCopy }: QuickEmbedProps) => {
@@ -53,6 +55,12 @@ export const QuickEmbed = ({ onClose, onCopy }: QuickEmbedProps) => {
   const [embedUrl, setEmbedUrl] = useState<string>(service.embedUrl(false))
   const { selectedTheme } = useThemesStoreState()
   const { selectThemeAction } = useThemeActions()
+
+  const handleCopy = () => {
+    if (onCopy) {
+      onCopy()
+    }
+  }
 
   const handleToggle = () => {
     const newToggleValue = !toggleValue
@@ -109,7 +117,7 @@ export const QuickEmbed = ({ onClose, onCopy }: QuickEmbedProps) => {
       </Space>
 
       <Space mt="large" between>
-        <Space onClick={onCopy} width="fit-content">
+        <Space onClick={handleCopy} width="fit-content">
           <CopyToClipboard content={embedUrl}>
             <ButtonOutline iconBefore={<Link />}>Copy Link</ButtonOutline>
           </CopyToClipboard>


### PR DESCRIPTION
Adding onCopy function to QuickEmbed component and added tests for both close and copy. 

document.execCommand = jest.fn(), was added to the test file because the copying to clipboard function must be mocked.