### PR TITLE
fix: allow cloud.google.com for the API Explorer extension

### DIFF
--- a/packages/extension-api-explorer/manifest.lkml
+++ b/packages/extension-api-explorer/manifest.lkml
@@ -8,13 +8,13 @@ application: api-explorer {
      local_storage: yes
      navigation: no
      new_window: yes
-     new_window_external_urls: ["https://looker.com/*", "https://developer.mozilla.org/*", "https://docs.looker.com/*"]
+     new_window_external_urls: ["https://looker.com/*", "https://developer.mozilla.org/*", "https://docs.looker.com/*", "https://cloud.google.com/*"]
      raw_api_request: yes
      use_form_submit: yes
      use_embeds: yes
      use_clipboard: yes
      core_api_methods: ["versions", "api_spec"]
-     external_api_urls : ["https://raw.githubusercontent.com","http://localhost:30000","https://localhost:8080","https://static-a.cdn.looker.app","https://docs.looker.com","https://developer.mozilla.org/"]
+     external_api_urls : ["https://raw.githubusercontent.com","http://localhost:30000","https://localhost:8080","https://static-a.cdn.looker.app","https://docs.looker.com","https://cloud.google.com", "https://developer.mozilla.org/"]
      oauth2_urls: []
   }
 }


### PR DESCRIPTION
Allow https://cloud.google.com as an external URL for the API Explorer extension