### PR TITLE
fix: use new CDN for errorcodes repository

### DIFF
--- a/kotlin/src/main/com/looker/rtl/Constants.kt
+++ b/kotlin/src/main/com/looker/rtl/Constants.kt
@@ -61,12 +61,12 @@ class DelimArray<T> : Array<T>() {
  */
 
 fun isTrue(value: String?): Boolean {
-    val low = unQuote(value?.toLowerCase())
+    val low = unQuote(value?.lowercase())
     return low == "true" || low == "1" || low == "t" || low == "y" || low == "yes"
 }
 
 fun isFalse(value: String?): Boolean {
-    val low = unQuote(value?.toLowerCase())
+    val low = unQuote(value?.lowercase())
     return low == "false" || low == "0" || low == "f" || low == "n" || low == "no"
 }
 

--- a/kotlin/src/main/com/looker/rtl/ErrorDoc.kt
+++ b/kotlin/src/main/com/looker/rtl/ErrorDoc.kt
@@ -109,7 +109,7 @@ typealias ErrorCodeIndex = HashMap<String, ErrorDocItem>
 class ErrorDoc(val sdk: APIMethods, val cdnUrl: String = ErrorCodesUrl): IErrorDoc {
     companion object {
         /** Location of the public CDN for Looker API Error codes */
-        const val ErrorCodesUrl = "https://marketplace-api.looker.com/errorcodes/"
+        const val ErrorCodesUrl = "https://static-a.cdn.looker.app/errorcodes/"
 
         /** Default "not found" content for error documents that don't (yet) exist */
         const val ErrorDocNotFound = "### No documentation found for "

--- a/packages/extension-api-explorer/README.md
+++ b/packages/extension-api-explorer/README.md
@@ -24,7 +24,7 @@ The API Explorer extension can be manually installed and run with a Looker insta
          use_embeds: yes
          use_clipboard: yes
          core_api_methods: ["versions", "api_spec"]
-         external_api_urls : ["https://raw.githubusercontent.com","http://localhost:30000","https://localhost:8080","https://marketplace-api.looker.com","https://docs.looker.com","https://developer.mozilla.org/"]
+         external_api_urls : ["https://raw.githubusercontent.com","http://localhost:30000","https://localhost:8080","https://static-a.cdn.looker.app","https://docs.looker.com","https://developer.mozilla.org/"]
          oauth2_urls: []
       }
    }

--- a/packages/sdk-rtl/src/errorDoc.spec.ts
+++ b/packages/sdk-rtl/src/errorDoc.spec.ts
@@ -222,10 +222,7 @@ describe('ErrorDoc', () => {
       ['login_2_404.md', 'login_2'],
       ['and_another_404.md', 'and_another'],
       ['errorcodes/live/login_404.md', 'login'],
-      [
-        'https://marketplace-api.looker.com/errorcodes/live/login_404.md',
-        'login',
-      ],
+      ['https://static-a.cdn.looker.app/errorcodes/live/login_404.md', 'login'],
     ])('url:"%s" should be "%s"', (url, expected) => {
       expect(errDoc.methodName(url)).toEqual(expected)
     })

--- a/packages/sdk-rtl/src/errorDoc.ts
+++ b/packages/sdk-rtl/src/errorDoc.ts
@@ -33,7 +33,7 @@ export interface IErrorDocItem {
 }
 
 /** Location of the public CDN for Looker API Error codes */
-export const ErrorCodesUrl = 'https://marketplace-api.looker.com/errorcodes/'
+export const ErrorCodesUrl = 'https://static-a.cdn.looker.app/errorcodes/'
 
 /** Structure of the error code document index */
 export type ErrorCodeIndex = Record<string, IErrorDocItem>


### PR DESCRIPTION
using https://static-a.cdn.looker.app instead of the old CDN