### PR TITLE
feat: allow node 20 for the TS SDK

### DIFF
--- a/.github/workflows/tssdk-ci.yml
+++ b/.github/workflows/tssdk-ci.yml
@@ -43,7 +43,7 @@ jobs:
       matrix:
         os:
           - ubuntu
-        node-version: [22.x]
+        node-version: [20.x, 22.x]
 
     steps:
       - name: Cancel Previous Runs
@@ -122,7 +122,7 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     strategy:
       matrix:
-        node-version: [22.x]
+        node-version: [20.x, 22.x]
         os:
           - ubuntu
         looker: ${{ fromJson(needs.setup.outputs.matrix_json) }}

--- a/packages/sdk-node/README.md
+++ b/packages/sdk-node/README.md
@@ -201,9 +201,9 @@ The [deprecated NodeJS `request` package](https://www.npmjs.com/package/request)
 The streaming method callback signature changed from `(readable: Readable) => Promise<x>` to `(response: Response) => Promise<x>`. Using `Response` as the parameter to the callback greatly
 increases the flexibility of streaming implementations and provides other valuable information like `Content-Type` and other headers to the streaming callback.
 
-For the Browser SDK (`@looker/sdk`), the standard `fetch` function is still used. For the Node SDK (`@looker/sdk-node`), the global [`fetch`](https://nodejs.org/api/globals.html#fetch) function from NodeJS v22 is used.
+For the Browser SDK (`@looker/sdk`), the standard `fetch` function is still used. For the Node SDK (`@looker/sdk-node`), the global [`fetch`](https://nodejs.org/api/globals.html#fetch) function from NodeJS is used, which was marked **stable** in version 22.
 
-This means the Looker Node SDK now uses NodeJS v22.
+This means the Looker Node SDK now requires Node 20 or above.
 
 The streaming version of the SDK methods should be initialized using the same `AuthSession` as the main SDK to reduce authentication thrashing.
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -82,9 +82,9 @@ The [deprecated NodeJS `request` package](https://www.npmjs.com/package/request)
 The streaming method callback signature changed from `(readable: Readable) => Promise<x>` to `(response: Response) => Promise<x>`. Using `Response` as the parameter to the callback greatly
 increases the flexibility of streaming implementations and provides other valuable information like `Content-Type` and other headers to the streaming callback.
 
-For the Browser SDK (`@looker/sdk`), the standard `fetch` function is still used. For the Node SDK (`@looker/sdk-node`), the global [`fetch`](https://nodejs.org/api/globals.html#fetch) function from NodeJS v22 is used.
+For the Browser SDK (`@looker/sdk`), the standard `fetch` function is still used. For the Node SDK (`@looker/sdk-node`), the global [`fetch`](https://nodejs.org/api/globals.html#fetch) function from NodeJS is used, which was marked **stable** in version 22.
 
-This means the Looker Node SDK now uses NodeJS v22.
+This means the Looker Node SDK now requires Node 20 or above.
 
 The streaming version of the SDK methods should be initialized using the same `AuthSession` as the main SDK to reduce authentication thrashing.
 

--- a/shell.nix
+++ b/shell.nix
@@ -4,5 +4,5 @@ with nixpkgs;
 with lib;
 mkShell {
   name = "sdk-codegen";
-  buildInputs =[nodejs_22 yarn];
+  buildInputs =[nodejs yarn];
 }


### PR DESCRIPTION
Allow Node 20 as a runtime environment for the Looker TypeScript SDK
