### PR TITLE
chore: Add extension-tile-playground package to release please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -26,6 +26,7 @@
     "packages/code-editor": {},
     "packages/extension-api-explorer": {},
     "packages/extension-playground": {},
+    "packages/extension-tile-playground": {},
     "packages/extension-sdk": {
       "component": "extension-sdk",
       "versioning": "always-bump-patch"


### PR DESCRIPTION
Missed one line change to properly release new package. For context read previous commit: https://github.com/looker-open-source/sdk-codegen/commit/fbec58f290a31cc55b8ea96de28f366810b532a9 