### PR TITLE
UI/UX: Minimal HTML with missing meta tags

### DIFF
--- a/packages/api-explorer/public/index.html
+++ b/packages/api-explorer/public/index.html
@@ -1,7 +1,8 @@
-<html>
+<html lang="en">
   <head>
-    <meta name="viewport" content="width=device-width" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>API Explorer</title>
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'></text></svg>" />
   </head>
   <body>
     <div id="container"></div>


### PR DESCRIPTION
## Summary

UI/UX: Minimal HTML with missing meta tags

## Problem

**Severity**: `Medium` | **File**: `packages/api-explorer/public/index.html:L1`

The API Explorer index.html lacks viewport meta tag for proper mobile rendering, no favicon, no lang attribute, and no accessibility features.

## Solution

Add <meta name="viewport" content="width=device-width, initial-scale=1">, <html lang="en">, and consider adding a favicon link.

## Changes

- `packages/api-explorer/public/index.html` (modified)