### PR TITLE
feat(python): add disabled field to DBConnection and WriteDBConnection

### DIFF
--- a/python/looker_sdk/sdk/api40/models.py
+++ b/python/looker_sdk/sdk/api40/models.py
@@ -5799,6 +5799,7 @@ class DBConnection(model.Model):
         p4sa_name: The name of P4SA service account that is associated with the Looker instance
         query_holding_disabled: Disable query holding for this connection.
         service_name: Service name used for connections with TNS enabled
+        disabled: Disable database connection
     """
 
     can: Optional[MutableMapping[str, bool]] = None
@@ -5866,6 +5867,7 @@ class DBConnection(model.Model):
     p4sa_name: Optional[str] = None
     query_holding_disabled: Optional[bool] = None
     service_name: Optional[str] = None
+    disabled: Optional[str] = None
 
     def __init__(
         self,
@@ -5934,7 +5936,8 @@ class DBConnection(model.Model):
         bq_roles_verified: Optional[bool] = None,
         p4sa_name: Optional[str] = None,
         query_holding_disabled: Optional[bool] = None,
-        service_name: Optional[str] = None
+        service_name: Optional[str] = None,
+        disabled: Optional[str] = None
     ):
         self.can = can
         self.name = name
@@ -6001,6 +6004,7 @@ class DBConnection(model.Model):
         self.p4sa_name = p4sa_name
         self.query_holding_disabled = query_holding_disabled
         self.service_name = service_name
+        self.disabled = disabled
 
 
 @attr.s(auto_attribs=True, init=False)
@@ -17513,6 +17517,7 @@ class WriteDBConnection(model.Model):
             bq_roles_verified: When true, represents that all project roles have been verified.
             query_holding_disabled: Disable query holding for this connection.
             service_name: Service name used for connections with TNS enabled
+            disabled: Disable database connection
     """
 
     name: Optional[str] = None
@@ -17562,6 +17567,7 @@ class WriteDBConnection(model.Model):
     bq_roles_verified: Optional[bool] = None
     query_holding_disabled: Optional[bool] = None
     service_name: Optional[str] = None
+    disabled: Optional[str] = None
 
     def __init__(
         self,
@@ -17612,7 +17618,8 @@ class WriteDBConnection(model.Model):
         bq_storage_project_id: Optional[str] = None,
         bq_roles_verified: Optional[bool] = None,
         query_holding_disabled: Optional[bool] = None,
-        service_name: Optional[str] = None
+        service_name: Optional[str] = None,
+        disabled: Optional[str] = None
     ):
         self.name = name
         self.named_driver_version_requested = named_driver_version_requested
@@ -17661,6 +17668,7 @@ class WriteDBConnection(model.Model):
         self.bq_roles_verified = bq_roles_verified
         self.query_holding_disabled = query_holding_disabled
         self.service_name = service_name
+        self.disabled = disabled
 
 
 @attr.s(auto_attribs=True, init=False)

--- a/python/looker_sdk/sdk/api40/models.py
+++ b/python/looker_sdk/sdk/api40/models.py
@@ -5937,7 +5937,7 @@ class DBConnection(model.Model):
         p4sa_name: Optional[str] = None,
         query_holding_disabled: Optional[bool] = None,
         service_name: Optional[str] = None,
-        disabled: Optional[str] = None
+        disabled: Optional[bool] = None
     ):
         self.can = can
         self.name = name
@@ -17619,7 +17619,7 @@ class WriteDBConnection(model.Model):
         bq_roles_verified: Optional[bool] = None,
         query_holding_disabled: Optional[bool] = None,
         service_name: Optional[str] = None,
-        disabled: Optional[str] = None
+        disabled: Optional[bool] = None
     ):
         self.name = name
         self.named_driver_version_requested = named_driver_version_requested

--- a/python/looker_sdk/sdk/api40/models.py
+++ b/python/looker_sdk/sdk/api40/models.py
@@ -17567,7 +17567,7 @@ class WriteDBConnection(model.Model):
     bq_roles_verified: Optional[bool] = None
     query_holding_disabled: Optional[bool] = None
     service_name: Optional[str] = None
-    disabled: Optional[str] = None
+    disabled: Optional[bool] = None
 
     def __init__(
         self,

--- a/python/looker_sdk/sdk/api40/models.py
+++ b/python/looker_sdk/sdk/api40/models.py
@@ -5867,7 +5867,7 @@ class DBConnection(model.Model):
     p4sa_name: Optional[str] = None
     query_holding_disabled: Optional[bool] = None
     service_name: Optional[str] = None
-    disabled: Optional[str] = None
+    disabled: Optional[bool] = None
 
     def __init__(
         self,


### PR DESCRIPTION
## 👋👋 Thank you for contributing to Looker sdk-codegen (⚡️🍣)

This PR adds the missing `disabled` field to the `DBConnection` and `WriteDBConnection` models within the Python SDK (API 4.0). 

**Context:**
While the Looker API supports disabling database connections, the Python SDK was not exposing this attribute in its model definitions. This change allows developers to manage the operational status of connections directly through the SDK.

**Changes:**
- Added `disabled: Optional[bool] = None` to the `DBConnection` class.
- Added `disabled: Optional[bool] = None` to the `WriteDBConnection` class.
- Updated the class constructors/type hints in `python/looker_sdk/sdk/api40/models.py`.

## Developer Checklist [ℹ️](https://github.com/looker-open-source/sdk-codegen/blob/main/CONTRIBUTING.md#developer-checklist)

- [x] Make sure to open an issue as a [bug/issue](https://github.com/looker-open-source/sdk-codegen/issues/new/choose) before writing your code! 
- [x] Ensure the tests and linter pass
- [ ] Appropriate docs were updated (N/A - Model change)

Fixes #1677 🦕