### PR TITLE
fix(packages/sdk): import interface as type

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -30,7 +30,7 @@
  * Note: functions should be deep-linked from their 4.0/funcs path
  */
 
-export { ILooker40SDK } from './4.0/methodsInterface';
+export type { ILooker40SDK } from './4.0/methodsInterface';
 export { Looker40SDK } from './4.0/methods';
 export { Looker40SDKStream } from './4.0/streams';
 


### PR DESCRIPTION
Hello!

Importing an interface/type without `import type` causes build failures in `vite 8`. Only this specific import caused issue in my case. But there could be other imports as well.

Thanks!