### PR TITLE
chore: Fix NPM publishing workflow

### DIFF
--- a/.github/workflows/lerna-publish.yml
+++ b/.github/workflows/lerna-publish.yml
@@ -84,6 +84,6 @@ jobs:
           ${{ github.workspace }}/.github/scripts/wait_for_looker.sh
 
       - name: Publish to NPM registry
-        run: $(npm bin)/lerna publish from-package --yes --no-verify-access
+        run: npx lerna publish from-package --yes --no-verify-access
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_RELEASE_BACKED }}


### PR DESCRIPTION
Our publishing workflow was unable to execute `lerna publish` to publish our npm packages because its method of execution `npm bin` is not supported anymore. This stackoverflow article for more context: https://stackoverflow.com/questions/9679932/how-to-use-executables-from-a-package-installed-locally-in-node-modules

- Switching to using `npx`. I confirmed locally that `npx lerna -h` works which means other lerna commands should work. (unable to do publishing dry run because our version of lerna is too old, and doesn't have that option)