### PR TITLE
chore: Update sdk_gen script to lint and not do smoke tests

### DIFF
--- a/bin/sdk_gen
+++ b/bin/sdk_gen
@@ -193,12 +193,12 @@ const regen = async (release) => {
       return batch(
         [
           'yarn gen',
-          'yarn fix', // Fixes eslint
-          'pipenv run black api40/*.py',
-          './kotlin/gradlew -p kotlin spotlessApply',  
-          // 'git add -u',
-          // `git commit -m "feat: generate SDKs for Looker ${release}" -m "Release-As: ${release}.0"`,
-          // `git push origin ${branch}`,
+          'yarn fix', // Lint fix typescript
+          'pipenv run black python/looker_sdk/sdk/api40/*.py', // Lint fix python
+          './kotlin/gradlew -p kotlin spotlessApply', // Lint fix kotlin
+          'git add -u',
+          `git commit -m "feat: generate SDKs for Looker ${release}" -m "Release-As: ${release}.0"`,
+          `git push origin ${branch}`,
           /* create PR
            */
         ],

--- a/bin/sdk_gen
+++ b/bin/sdk_gen
@@ -193,10 +193,12 @@ const regen = async (release) => {
       return batch(
         [
           'yarn gen',
-          'bin/smoke typescript python kotlin',
-          'git add -u',
-          `git commit -m "feat: generate SDKs for Looker ${release}" -m "Release-As: ${release}.0"`,
-          `git push origin ${branch}`,
+          'yarn fix', // Fixes eslint
+          'pipenv run black api40/*.py',
+          './kotlin/gradlew -p kotlin spotlessApply',  
+          // 'git add -u',
+          // `git commit -m "feat: generate SDKs for Looker ${release}" -m "Release-As: ${release}.0"`,
+          // `git push origin ${branch}`,
           /* create PR
            */
         ],
@@ -214,6 +216,7 @@ const regen = async (release) => {
   const args = process.argv.slice(2);
   if (args.length >= 1) {
     await regen(args[0]);
+    console.info('If generated SDKs fail CI, run "bin/smoke [language]"  locally to verify and debug')
   } else {
     console.error('No release version was specified');
   }


### PR DESCRIPTION
- Removed smoke tests as our CI already runs them. 
- Added python and kotlin linting to the script
- Added `yarn fix` to the script. For some reason, our pre-commit hook hangs on eslint. So if we first fix the eslint issues with `yarn fix` this lets our pre-commit hook work. 

Additionally:
- Updated our playbook with additional setup steps for linting
- Updated our playbook and console output with smoke test debugging steps if CI breaks

Confirmed it generates sdk with consistent styling. From last generation:
`26 files changed, 519 insertions(+), 188 deletions(-)`