### PR TITLE
fix: Improve ok() helper function

### DIFF
--- a/.github/workflows/kotlin-ci.yml
+++ b/.github/workflows/kotlin-ci.yml
@@ -1,0 +1,63 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
+
+name: Kotlin CI
+
+on:
+  pull_request:
+    paths:
+      - kotlin/**
+      - .github/workflows/gradle.yml
+
+  push:
+    branches: [ "main" ]
+    paths:
+      - kotlin/**
+      - .github/workflows/gradle.yml
+
+# TODO(#1544): Also run tests
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+    - name: Build with Gradle Wrapper
+      run: ./gradlew jar
+      working-directory: kotlin
+
+  dependency-submission:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+    - run: cd kotlin
+
+    # Generates and submits a dependency graph, enabling Dependabot Alerts for all project dependencies.
+    # See: https://github.com/gradle/actions/blob/main/dependency-submission/README.md
+    - name: Generate and submit dependency graph
+      uses: gradle/actions/dependency-submission@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+      with:
+        build-root-directory: kotlin


### PR DESCRIPTION
I'm hesitant to change this function too much, since we don't know what kind of odd dependencies on its current behavior might exist. However, adding exception chaining and surfacing the original error message seems like a risk worth taking.

- Eliminate duplicated version in AuthSession by delegating to a shared implementation defined on the SDKResponse companion object.

- For the SDKError case:
  - Set Error.message from SDKError.message
  - Set Error.casue from SDKError.cause

- Also ran `ktlint -F` on the files I changed so that `gradle check` would pass the linting stage
- Also added kotlin-ci.yml to run `./gradlew jar` on kotlin changes

Fixes #1539 🦕
