### PR TITLE
chore: Add extension-tile-playground package to release-please manifest

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -18,6 +18,7 @@
   "packages/wholly-sheet": "0.5.51",
   "python": "23.20.1",
   "packages/extension-playground": "1.0.12",
+  "packages/extension-tile-playground": "1.0.0", 
   "packages/embed-services": "23.20.1",
   "packages/embed-components": "23.20.1"
 }

--- a/packages/extension-tile-playground/package.json
+++ b/packages/extension-tile-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@looker/extension-tile-playground",
-  "version": "22.10.1",
+  "version": "1.0.0",
   "description": "Extension Tile Playground",
   "main": "lib/index.js",
   "module": "lib/esm/index.js",


### PR DESCRIPTION
extension-tile-playground package was not part of the release-please manifest. This meant release-please does not update its package.json with every release PR. 
For context:
Our release PR branch was failing on build. Why?
1. `extension-tile-playground` depends on `extension-sdk`. `extension-sdk` was on 23.20.1. 
2. We added a breaking change to it and had to update `extension-tile-playground`. All done in 1 PR.
3. Latest main branch built successfully since since the playground is pointing to `extension-sdk` 23.20.1 which is latest in repo. 
4. However release-please created a release PR that bumped `extension-sdk` to 24.0.0, BUT did not bump `extension-tile-playground` package.json's `extension-sdk` dependency which stayed on 23.20.1
5. This forced yarn to pull in `extension-sdk` 23.20.1 from npm which would not contain latest changes in repo, breaking the build.  

Or so i think!