### PR TITLE
chore(deps): Bump http-proxy-middleware from 2.0.6 to 2.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "@types/js-yaml": "^3.12.1",
     "@types/lodash": "4.14.172",
     "@types/node": "22.5.4",
+    "@types/prettier": "2.7.3",
     "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "^5.61.0",
     "@typescript-eslint/parser": "^5.61.0",
@@ -144,7 +145,6 @@
     "npm-run-all": "4.1.5",
     "openapi3-ts": "2.0.2",
     "pre-commit": "1.2.2",
-    "@types/prettier": "2.7.3",
     "prettier": "2.8.8",
     "pretty-quick": "2.0.2",
     "react": "^17.0.2",
@@ -160,8 +160,7 @@
     "uuid": "9.0.1",
     "webpack": "5.94.0",
     "webpack-bundle-analyzer": "^4.10.2",
-    "webpack-merge": "^5.10.0",
-    "yarn-deduplicate": "6.0.2"
+    "webpack-merge": "^5.10.0"
   },
   "lint-staged": {
     "**/*.ts?(x)": [
@@ -345,5 +344,7 @@
     "**/url-parse": ">= 1.5.7",
     "parse-url": "^8.1.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "yarn-deduplicate": "^6.0.2"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9639,9 +9639,9 @@ http-proxy-agent@^5.0.0:
     debug "4"
 
 http-proxy-middleware@^2.0.3:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz#e1a4dd6979572c7ab5a4e4b55095d1f32a74963f"
-  integrity sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz#915f236d92ae98ef48278a95dedf17e991936ec6"
+  integrity sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==
   dependencies:
     "@types/http-proxy" "^1.17.8"
     http-proxy "^1.18.1"


### PR DESCRIPTION
Copy of https://github.com/looker-open-source/sdk-codegen/pull/1524

Bumps [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware) from 2.0.6 to 2.0.7.
- [Release notes](https://github.com/chimurai/http-proxy-middleware/releases)
- [Changelog](https://github.com/chimurai/http-proxy-middleware/blob/v2.0.7/CHANGELOG.md)
- [Commits](https://github.com/chimurai/http-proxy-middleware/compare/v2.0.6...v2.0.7)

---
updated-dependencies:
- dependency-name: http-proxy-middleware dependency-type: indirect ...
