### PR TITLE
chore: fix rate limit error in bq load

### DIFF
--- a/.github/workflows/release-metrics.yml
+++ b/.github/workflows/release-metrics.yml
@@ -30,4 +30,9 @@ jobs:
           draft,
           prerelease
           }'' $GITHUB_EVENT_PATH > releases.json'
+
+      # Avoid rate limit exceeded error in bq load step
+      - name: Sleep for random time
+        run: sleep $((RANDOM % 120))
+
       - run: bq load --source_format=NEWLINE_DELIMITED_JSON metrics.releases releases.json


### PR DESCRIPTION
The step to record publish metrics in BQ was hitting a rate limit, so doing a simple random sleep of up to 2 minutes
