### PR TITLE
fix(testAllFolders): Updated Kotlin test after API change for all_folders

### DIFF
--- a/kotlin/src/test/TestMethods.kt
+++ b/kotlin/src/test/TestMethods.kt
@@ -295,7 +295,7 @@ class TestMethods {
 
     @Test
     fun testAllFolders() {
-        testAll<Folder, String, Folder>(
+        testAll<FolderBase, String, FolderBase>(
             { sdk.all_folders() },
             { item -> item.id!! },
             { id, fields -> sdk.folder(id, fields) },


### PR DESCRIPTION
https://cloud.google.com/looker/docs/reference/looker-api/latest/methods/Folder/all_folders was changed in the last 6 months to return `FolderBase` instead of `Folder`

Updating test to reflect API change.

Fixes #1567  🦕
