### PR TITLE
fix: backslash in regex causing warnings - switch to raw string

### DIFF
--- a/python/looker_sdk/error.py
+++ b/python/looker_sdk/error.py
@@ -99,7 +99,7 @@ class ErrorDocHelper:
     ERROR_CODES_URL: str = "https://static-a.cdn.looker.app/errorcodes/"
     lookup_dict: Dict[str, Dict[str, str]] = {}
     RE_PATTERN: str = (
-        """(https://docs\.looker\.com/r/err/|https://cloud\.google\.com/looker/docs/r/err/)(.*)/(\d{3})(.*)"""
+        r'(https://docs\.looker\.com/r/err/|https://cloud\.google\.com/looker/docs/r/err/)(.*)/(\d{3})(.*)'
     )
     pattern = re.compile(RE_PATTERN, flags=re.IGNORECASE)
 


### PR DESCRIPTION
fix for https://github.com/looker-open-source/sdk-codegen/issues/1460
