### PR TITLE
fix(Transport): Disable automatic User Agent Suffix

### DIFF
--- a/kotlin/src/main/com/looker/rtl/Transport.kt
+++ b/kotlin/src/main/com/looker/rtl/Transport.kt
@@ -351,7 +351,7 @@ class Transport(val options: TransportOptions) {
             finalizedRequestSettings.method.toString(),
             GenericUrl(finalizedRequestSettings.url),
             httpContent,
-        )
+        ).setSuppressUserAgentSuffix(true)
 
 // TODO get overrides parameter to work without causing compilation errors in UserSession
 //            overrides: TransportOptions? = null): SDKResponse {


### PR DESCRIPTION
This small fix to the Kotlin Transport code, disables automatic User Agent suffixing by the Google-HTTP-Java library.

Looker is very specific about User Agent names, especially when using cookieless embedding sessions and this change will fix the contract violation between this code and the API.


Related to this [discussion](https://github.com/looker-open-source/sdk-codegen/commit/5407e6316491fc2ed6fcc017b317d931c283179c#commitcomment-136501445).

