### PR TITLE
chore: Changed imported package models to models40

### DIFF
--- a/examples/python/download_dashboard_pdf.py
+++ b/examples/python/download_dashboard_pdf.py
@@ -19,7 +19,7 @@ import time
 from typing import cast, Dict, Optional
 
 import looker_sdk
-from looker_sdk import models
+from looker_sdk import models40 as models
 
 sdk = looker_sdk.init40("../../looker.ini")
 


### PR DESCRIPTION
When tested with requirements below, `looker_sdk` no longer have `models` class. So the solution is to import the equivalent class `models40` which I chose the latest Looker API version (4.0).

Then it runs perfectly !

### Requirements:
looker-sdk==24.2.0


Fixes #1 🦕
