### PR TITLE
chore: Update node version to 18 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/looker-open-source/sdk-codegen/issues"
   },
   "engines": {
-    "node": ">=14",
+    "node": ">=18",
     "yarn": ">=1.22.0"
   },
   "scripts": {


### PR DESCRIPTION
Since we're now on node 18 in our CI and dependencies.