### PR TITLE
fix: Fix bad python package exclude

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -49,7 +49,7 @@ setup(
     keywords=["Looker", "Looker API", "looker_sdk", "Looker API 4.0"],
     name=NAME,
     package_data={"looker_sdk": ["py.typed", "looker_sdk/looker-sample.ini"]},
-    packages=find_packages(include=("looker_sdk",)),
+    packages=find_packages(exclude=("tests",)),
     # restrict python to <=3.9.9 due to https://github.com/looker-open-source/sdk-codegen/issues/944
     python_requires=">=3.6",
     url="https://pypi.python.org/pypi/looker_sdk",


### PR DESCRIPTION
The original exclude instead only included the `looker_sdk` folder. Afaict based off other examples, we should be using exclude.
