### PR TITLE
fix(BaseTransport) Fix handling of AbortSignal availability detection in selected transport

### DIFF
--- a/packages/sdk-rtl/src/baseTransport.ts
+++ b/packages/sdk-rtl/src/baseTransport.ts
@@ -173,7 +173,7 @@ export abstract class BaseTransport implements ITransport {
     let signaller;
     if (AbortSignal.timeout) {
       const ms = sdkTimeout(options) * 1000;
-      let signaller = AbortSignal.timeout(ms);
+      signaller = AbortSignal.timeout(ms);
       if ('signal' in options && options.signal) {
         // AbortSignal.any may not be available, tolerate its absence
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -189,11 +189,11 @@ export abstract class BaseTransport implements ITransport {
           );
           console.debug({ AbortSignal });
         }
-      } else {
-        console.debug(
-          'AbortSignal.timeout is not defined. Timeout will use default behavior'
-        );
       }
+    } else {
+      console.debug(
+        'AbortSignal.timeout is not defined. Timeout will use default behavior'
+      );
     }
 
     let props: IRequestProps = {


### PR DESCRIPTION
Updated the assignment of the signaller variable in the BaseTransport class to ensure proper usage of AbortSignal.timeout. The debug message for when AbortSignal.timeout is not defined has also been made to execute at the correct time.