### PR TITLE
feat: update Go SDK to accept auth session interface

### DIFF
--- a/packages/sdk-codegen/src/go.gen.ts
+++ b/packages/sdk-codegen/src/go.gen.ts
@@ -371,11 +371,15 @@ import (
     "time"
 )
 
-type LookerSDK struct {
-  session *rtl.AuthSession
+type authSessionDoer interface {
+  Do(result interface{}, method, ver, path string, reqPars map[string]interface{}, body interface{}, options *rtl.ApiSettings) error
 }
 
-func NewLookerSDK(session *rtl.AuthSession) *LookerSDK {
+type LookerSDK struct {
+  session authSessionDoer
+}
+
+func NewLookerSDK(session authSessionDoer) *LookerSDK {
   return &LookerSDK{
     session: session,
   }


### PR DESCRIPTION
This change alters the Go SDK client struct to accept an interface instead of the AuthSession. The interface allows for custom implementations of the RTL package, but since the existing AuthSession fulfills the new interface (its based on the Do method from the current AuthSession after all) this change will be completely transparent to those who are currently using the current AuthSession. 
