### PR TITLE
fix(return type):Update render-task-result in methods.ts

### DIFF
--- a/packages/sdk/src/4.0/methods.ts
+++ b/packages/sdk/src/4.0/methods.ts
@@ -9598,7 +9598,7 @@ export class Looker40SDK extends APIMethods implements ILooker40SDK {
     options?: Partial<ITransportSettings>
   ): Promise<SDKResponse<string, IError>> {
     render_task_id = encodeParam(render_task_id)
-    return this.get<string, IError>(
+    return this.get<Blob, IError>(
       `/render_tasks/${render_task_id}/results`,
       null,
       null,


### PR DESCRIPTION
Fix for #1369 - Update render-task-result in methods.ts to return Blob result

## 👋👋 Thank you for contributing to Looker sdk-codegen (⚡️🍣)

- 👉 While using render_task_result call to render the pdf result for dashboard. it returns string blob which is not accepted as parameter to URL.createObjectUrl(). URL.createObjectUrl() function accepts the value in Blob format

## Developer Checklist [ℹ️](https://github.com/looker-open-source/sdk-codegen/blob/main/CONTRIBUTING.md#developer-checklist)

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/looker-open-source/sdk-codegen/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Appropriate docs were updated (if necessary)

Fixes #1375  🦕
