### PR TITLE
BugFix(SDKError): Correct error formatting in SDKError __str__ method…

### DIFF
--- a/python/looker_sdk/error.py
+++ b/python/looker_sdk/error.py
@@ -82,7 +82,7 @@ class SDKError(Exception):
     documentation_url: {self.documentation_url}
     error_doc_url:     {self.error_doc_url}
     error details:
-    {sep.join(str(error) for error in self.errors)}
+    {sep.join(str(error_details) for error_details in self.errors)}
     """
 
 


### PR DESCRIPTION
… (#1587)

### BugFix: Correct error formatting in SDKError.__str__

#### Problem
Calling `str(SDKError)` raised the following runtime error: `looker_sdk.error.SDKError: <exception str() failed>`

This happened when the SDK attempted to convert the error to a string, which failed due to a malformed generator expression or naming conflict during the formatting of `self.errors`.

#### Fix
Updated the loop variable in the generator expression from `error` to `error_details` to:
- Avoid potential name shadowing.
- Improve clarity and correctness of the `__str__` implementation.
- Resolve the runtime error so the error can now be printed correctly.

#### Notes
- The variable `error_details` represents a single instance; per PEP 8, we may later rename it to `error_detail` for readability.
