### PR TITLE
fix: update looker TypeScript package dependencies

### DIFF
--- a/.github/workflows/apix-ci.yml
+++ b/.github/workflows/apix-ci.yml
@@ -97,6 +97,10 @@ jobs:
     if: success() || failure()
     runs-on: ubuntu-latest
 
+    permissions:
+      pull-requests: write
+      checks: write
+
     steps:
       - name: Download Artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/codegen-ci.yml
+++ b/.github/workflows/codegen-ci.yml
@@ -133,6 +133,10 @@ jobs:
     if: success() || failure()
     runs-on: ubuntu-latest
 
+    permissions:
+      pull-requests: write
+      checks: write
+
     steps:
       - name: Download Artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -190,6 +190,10 @@ jobs:
     if: success() || failure()
     runs-on: ubuntu-latest
 
+    permissions:
+      pull-requests: write
+      checks: write
+
     steps:
       - name: Download Artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -245,6 +245,10 @@ jobs:
     if: success() || failure()
     runs-on: ubuntu-latest
 
+    permissions:
+      pull-requests: write
+      checks: write
+
     steps:
       - name: Download Artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/tssdk-ci.yml
+++ b/.github/workflows/tssdk-ci.yml
@@ -185,6 +185,10 @@ jobs:
     if: success() || failure()
     runs-on: ubuntu-latest
 
+    permissions:
+      pull-requests: write
+      checks: write
+
     steps:
       - name: Download Artifacts
         uses: actions/download-artifact@v4

--- a/packages/api-explorer/package.json
+++ b/packages/api-explorer/package.json
@@ -71,8 +71,8 @@
   },
   "dependencies": {
     "@looker/code-editor": "0.1.38",
-    "@looker/components": "^4.1.3",
-    "@looker/design-tokens": "^3.1.0",
+    "@looker/components": "^5.0.3",
+    "@looker/design-tokens": "^3.1.3",
     "@looker/extension-utils": "0.1.48",
     "@looker/icons": "^1.5.21",
     "@looker/redux": "^0.0.1",

--- a/packages/code-editor/package.json
+++ b/packages/code-editor/package.json
@@ -49,8 +49,8 @@
     "webpack-cli": "5.0.1"
   },
   "dependencies": {
-    "@looker/components": "^4.1.3",
-    "@looker/design-tokens": "^3.1.0",
+    "@looker/components": "^5.0.3",
+    "@looker/design-tokens": "^3.1.3",
     "prism-react-renderer": "^1.2.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/packages/embed-components/package.json
+++ b/packages/embed-components/package.json
@@ -44,7 +44,7 @@
     "@testing-library/user-event": "13.1.5"
   },
   "dependencies": {
-    "@looker/components": "^4.1.3",
+    "@looker/components": "^5.0.3",
     "@looker/embed-services": "25.0.0",
     "@looker/redux": "^0.0.1",
     "@looker/sdk": "25.0.0",

--- a/packages/embed-playground/package.json
+++ b/packages/embed-playground/package.json
@@ -37,7 +37,7 @@
     "webpack-dev-server": "4.15.1"
   },
   "dependencies": {
-    "@looker/components": "^4.1.3",
+    "@looker/components": "^5.0.3",
     "@looker/embed-services": "23.20.1",
     "@looker/embed-components": "23.20.1",
     "@looker/extension-utils": "0.1.32",

--- a/packages/extension-api-explorer/package.json
+++ b/packages/extension-api-explorer/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@looker/api-explorer": "0.9.71",
-    "@looker/components": "^4.1.3",
+    "@looker/components": "^5.0.3",
     "@looker/extension-sdk": "25.0.0",
     "@looker/extension-sdk-react": "25.0.0",
     "@looker/extension-utils": "0.1.48",

--- a/packages/extension-playground/package.json
+++ b/packages/extension-playground/package.json
@@ -16,7 +16,7 @@
     "@looker/extension-sdk": "25.0.0",
     "@looker/extension-sdk-react": "25.0.0",
     "@looker/sdk": "25.0.0",
-    "@looker/components": "^4.1.3",
+    "@looker/components": "^5.0.3",
     "@looker/icons": "^1.5.21",
     "@styled-icons/material": "^10.47.0",
     "@styled-icons/material-outlined": "^10.47.0",

--- a/packages/extension-tile-playground/package.json
+++ b/packages/extension-tile-playground/package.json
@@ -17,7 +17,7 @@
     "@looker/extension-sdk": "25.0.0",
     "@looker/extension-sdk-react": "25.0.0",
     "@looker/sdk": "25.0.0",
-    "@looker/components": "^4.1.3",
+    "@looker/components": "^5.0.3",
     "@looker/icons": "^1.5.21",
     "@styled-icons/material": "^10.47.0",
     "@styled-icons/material-outlined": "^10.47.0",

--- a/packages/extension-utils/package.json
+++ b/packages/extension-utils/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@looker/code-editor": "0.1.38",
-    "@looker/components": "^4.1.3",
+    "@looker/components": "^5.0.3",
     "@looker/extension-sdk": "25.0.0",
     "@looker/extension-sdk-react": "25.0.0",
     "@looker/redux": "^0.0.1",

--- a/packages/hackathon/package.json
+++ b/packages/hackathon/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@looker/code-editor": "0.1.38",
-    "@looker/components": "^4.1.3",
+    "@looker/components": "^5.0.3",
     "@looker/extension-sdk": "25.0.0",
     "@looker/extension-sdk-react": "25.0.0",
     "@looker/extension-utils": "0.1.48",

--- a/packages/run-it/package.json
+++ b/packages/run-it/package.json
@@ -53,8 +53,8 @@
   },
   "dependencies": {
     "@looker/code-editor": "0.1.38",
-    "@looker/components": "^4.1.3",
-    "@looker/design-tokens": "^3.1.0",
+    "@looker/components": "^5.0.3",
+    "@looker/design-tokens": "^3.1.3",
     "@looker/extension-utils": "0.1.48",
     "@looker/icons": "^1.5.21",
     "@looker/sdk": "25.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2551,6 +2551,18 @@
     react-i18next "11.8.15"
     tabbable "^5.2.0"
 
+"@looker/components-providers@^1.5.34":
+  version "1.5.34"
+  resolved "https://registry.yarnpkg.com/@looker/components-providers/-/components-providers-1.5.34.tgz#4f9f0a703fe00b2d967d7bbad42e3e03716f01c2"
+  integrity sha512-fsURtzhatmOSuwbJUKusCNdaUbDoiuqOE0K0V31/xts4LSf+EYR5TFf7g9nj5hqJ5TrymtqsLkFcH6nKsNe8cA==
+  dependencies:
+    "@looker/design-tokens" "^3.1.1"
+    "@looker/i18n" "1.0.0"
+    i18next "20.3.1"
+    react-helmet-async "^1.0.9"
+    react-i18next "11.8.15"
+    tabbable "^5.2.0"
+
 "@looker/components-test-utils@^1.5.27":
   version "1.5.27"
   resolved "https://registry.yarnpkg.com/@looker/components-test-utils/-/components-test-utils-1.5.27.tgz#e008243385d825020b62e4f3c8f19e3a3a275435"
@@ -2577,7 +2589,29 @@
     react-i18next "11.8.15"
     uuid "*"
 
-"@looker/design-tokens@3.1.1", "@looker/design-tokens@^3.1.0", "@looker/design-tokens@^3.1.1":
+"@looker/components@^5.0.3":
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/@looker/components/-/components-5.0.3.tgz#1ac4a31cc914bb4693672485c9d18ffe7d7a213b"
+  integrity sha512-lyVvUmUY85Sb7pxi2j4f6YwdlmaHGgNe4i+++89zYNGgJ3yPgsWdGZHQyFPtWjx9/0DlR2VyvV6F2F4CED/Gng==
+  dependencies:
+    "@looker/components-providers" "^1.5.34"
+    "@looker/design-tokens" "^3.1.3"
+    "@looker/i18n" "1.0.0"
+    "@popperjs/core" "^2.6.0"
+    "@styled-icons/material" "10.34.0"
+    "@styled-icons/material-outlined" "10.34.0"
+    "@styled-icons/material-rounded" "10.34.0"
+    "@styled-icons/styled-icon" "^10.6.3"
+    d3-color "3.1.0"
+    d3-hsv "^0.1.0"
+    date-fns "^2.10.0"
+    date-fns-tz "^1.0.12"
+    i18next "20.3.1"
+    prism-react-renderer "^1.3.5"
+    react-i18next "11.8.15"
+    uuid "8.3.2"
+
+"@looker/design-tokens@3.1.1", "@looker/design-tokens@^3.1.1":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@looker/design-tokens/-/design-tokens-3.1.1.tgz#f2445684af19daa50a87ea8221eeca1fbd1d4533"
   integrity sha512-J0YjLFOratxEc2+U5QbphTU5ozIeJGdBDtPEUXkJhajSZKmwPYZi6j4A2EyGWBV0TzWUzTiYipAYOwSdvm8ETQ==
@@ -2586,6 +2620,17 @@
     "@styled-system/should-forward-prop" "5.1.5"
     polished "^4.1.3"
     styled-system "*"
+
+"@looker/design-tokens@^3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@looker/design-tokens/-/design-tokens-3.1.3.tgz#f573e48b89ab2ce37ca0653a5d766d5452065594"
+  integrity sha512-YR78GTJj2JN+jDS0PcvrrCZ2bRFMxlwiCYyuXj9J7UtEYZR4QWTEYkSMHGKyzYYoiv0MHQVg8H/TQdKak6cJ9A==
+  dependencies:
+    "@styled-system/props" "^5.1.5"
+    "@styled-system/should-forward-prop" "5.1.5"
+    "@types/styled-system" "5.1.13"
+    polished "^4.1.3"
+    styled-system "5.1.5"
 
 "@looker/embed-components@23.20.1":
   version "23.20.1"
@@ -5670,9 +5715,9 @@ camelize@^1.0.0:
   integrity sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==
 
 caniuse-lite@^1.0.30001646:
-  version "1.0.30001655"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001655.tgz#0ce881f5a19a2dcfda2ecd927df4d5c1684b982f"
-  integrity sha512-jRGVy3iSGO5Uutn2owlb5gR6qsGngTw9ZTb4ali9f3glshcNmJ2noam4Mo9zia5P9Dk3jNNydy7vQjuE5dQmfg==
+  version "1.0.30001697"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001697.tgz"
+  integrity sha512-GwNPlWJin8E+d7Gxq96jxM6w0w+VFeyyXRsjU58emtkYqnbwHqXm5uT2uCmO0RQE9htWknOP4xtBlLmM/gWxvQ==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -14006,7 +14051,7 @@ pretty-quick@2.0.2:
     mri "^1.1.4"
     multimatch "^4.0.0"
 
-prism-react-renderer@^1.2.0:
+prism-react-renderer@^1.2.0, prism-react-renderer@^1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/prism-react-renderer/-/prism-react-renderer-1.3.5.tgz#786bb69aa6f73c32ba1ee813fbe17a0115435085"
   integrity sha512-IJ+MSwBWKG+SM3b2SUfdrhC+gu01QkV2KmRQgREThBfSQRoufqRfxfHUxpG1WcaFjP+kojcFyO9Qqtpgt3qLCg==
@@ -16206,7 +16251,7 @@ styled-components@^5.3.1:
     shallowequal "^1.1.0"
     supports-color "^5.5.0"
 
-styled-system@*, styled-system@^5.1.2, styled-system@^5.1.5:
+styled-system@*, styled-system@5.1.5, styled-system@^5.1.2, styled-system@^5.1.5:
   version "5.1.5"
   resolved "https://registry.yarnpkg.com/styled-system/-/styled-system-5.1.5.tgz#e362d73e1dbb5641a2fd749a6eba1263dc85075e"
   integrity sha512-7VoD0o2R3RKzOzPK0jYrVnS8iJdfkKsQJNiLRDjikOpQVqQHns/DXWaPZOH4tIKkhAT7I6wIsy9FWTWh2X3q+A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2539,19 +2539,7 @@
     debug "^2.2.0"
     es6-promise "^4.2.8"
 
-"@looker/components-providers@^1.5.31":
-  version "1.5.31"
-  resolved "https://registry.yarnpkg.com/@looker/components-providers/-/components-providers-1.5.31.tgz#a75be142698f8bb57e75a9a53ce9ca4aaf327ff5"
-  integrity sha512-kW+rM8vM/g+KN/1F+x0oYBtbEqzAmPKK9AiKaC/6xqbolt4EooKq3LbJWCh1GdyWwgKDzeD1qWP2hfLQNziKDA==
-  dependencies:
-    "@looker/design-tokens" "3.1.1"
-    "@looker/i18n" "1.0.0"
-    i18next "20.3.1"
-    react-helmet-async "^1.0.9"
-    react-i18next "11.8.15"
-    tabbable "^5.2.0"
-
-"@looker/components-providers@^1.5.34":
+"@looker/components-providers@^1.5.31", "@looker/components-providers@^1.5.34":
   version "1.5.34"
   resolved "https://registry.yarnpkg.com/@looker/components-providers/-/components-providers-1.5.34.tgz#4f9f0a703fe00b2d967d7bbad42e3e03716f01c2"
   integrity sha512-fsURtzhatmOSuwbJUKusCNdaUbDoiuqOE0K0V31/xts4LSf+EYR5TFf7g9nj5hqJ5TrymtqsLkFcH6nKsNe8cA==
@@ -2611,17 +2599,7 @@
     react-i18next "11.8.15"
     uuid "8.3.2"
 
-"@looker/design-tokens@3.1.1", "@looker/design-tokens@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@looker/design-tokens/-/design-tokens-3.1.1.tgz#f2445684af19daa50a87ea8221eeca1fbd1d4533"
-  integrity sha512-J0YjLFOratxEc2+U5QbphTU5ozIeJGdBDtPEUXkJhajSZKmwPYZi6j4A2EyGWBV0TzWUzTiYipAYOwSdvm8ETQ==
-  dependencies:
-    "@styled-system/props" "^5.1.5"
-    "@styled-system/should-forward-prop" "5.1.5"
-    polished "^4.1.3"
-    styled-system "*"
-
-"@looker/design-tokens@^3.1.3":
+"@looker/design-tokens@^3.1.1", "@looker/design-tokens@^3.1.3":
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/@looker/design-tokens/-/design-tokens-3.1.3.tgz#f573e48b89ab2ce37ca0653a5d766d5452065594"
   integrity sha512-YR78GTJj2JN+jDS0PcvrrCZ2bRFMxlwiCYyuXj9J7UtEYZR4QWTEYkSMHGKyzYYoiv0MHQVg8H/TQdKak6cJ9A==
@@ -16251,7 +16229,7 @@ styled-components@^5.3.1:
     shallowequal "^1.1.0"
     supports-color "^5.5.0"
 
-styled-system@*, styled-system@5.1.5, styled-system@^5.1.2, styled-system@^5.1.5:
+styled-system@5.1.5, styled-system@^5.1.2, styled-system@^5.1.5:
   version "5.1.5"
   resolved "https://registry.yarnpkg.com/styled-system/-/styled-system-5.1.5.tgz#e362d73e1dbb5641a2fd749a6eba1263dc85075e"
   integrity sha512-7VoD0o2R3RKzOzPK0jYrVnS8iJdfkKsQJNiLRDjikOpQVqQHns/DXWaPZOH4tIKkhAT7I6wIsy9FWTWh2X3q+A==


### PR DESCRIPTION
The `@looker/components` and `@looker/design-tokens` packages were out of date. This updates them to the latest.