### PR TITLE
fix(deps): limit cattrs to versions <23.2

### DIFF
--- a/python/Pipfile
+++ b/python/Pipfile
@@ -27,7 +27,7 @@ tox-pyenv = "*"
 [packages]
 requests = "*"
 attrs = "*"
-cattrs = ">=1.3"
+cattrs = ">=1.3, <23.2"
 python-dateutil = "*"
 
 [requires]


### PR DESCRIPTION
As stated in issue #1410 , `cattrs` appears to have introduced a breaking change starting in version 23.2.

Fixes #1468
